### PR TITLE
Fix: poi panel cannot be scrolled

### DIFF
--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -109,7 +109,6 @@ $HEADER_SIZE: 40px;
   border-top-left-radius: 0;
   box-shadow: rgba(0, 0, 0, 0.16) 1px 4px 4px;
   max-height: calc(100vh - 120px - #{$HEADER_SIZE});
-  overflow: hidden;
 }
 
 .poi_panel__back_to_list:hover {


### PR DESCRIPTION
## Description
Removes a CSS rule introduced in #289. 
It breaks scroll behavior in poi panel on desktop, and seems to have no effect on mobile.


## Screenshots

|Before|After|
|---|---|
![image](https://user-images.githubusercontent.com/4726554/64767868-cae6dd80-d548-11e9-8994-0b0b3d262cc9.png)| ![image](https://user-images.githubusercontent.com/4726554/64768092-2913c080-d549-11e9-9f16-b2aa1251a485.png)|


