### PR TITLE
Add a drop shadow on top bar when the suggestions are scrolled

### DIFF
--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -18,6 +18,7 @@ const Suggest = ({
   onClear,
   onToggleSuggestions,
   className,
+  onScroll,
 }) => {
   const [items, setItems] = useState([]);
   const [isOpen, setIsOpen] = useState(false);
@@ -138,6 +139,7 @@ const Suggest = ({
         }
       }}
       onClear={onClear}
+      onScroll={onScroll}
     />;
 
   return ReactDOM.createPortal(<SuggestsDropdownElement />, outputNode);
@@ -152,6 +154,7 @@ Suggest.propTypes = {
   onClear: func,
   onToggleSuggestions: func,
   className: string,
+  onScroll: func,
 };
 
 export default Suggest;

--- a/src/components/ui/SuggestsDropdown.jsx
+++ b/src/components/ui/SuggestsDropdown.jsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import classnames from 'classnames';
 import { object, func, string, arrayOf } from 'prop-types';
-
+import useScrollWatcher from 'src/hooks/useScrollWatcher';
 import SuggestItem from './SuggestItem';
 
 const SuggestsDropdown = ({
@@ -9,8 +9,12 @@ const SuggestsDropdown = ({
   suggestItems,
   onSelect,
   onHighlight,
+  onScroll,
 }) => {
   const [highlighted, setHighlighted] = useState(null);
+  const dropdownElt = useRef(null);
+
+  useScrollWatcher(dropdownElt, onScroll);
 
   useEffect(() => {
     const keyDownHandler = e => {
@@ -66,7 +70,7 @@ const SuggestsDropdown = ({
   });
 
   return (
-    <ul className={classnames('autocomplete_suggestions', className)}>
+    <ul className={classnames('autocomplete_suggestions', className)} ref={dropdownElt}>
       {suggestItems.map((suggest, index) =>
         <li
           key={index}
@@ -91,6 +95,7 @@ SuggestsDropdown.propTypes = {
   suggestItems: arrayOf(object).isRequired,
   onHighlight: func.isRequired,
   onSelect: func.isRequired,
+  onScroll: func,
   className: string,
 };
 

--- a/src/hooks/useScrollWatcher.js
+++ b/src/hooks/useScrollWatcher.js
@@ -14,8 +14,8 @@ function useScrollWatcher(ref, cb, throttlingTimeout = 0) {
     scrollingElement.addEventListener('scroll', onScroll);
 
     return () => {
-      cb(0);
       scrollingElement.removeEventListener('scroll', onScroll);
+      cb(0);
     };
   }, [ref, cb, throttlingTimeout]);
 }

--- a/src/hooks/useScrollWatcher.js
+++ b/src/hooks/useScrollWatcher.js
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import throttle from 'lodash.throttle';
+
+function useScrollWatcher(ref, cb, throttlingTimeout = 0) {
+  useEffect(() => {
+    if (!cb) {
+      return;
+    }
+    const scrollingElement = ref.current;
+    const onScroll = throttle(() => {
+      cb(scrollingElement.scrollTop);
+    }, throttlingTimeout);
+
+    scrollingElement.addEventListener('scroll', onScroll);
+
+    return () => {
+      cb(0);
+      scrollingElement.removeEventListener('scroll', onScroll);
+    };
+  }, [ref, cb, throttlingTimeout]);
+}
+
+export default useScrollWatcher;

--- a/src/panel/RootComponent.jsx
+++ b/src/panel/RootComponent.jsx
@@ -34,6 +34,16 @@ const RootComponent = ({
     };
   });
 
+  const searchFormElement = document.querySelector('.search_form');
+
+  const onScrollSuggest = scrollPosition => {
+    if (scrollPosition > 0) {
+      searchFormElement.classList.add('shadow');
+    } else {
+      searchFormElement.classList.remove('shadow');
+    }
+  };
+
   return <DeviceContext.Provider value={isMobile}>
     <PanelManager router={router} />
     {burgerMenuEnabled && <MenuComponent isMobile={isMobile} />}
@@ -42,6 +52,7 @@ const RootComponent = ({
       outputNode={document.querySelector('.search_form__result')}
       withCategories
       onToggleSuggestions={suggestionsOpened => { togglePanelVisibility(!suggestionsOpened); }}
+      onScroll={onScrollSuggest}
     />
   </DeviceContext.Provider>;
 };

--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -101,6 +101,18 @@ class DirectionInput extends React.Component {
     this.props.inputRef.current.dispatchEvent(new Event('input'));
   }
 
+  onScrollSuggest = scrollPosition => {
+    const topBarElement = this.props.inputRef?.current?.parentNode;
+    if (!topBarElement) {
+      return;
+    }
+    if (scrollPosition > 0) {
+      topBarElement.classList.add('shadow');
+    } else {
+      topBarElement.classList.remove('shadow');
+    }
+  }
+
   render() {
     const { pointType, inputRef, isLoading, withGeoloc, value } = this.props;
     const { mounted, readOnly } = this.state;
@@ -140,6 +152,7 @@ class DirectionInput extends React.Component {
               withGeoloc={withGeoloc}
               onSelect={this.selectItem}
               onClear={this.removePoint}
+              onScroll={this.onScrollSuggest}
             />
         }
       </div>

--- a/src/scss/includes/colors.scss
+++ b/src/scss/includes/colors.scss
@@ -44,3 +44,4 @@ $active-gradient-vertical: linear-gradient(to bottom, $action-blue-base, $action
 
 $shadow: 0 1px 4px 0 rgba(12, 12, 14, 0.2), 0 0 2px 0 rgba(12, 12, 14, 0.12);
 $shadow-focus: 0px 0px 0px 4px rgba(128, 172, 255, 0.2);
+$shadow-scroll: 0 2px 16px 0 rgba(12, 12, 14, 0.2), 0 4px 8px 0 rgba(12, 12, 14, 0.12);

--- a/src/scss/includes/direction-field.scss
+++ b/src/scss/includes/direction-field.scss
@@ -13,6 +13,11 @@
 
     @media (max-width: 640px) {
       font-size: 14px;
+      transition: box-shadow 0.2s;
+
+      &.shadow {
+        box-shadow: $shadow-scroll;
+      }
 
       &:focus-within {
         position: fixed;

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -6,6 +6,11 @@
   pointer-events: auto;
   display: flex;
   align-items: center;
+  transition: box-shadow 0.2s;
+
+  &.shadow {
+    box-shadow: $shadow-scroll;
+  }
 }
 
 // Wrapper around the field and some icons, gets a colored border when the field is focused

--- a/src/scss/includes/suggest.scss
+++ b/src/scss/includes/suggest.scss
@@ -8,8 +8,10 @@
   overflow-y: auto;
   padding-bottom: 12px;
 
-  .top_bar & {
-    border-top: 1px solid $grey-light;
+  @media (min-width: 641px) {
+    .top_bar & {
+      border-top: 1px solid $grey-light;
+    }
   }
 }
 


### PR DESCRIPTION
## Description
Adds a drop shadow on input bars when the suggest list scrolls "under" it.
Do it on the main search bar and on the direction input, which are still 2 different components even if looking the same.

Define a new hook to ease such operations as this effect is to be re-used on other screens of the app.

**This doesn't work yet on iOS, as when the keyboard is open the whole body is scrolling. This is unrelated to this PR, I'll try to fix it separately.**

## Screenshots
![Peek 14-12-2020 10-10](https://user-images.githubusercontent.com/243653/102062399-f5cb7b80-3df4-11eb-9270-6ee0c449062f.gif)
