### PR TITLE
QMAPS-1902 (poc) make steps scroll more rigid

### DIFF
--- a/src/panel/direction/MobileRoadMapPreview.jsx
+++ b/src/panel/direction/MobileRoadMapPreview.jsx
@@ -16,14 +16,25 @@ const MobileRoadMapPreview = ({
   const scroll = () => {
 
     const newStep = Math.floor(
-      // Divide the step container's scrollLeft up to the middle of the screen with the size of a step
-      // to determine which step is present at the middle of the screen
-      (stepsRef.current.scrollLeft + window.innerWidth / 2) / (window.innerWidth - 70 + 12)
+      // Determine which step is fully visible on screen
+      stepsRef.current.scrollLeft / (window.innerWidth - 70 + 12)
     );
 
-    // If it has changed, save it and highlight it as the current step
+    // If it is different from the current step:
     if (currentStep !== newStep) {
+
+      // Save it and highlight it as the current step
       setCurrentStep(newStep);
+
+      if ((currentStep - 1) !== newStep) {
+        // Stop scroll inertia
+        stepsRef.current.style.overflow = 'hidden';
+        stepsRef.current.scrollLeft = stepsRef.current.scrollLeft;
+        setTimeout(() => {
+          // Ref is not available in setTimeout, use querySelector instead
+          document.querySelector('.mobile-roadmap-preview-steps').style.overflow = 'auto';
+        }, 100);
+      }
     }
   };
 

--- a/src/panel/direction/MobileRoadMapPreview.jsx
+++ b/src/panel/direction/MobileRoadMapPreview.jsx
@@ -26,8 +26,8 @@ const MobileRoadMapPreview = ({
       // Save it and highlight it as the current step
       setCurrentStep(newStep);
 
+      // Stop scroll inertia (except when going to previous step, which happens at the start of the scroll)
       if ((currentStep - 1) !== newStep) {
-        // Stop scroll inertia
         stepsRef.current.style.overflow = 'hidden';
         stepsRef.current.scrollLeft = stepsRef.current.scrollLeft;
         setTimeout(() => {


### PR DESCRIPTION
## Description
Try to hijack css snap scroll to avoid scrolling many itinerary mobile's steps at once


## Screenshots
![scroll](https://user-images.githubusercontent.com/1225909/103787293-b41da180-503d-11eb-80e7-495ca0baeb5c.gif)

