### PR TITLE
Itinerary step-by-step tweaks

### DIFF
--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -375,10 +375,9 @@ button.direction_shortcut {
         visibility: hidden;
       }
 
-      &.expanded {
+      &:not(.expanded) {
         .itinerary_mobile_step .itinerary_roadmap_instruction {
-          max-height: 30vh;
-          overflow: auto;
+          @include lineClamp(2);
         }
       }
 
@@ -435,13 +434,11 @@ button.direction_shortcut {
 
         .itinerary_roadmap_instruction {
           grid-area: instruction;
-          border: none;
-          max-height: 40px;
           padding: 0;
           margin-bottom: 2px;
-          overflow: hidden;
           display: block;
-          position: relative;
+          max-height: 30vh;
+          overflow: auto;
         }
 
         .itinerary_roadmap_distance {

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -338,6 +338,10 @@ button.direction_shortcut {
 
     .floatingButton {
       margin-left: $spacing-s;
+
+      i {
+        color: $grey-black;
+      }
     }
 
     .divider {
@@ -395,6 +399,7 @@ button.direction_shortcut {
         border: none;
         border-radius: 12px;
         box-shadow: $shadow;
+        padding: 10px $spacing-s 10px $spacing-xxs;
 
         &.past {
           background-color: $grey-lighter;
@@ -416,35 +421,27 @@ button.direction_shortcut {
         .roadmapIcon {
           width: 20px;
           height: 20px;
-          margin: $spacing-xs;
         }
 
         .itinerary_roadmap_item {
           border-left: 0;
           width: 100%;
           height: 100%;
-          padding: 10px;
+        }
+
+        .itinerary_roadmap_item_icon {
+          margin-right: $spacing-s;
         }
 
         .itinerary_roadmap_instruction {
           grid-area: instruction;
           border: none;
-          max-height: 44px;
-          line-height: 16px;
-          padding: 0 0 $spacing-xs 0;
+          max-height: 40px;
+          padding: 0;
+          margin-bottom: 2px;
           overflow: hidden;
           display: block;
           position: relative;
-
-          &:after {
-            content: "";
-            position: absolute;
-            bottom: 0;
-            background: linear-gradient(#ffffff77, #ffffff);
-            height: 6px;
-            width: 100%;
-            left: 0;
-          }
         }
 
         .itinerary_roadmap_distance {


### PR DESCRIPTION
## Description
Tweak some style on the step-by-step mode to closely match the design:
 - color of the back arrow
 - margins/paddings of elements
 - remove the ellipsis gradient

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran 2021-01-28 à 11 19 30](https://user-images.githubusercontent.com/243653/106123949-d7c69a00-615a-11eb-95dd-67d7308c40d7.png)|![Capture d’écran 2021-01-28 à 11 12 36](https://user-images.githubusercontent.com/243653/106123958-db5a2100-615a-11eb-996e-d6d7fa0ce82d.png)|

