### PR TITLE
Fix broken Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
     gettext git python3 build-essential ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm i npm@latest -g
+RUN npm i npm@latest-6 -g
 RUN mkdir -p $PROJECT_DIR
 RUN chown node $PROJECT_DIR
 


### PR DESCRIPTION
## Description
Force the docker build config to stay on npm 6, as the version 7 released 3 days ago as `latest` has breaking changes for us.