### PR TITLE
style: Fallback to "en" on unsupported "lang", and implement "layers" filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,18 +119,20 @@ Run integration tests only with `npm run integration-test`
 `npm run bench ` will build a production bundle and return size and js execution time metrics to compare evolution of application performance along the project life time.
 
 
-## EntryPoints
+### EntryPoints
 
 #### Style
- ` /style.json  ` gives access to prebuilt style with (optional) language.
 
-A [small script](https://github.com/Qwant/map-style-builder) is used behind the scene to build the style of the map and to ease the usage of the icons for the front end. The fonts used for the text displayed on the map are also built using an [OpenMapTiles script](https://github.com/Qwant/qwant-maps-fonts).
+**GET** `/style.json` provides a ready-to-use mapbox-gl style, with optional query parameters.
 
 Parameters:
 
-  |method |name |value       |optional |default |
-  |-------|-----|------------|---------|--------|
-  |get    |lang |en, gb ...  |true     |en      |
+  |name     |value             |default   |  |
+  |---------|------------------|----------|--|
+  |`lang`   |`en`, `fr`, `it`..|`en`      | Invalid or unsupported languages fallback to "en" |
+  |`layers` |`all`, `nopoi`    |`all`     | "nopoi" excludes layers with Points of Interests not related to public transport |
+
+  A [style builder](https://github.com/Qwant/map-style-builder) is used behind the scene to build the style of the map and to ease the usage of the icons for the front end. The fonts used for the text displayed on the map are also built using an [OpenMapTiles script](https://github.com/Qwant/qwant-maps-fonts).
 
 ### Development tips
 

--- a/bin/app.js
+++ b/bin/app.js
@@ -94,7 +94,8 @@ function App(config) {
 
   router.use('/style.json',
     compression(),
-    new mapStyle(config, languages));
+    ...new mapStyle(config, constants)
+  );
 
   if (config.server.enablePrometheus) {
     router.get('/metrics', (req, res) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10975,12 +10975,19 @@
       }
     },
     "express-validator": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.1.1.tgz",
-      "integrity": "sha512-AF6YOhdDiCU7tUOO/OHp2W++I3qpYX7EInMmEEcRGOjs+qoubwgc5s6Wo3OQgxwsWRGCxXlrF73SIDEmY4y3wg==",
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.9.2.tgz",
+      "integrity": "sha512-Yqlsw2/uBobtBVkP+gnds8OMmVAEb3uTI4uXC93l0Ym5JGHgr8Vd4ws7oSo7GGYpWn5YCq4UePMEppKchURXrw==",
       "requires": {
-        "lodash": "^4.17.11",
-        "validator": "^11.0.0"
+        "lodash": "^4.17.20",
+        "validator": "^13.5.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        }
       }
     },
     "extend": {
@@ -21356,9 +21363,9 @@
       }
     },
     "validator": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz",
-      "integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg=="
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.2.tgz",
+      "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ=="
     },
     "varstream": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "ejs": "^2.6.1",
     "express": "^4.16.3",
     "express-static-gzip": "^1.1.3",
-    "express-validator": "^6.1.1",
+    "express-validator": "^6.9.2",
     "finalhandler": "^1.1.2",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",

--- a/tests/integration/tests/server.js
+++ b/tests/integration/tests/server.js
@@ -66,3 +66,63 @@ test('refuses array in telemetry type', done => {
     .send('{"type":["localise_trigger"]}')
     .expect(400, done);
 });
+
+
+describe('get style.json', () => {
+  test('without parameter', done => {
+    server
+      .get('/style.json')
+      .expect(200, /name:en/)
+      .then(response => {
+        expect(response.body.layers.map(l => l.id)).toContain('poi-level-1');
+        done();
+      });
+  });
+
+  test('with nopoi layers', done => {
+    server
+      .get('/style.json?layers=nopoi')
+      .expect(200, /name:en/)
+      .then(response => {
+        expect(response.body.layers.map(l => l.id)).not.toContain('poi-level-1');
+        done();
+      });
+  });
+
+
+  test('with lang=fr', done => {
+    server
+      .get('/style.json?lang=fr')
+      .expect(200, /name:fr/)
+      .then(response => {
+        expect(response.body.layers.map(l => l.id)).toContain('poi-level-1');
+        done();
+      });
+  });
+
+  test('with unknown lang, fallback to en', done => {
+    server
+      .get('/style.json?lang=abc')
+      .expect(200, /name:en/)
+      .then(response => {
+        expect(response.body.layers.map(l => l.id)).toContain('poi-level-1');
+        done();
+      });
+  });
+
+  test('with explicit layers and lang', done => {
+    server
+      .get('/style.json?layers=nopoi&lang=fr')
+      .expect(200, /name:fr/)
+      .then(response => {
+        expect(response.body.layers.map(l => l.id)).not.toContain('poi-level-1');
+        done();
+      });
+  });
+
+  test('invalid value for layers leads to 400', done => {
+    server
+      .get('/style.json?layers=invalid')
+      .expect(400, done);
+  });
+});


### PR DESCRIPTION
Extends the existing "/style.json" endpoint, with validation of its optional parameters:

* `lang` now fallbacks to English for unsupported languages.
* `layers` is a new parameter that accept "**all**" or "**nopoi**".  
"all" layers are returned by default. "nopoi" excludes non-transport POIs.

Tests are defined in "tests/integration/tests/server.js" to validate this behavior.

