### PR TITLE
Back to Qwant button

### DIFF
--- a/src/components/BackToQwantButton.jsx
+++ b/src/components/BackToQwantButton.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { Button } from 'src/components/ui';
+
+export const BackToQwantButton = ({ ...props }) => {
+
+  return (
+    <Button
+      key="back-to-qwant"
+      icon="arrow-left"
+      variant="tertiary"
+      onClick={() => window.history.back()}
+      style={{
+        backgroundColor: 'white',
+        boxShadow: '0 1px 4px 0 rgba(12, 12, 14, 0.2), 0 0 2px 0 rgba(12, 12, 14, 0.12)',
+      }}
+      {...props}
+    >
+      Retour sur Qwant
+    </Button>
+  );
+};

--- a/src/components/BackToQwantButton.jsx
+++ b/src/components/BackToQwantButton.jsx
@@ -1,9 +1,29 @@
 /* globals _ */
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { Button } from 'src/components/ui';
 
-export const BackToQwantButton = ({ ...props }) => {
+export const BackToQwantButton = ({ isMobile }) => {
+
+  useEffect(() => {
+    let mapScaleElement;
+
+    window.execOnMapLoaded(() => {
+      if (!isMobile) {return;}
+      // Hide scale while the button is mounted as it would overlap
+      const elems = document.getElementsByClassName('map_control__scale_attribute_container');
+      if (elems.length > 0) {
+        mapScaleElement = elems[0];
+        mapScaleElement.style.visibility = 'hidden';
+      }
+    });
+
+    return () => {
+      if (mapScaleElement) {
+        mapScaleElement.style.visibility = 'visible';
+      }
+    };
+  }, [isMobile]);
 
   return (
     <Button
@@ -11,7 +31,6 @@ export const BackToQwantButton = ({ ...props }) => {
       icon="arrow-left"
       variant="tertiary"
       onClick={() => window.history.back()}
-      {...props}
     >
       {_('Back to Qwant.com')}
     </Button>

--- a/src/components/BackToQwantButton.jsx
+++ b/src/components/BackToQwantButton.jsx
@@ -3,26 +3,16 @@ import React, { useEffect } from 'react';
 
 import { Button } from 'src/components/ui';
 
+const hiddenAttributeClassName = 'map_control__scale_attribute_container--hidden';
+
 export const BackToQwantButton = ({ isMobile }) => {
 
   useEffect(() => {
-    let mapScaleElement;
+    if (!isMobile) {return;}
 
-    window.execOnMapLoaded(() => {
-      if (!isMobile) {return;}
-      // Hide scale while the button is mounted as it would overlap
-      const elems = document.getElementsByClassName('map_control__scale_attribute_container');
-      if (elems.length > 0) {
-        mapScaleElement = elems[0];
-        mapScaleElement.style.visibility = 'hidden';
-      }
-    });
-
-    return () => {
-      if (mapScaleElement) {
-        mapScaleElement.style.visibility = 'visible';
-      }
-    };
+    // Hide scale while the button is mounted as it would overlap
+    document.body.classList.add(hiddenAttributeClassName);
+    return () => document.body.classList.remove(hiddenAttributeClassName);
   }, [isMobile]);
 
   return (

--- a/src/components/BackToQwantButton.jsx
+++ b/src/components/BackToQwantButton.jsx
@@ -1,3 +1,4 @@
+/* globals _ */
 import React from 'react';
 
 import { Button } from 'src/components/ui';
@@ -12,7 +13,7 @@ export const BackToQwantButton = ({ ...props }) => {
       onClick={() => window.history.back()}
       {...props}
     >
-      Retour sur Qwant
+      {_('Back to Qwant.com')}
     </Button>
   );
 };

--- a/src/components/BackToQwantButton.jsx
+++ b/src/components/BackToQwantButton.jsx
@@ -6,7 +6,6 @@ export const BackToQwantButton = ({ ...props }) => {
 
   return (
     <Button
-      key="back-to-qwant"
       icon="arrow-left"
       variant="tertiary"
       onClick={() => window.history.back()}

--- a/src/components/BackToQwantButton.jsx
+++ b/src/components/BackToQwantButton.jsx
@@ -6,13 +6,10 @@ export const BackToQwantButton = ({ ...props }) => {
 
   return (
     <Button
+      className="backToQwantButton"
       icon="arrow-left"
       variant="tertiary"
       onClick={() => window.history.back()}
-      style={{
-        backgroundColor: 'white',
-        boxShadow: '0 1px 4px 0 rgba(12, 12, 14, 0.2), 0 0 2px 0 rgba(12, 12, 14, 0.12)',
-      }}
       {...props}
     >
       Retour sur Qwant

--- a/src/components/ui/FloatingItems.jsx
+++ b/src/components/ui/FloatingItems.jsx
@@ -4,8 +4,8 @@ const FloatingItems = ({ items, position }) =>
   <div
     className="floatingItems"
     style={position === 'left'
-      ? { left: 12, transform: 'translateY(calc(-100% - 32px))' }
-      : { right: 12 }}>
+      ? { paddingLeft: 12, transform: 'translateY(calc(-100% - 32px))' }
+      : { paddingRight: 12 }}>
     {items}
   </div>
 ;

--- a/src/components/ui/FloatingItems.jsx
+++ b/src/components/ui/FloatingItems.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 
-const FloatingItems = ({ items }) =>
-  <div className="floatingItems">
+const FloatingItems = ({ items, position }) =>
+  <div
+    className="floatingItems"
+    style={position === 'left'
+      ? { left: 12, transform: 'translateY(calc(-100% - 32px))' }
+      : { right: 12 }}>
     {items}
   </div>
 ;

--- a/src/components/ui/FloatingItems.jsx
+++ b/src/components/ui/FloatingItems.jsx
@@ -4,7 +4,7 @@ const FloatingItems = ({ items, position }) =>
   <div
     className="floatingItems"
     style={position === 'left'
-      ? { paddingLeft: 12, transform: 'translateY(calc(-100% - 32px))' }
+      ? { paddingLeft: 12 }
       : { paddingRight: 12 }}>
     {items}
   </div>

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -284,7 +284,10 @@ class Panel extends React.Component {
   render() {
     const {
       children, minimizedTitle,
-      resizable, className, size, renderHeader, onClose, floatingItems } = this.props;
+      resizable, className, size,
+      renderHeader, onClose,
+      floatingItemsLeft, floatingItemsRight,
+    } = this.props;
     const { translateY, holding } = this.state;
 
     return (
@@ -311,7 +314,10 @@ class Panel extends React.Component {
             }}
             {...(isMobile && resizable && this.getEventHandlers())}
           >
-            {floatingItems && <FloatingItems items={floatingItems} />}
+            {floatingItemsLeft && size !== 'maximized' &&
+              <FloatingItems position="left" items={floatingItemsLeft} />
+            }
+            {floatingItemsRight && <FloatingItems position="right" items={floatingItemsRight} />}
             {onClose && <CloseButton onClick={onClose} className="panel-close" />}
             {isMobile && resizable &&
               <div

--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -317,7 +317,8 @@ class Panel extends React.Component {
             {floatingItemsLeft && size !== 'maximized' &&
               <FloatingItems position="left" items={floatingItemsLeft} />
             }
-            {floatingItemsRight && <FloatingItems position="right" items={floatingItemsRight} />}
+            {floatingItemsRight && size !== 'maximized' &&
+              <FloatingItems position="right" items={floatingItemsRight} />}
             {onClose && <CloseButton onClick={onClose} className="panel-close" />}
             {isMobile && resizable &&
               <div

--- a/src/components/ui/PanelNav.jsx
+++ b/src/components/ui/PanelNav.jsx
@@ -1,16 +1,10 @@
 import React from 'react';
-import { Button, Flex, Divider } from '.';
+import { Flex, Divider } from '.';
 
-const PanelNav = ({ onGoBack, goBackText }) =>
+const PanelNav = ({ children }) =>
   <div className="panelNav">
     <Flex className="panelNav-content" justifyContent="space-between">
-      <Button
-        icon="arrow-left"
-        variant="tertiary"
-        onClick={onGoBack}
-      >
-        {goBackText}
-      </Button>
+      {children}
     </Flex>
 
     <Divider

--- a/src/libs/url_utils.js
+++ b/src/libs/url_utils.js
@@ -73,8 +73,7 @@ export function updateQueryString(queriesObject) {
   });
 }
 
-export function isFromQwant() {
+export function shouldShowBackToQwant() {
   const params = parseQueryString(window.location.search);
-  const qwantClients = ['search-ia-local', 'search-ia-multi', 'search-ia-address'];
-  return params.client && qwantClients.includes(params.client);
+  return params.client && params.client === 'search-ia-maps-multi';
 }

--- a/src/libs/url_utils.js
+++ b/src/libs/url_utils.js
@@ -75,5 +75,6 @@ export function updateQueryString(queriesObject) {
 
 export function isFromQwant() {
   const params = parseQueryString(window.location.search);
-  return params.isFromQwant === 'true';
+  const qwantClients = ['search-ia-local', 'search-ia-multi', 'search-ia-address'];
+  return params.client && qwantClients.includes(params.client);
 }

--- a/src/libs/url_utils.js
+++ b/src/libs/url_utils.js
@@ -72,3 +72,8 @@ export function updateQueryString(queriesObject) {
     ...queriesObject,
   });
 }
+
+export function isFromQwant() {
+  const params = parseQueryString(window.location.search);
+  return params.isFromQwant === 'true';
+}

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -143,7 +143,7 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
     if (shouldShowBackToQwant()) {
       return (
         <PanelNav>
-          <BackToQwantButton style={{}}/>
+          <BackToQwantButton />
         </PanelNav>
       );
     }

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -155,7 +155,7 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
     minimizedTitle={_('Unfold to show the results', 'categories')}
     className={classnames('category__panel', { 'panel--pj': dataSource === sources.pagesjaunes })}
     floatingItemsLeft={[
-      isMobile && shouldShowBackToQwant() && <BackToQwantButton key="back-to-qwant" />,
+      isMobile && shouldShowBackToQwant() && <BackToQwantButton key="back-to-qwant" isMobile />,
     ]}
   >
     {panelContent}

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -19,7 +19,7 @@ import { sources } from 'config/constants.yml';
 import { DeviceContext } from 'src/libs/device';
 import { PanelContext } from 'src/libs/panelContext';
 import { BackToQwantButton } from 'src/components/BackToQwantButton';
-import { isFromQwant } from 'src/libs/url_utils';
+import { shouldShowBackToQwant } from 'src/libs/url_utils';
 import { PanelNav } from 'src/components/ui';
 
 const categoryConfig = nconf.get().category;
@@ -140,7 +140,7 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
   const NavHeader = () => {
     if (isMobile) {return null;}
 
-    if (isFromQwant()) {
+    if (shouldShowBackToQwant()) {
       return (
         <PanelNav>
           <BackToQwantButton style={{}} key="back-to-qwant" />

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -138,17 +138,15 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
   }
 
   const NavHeader = () => {
-    if (isMobile) {return null;}
-
-    if (shouldShowBackToQwant()) {
-      return (
-        <PanelNav>
-          <BackToQwantButton />
-        </PanelNav>
-      );
+    if (isMobile || !shouldShowBackToQwant()) {
+      return null;
     }
 
-    return null;
+    return (
+      <PanelNav>
+        <BackToQwantButton />
+      </PanelNav>
+    );
   };
 
   return <Panel

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -155,7 +155,7 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
     minimizedTitle={_('Unfold to show the results', 'categories')}
     className={classnames('category__panel', { 'panel--pj': dataSource === sources.pagesjaunes })}
     floatingItemsLeft={[
-      isMobile && shouldShowBackToQwant && <BackToQwantButton key="back-to-qwant" />,
+      isMobile && shouldShowBackToQwant() && <BackToQwantButton key="back-to-qwant" />,
     ]}
   >
     {panelContent}

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -157,7 +157,7 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
     minimizedTitle={_('Unfold to show the results', 'categories')}
     className={classnames('category__panel', { 'panel--pj': dataSource === sources.pagesjaunes })}
     floatingItemsLeft={[
-      isMobile && <BackToQwantButton key="back-to-qwant" />,
+      isMobile && shouldShowBackToQwant && <BackToQwantButton key="back-to-qwant" />,
     ]}
   >
     {panelContent}

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -143,7 +143,7 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
     if (shouldShowBackToQwant()) {
       return (
         <PanelNav>
-          <BackToQwantButton style={{}} key="back-to-qwant" />
+          <BackToQwantButton style={{}}/>
         </PanelNav>
       );
     }

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -18,6 +18,9 @@ import classnames from 'classnames';
 import { sources } from 'config/constants.yml';
 import { DeviceContext } from 'src/libs/device';
 import { PanelContext } from 'src/libs/panelContext';
+import { BackToQwantButton } from 'src/components/BackToQwantButton';
+import { isFromQwant } from 'src/libs/url_utils';
+import { PanelNav } from 'src/components/ui';
 
 const categoryConfig = nconf.get().category;
 const MAX_PLACES = Number(categoryConfig.maxPlaces);
@@ -134,10 +137,28 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
     </>;
   }
 
+  const NavHeader = () => {
+    if (isMobile) {return null;}
+
+    if (isFromQwant()) {
+      return (
+        <PanelNav>
+          <BackToQwantButton style={{}} key="back-to-qwant" />
+        </PanelNav>
+      );
+    }
+
+    return null;
+  };
+
   return <Panel
     resizable
+    renderHeader={<NavHeader isMobile={isMobile} />}
     minimizedTitle={_('Unfold to show the results', 'categories')}
     className={classnames('category__panel', { 'panel--pj': dataSource === sources.pagesjaunes })}
+    floatingItemsLeft={[
+      isMobile && <BackToQwantButton key="back-to-qwant" />,
+    ]}
   >
     {panelContent}
   </Panel>;

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -420,7 +420,7 @@ export default class DirectionPanel extends React.Component {
               minimizedTitle={_('Unfold to show the results', 'direction')}
               onClose={this.onClose}
               isMapBottomUIDisplayed={false}
-              floatingItems={[
+              floatingItemsRight={[
                 <ShareMenu key="action-share" url={window.location.toString()}>
                   {openMenu =>
                     <FloatingButton

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -9,7 +9,7 @@ import PoiBlockContainer from './PoiBlockContainer';
 import OsmContribution from 'src/components/OsmContribution';
 import CategoryList from 'src/components/CategoryList';
 import { isFromPagesJaunes, isFromOSM } from 'src/libs/pois';
-import { buildQueryString } from 'src/libs/url_utils';
+import { buildQueryString, isFromQwant } from 'src/libs/url_utils';
 import IdunnPoi from 'src/adapters/poi/idunn_poi';
 import Poi from 'src/adapters/poi/poi.js';
 import { fire, listen, unListen } from 'src/libs/customEvents';
@@ -17,7 +17,8 @@ import { addToFavorites, removeFromFavorites, isInFavorites } from 'src/adapters
 import PoiItem from 'src/components/PoiItem';
 import { isNullOrEmpty } from 'src/libs/object';
 import { DeviceContext } from 'src/libs/device';
-import { Flex, Panel, PanelNav, CloseButton, Divider } from 'src/components/ui';
+import { Flex, Panel, PanelNav, CloseButton, Divider, Button } from 'src/components/ui';
+import { BackToQwantButton } from 'src/components/BackToQwantButton';
 
 const covid19Enabled = (nconf.get().covid19 || {}).enabled;
 
@@ -221,6 +222,34 @@ export default class PoiPanel extends React.Component {
         ? this.backToFavorite
         : this.closeAction;
 
+    const NavHeader = ({ isMobile }) => {
+      if (isMobile) {return null;}
+
+      if (isFromQwant()) {
+        return (
+          <PanelNav>
+            <BackToQwantButton style={{}} key="back-to-qwant" />
+          </PanelNav>
+        );
+      }
+
+      if (backAction !== this.closeAction) {
+        return (
+          <PanelNav>
+            <Button
+              icon="arrow-left"
+              variant="tertiary"
+              onClick={backAction}
+            >
+              {_('Display all results')}
+            </Button>
+          </PanelNav>
+        );
+      }
+
+      return null;
+    };
+
     return <DeviceContext.Consumer>
       {isMobile =>
         <Panel
@@ -232,13 +261,10 @@ export default class PoiPanel extends React.Component {
             !isFromFavorite &&
             (!poiFilters || !poiFilters.category),
           })}
-          renderHeader={!isMobile && backAction !== this.closeAction &&
-            <PanelNav
-              isMobile={isMobile}
-              onGoBack={backAction}
-              goBackText={_('Display all results')}
-            />
-          }
+          renderHeader={<NavHeader isMobile={isMobile} />}
+          floatingItemsLeft={isMobile && [
+            <BackToQwantButton key="back-to-qwant" />,
+          ]}
         >
           <div className="poi_panel__content">
             <Flex alignItems="flex-start" justifyContent="space-between">

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -263,7 +263,7 @@ export default class PoiPanel extends React.Component {
           })}
           renderHeader={<NavHeader isMobile={isMobile} />}
           floatingItemsLeft={isMobile && shouldShowBackToQwant() && [
-            <BackToQwantButton key="back-to-qwant" />,
+            <BackToQwantButton key="back-to-qwant" isMobile />,
           ]}
         >
           <div className="poi_panel__content">

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -9,7 +9,7 @@ import PoiBlockContainer from './PoiBlockContainer';
 import OsmContribution from 'src/components/OsmContribution';
 import CategoryList from 'src/components/CategoryList';
 import { isFromPagesJaunes, isFromOSM } from 'src/libs/pois';
-import { buildQueryString, isFromQwant } from 'src/libs/url_utils';
+import { buildQueryString, shouldShowBackToQwant } from 'src/libs/url_utils';
 import IdunnPoi from 'src/adapters/poi/idunn_poi';
 import Poi from 'src/adapters/poi/poi.js';
 import { fire, listen, unListen } from 'src/libs/customEvents';
@@ -225,7 +225,7 @@ export default class PoiPanel extends React.Component {
     const NavHeader = ({ isMobile }) => {
       if (isMobile) {return null;}
 
-      if (isFromQwant()) {
+      if (shouldShowBackToQwant()) {
         return (
           <PanelNav>
             <BackToQwantButton style={{}} key="back-to-qwant" />

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -228,7 +228,7 @@ export default class PoiPanel extends React.Component {
       if (shouldShowBackToQwant()) {
         return (
           <PanelNav>
-            <BackToQwantButton style={{}} />
+            <BackToQwantButton />
           </PanelNav>
         );
       }

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -262,7 +262,7 @@ export default class PoiPanel extends React.Component {
             (!poiFilters || !poiFilters.category),
           })}
           renderHeader={<NavHeader isMobile={isMobile} />}
-          floatingItemsLeft={isMobile && [
+          floatingItemsLeft={isMobile && shouldShowBackToQwant && [
             <BackToQwantButton key="back-to-qwant" />,
           ]}
         >

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -262,7 +262,7 @@ export default class PoiPanel extends React.Component {
             (!poiFilters || !poiFilters.category),
           })}
           renderHeader={<NavHeader isMobile={isMobile} />}
-          floatingItemsLeft={isMobile && shouldShowBackToQwant && [
+          floatingItemsLeft={isMobile && shouldShowBackToQwant() && [
             <BackToQwantButton key="back-to-qwant" />,
           ]}
         >

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -228,7 +228,7 @@ export default class PoiPanel extends React.Component {
       if (shouldShowBackToQwant()) {
         return (
           <PanelNav>
-            <BackToQwantButton style={{}} key="back-to-qwant" />
+            <BackToQwantButton style={{}} />
           </PanelNav>
         );
       }

--- a/src/scss/includes/components/backToQwantButton.scss
+++ b/src/scss/includes/components/backToQwantButton.scss
@@ -1,0 +1,6 @@
+.backToQwantButton {
+  @media (max-width: 640px) {
+    background-color: white;
+    box-shadow: 0 1px 4px 0 rgba(12, 12, 14, 0.2), 0 0 2px 0 rgba(12, 12, 14, 0.12);
+  }
+}

--- a/src/scss/includes/components/floatingItems.scss
+++ b/src/scss/includes/components/floatingItems.scss
@@ -1,7 +1,6 @@
 .floatingItems {
   position: absolute;
   display: grid;
-  right: 12px;
   gap: 8px;
   transform: translateY(calc(-100% - 12px));
 }

--- a/src/scss/includes/components/panelNav.scss
+++ b/src/scss/includes/components/panelNav.scss
@@ -1,10 +1,9 @@
 .panelNav {
   background-color: $background;
-  height: 50px;
   width: 100%;
 
   &-content {
     padding: 0 $spacing-xxs;
-    height: 100%;
+    height: 50px;
   }
 }

--- a/src/scss/includes/map_theme.scss
+++ b/src/scss/includes/map_theme.scss
@@ -103,6 +103,12 @@
   }
 }
 
+.map_control__scale_attribute_container--hidden {
+  .map_control__scale_attribute_container {
+    visibility: hidden;
+  }
+}
+
 .map_control__scale_attribute_container .mapboxgl-ctrl.map_control__scale {
   margin: 4px 5px;
   float: left;

--- a/src/scss/includes/ui_components.scss
+++ b/src/scss/includes/ui_components.scss
@@ -14,3 +14,4 @@
 @import "./components/closeButton";
 @import "./components/floatingButton";
 @import "./components/floatingItems";
+@import "./components/backToQwantButton";


### PR DESCRIPTION
## Description
Display a "back to qwant" button on poi and category panels, depending on the presence of a `isFromQwant` query param.

Query param `client` can trigger this button withvalue 'search-ia-multi'

## Why
UX between phoenix and qwant

## Screenshots
![desktop POI panel](https://user-images.githubusercontent.com/2981774/109685364-7a6ea000-7b81-11eb-85bd-2e3494c15bcd.png)
![mobile POI panel](https://user-images.githubusercontent.com/2981774/109685416-86f2f880-7b81-11eb-85ad-051138c3d030.png)
![desktop POI category](https://user-images.githubusercontent.com/2981774/109685504-9bcf8c00-7b81-11eb-800d-a3503cb38c64.png)
![desktop POI category](https://user-images.githubusercontent.com/2981774/109811333-fa047980-7c2a-11eb-87dd-c69e3ba5e45e.png)


I still need to figure out why the divider is missing in the category panel, in desktop mode