### PR TITLE
Add missing 'lang' attribute to <html>

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= language.code %>">
   <head>
     <meta charset='utf-8'>
     <title><%= _('Qwant Maps') %>


### PR DESCRIPTION
## Description
Something I realized when building the [fallback page for old browsers](https://github.com/Qwant/erdapfel/pull/1030): we don't specify the content language in the page of the app, which is a big missing point.