### PR TITLE
Trigger the unsupported browser page when user uses IE11

### DIFF
--- a/bin/app.js
+++ b/bin/app.js
@@ -11,7 +11,6 @@ const fakePbf = require('./middlewares/fake_pbf/index');
 const compression = require('compression');
 const mapStyle = require('./middlewares/map_style');
 const getReqSerializer = require('./serializers/request');
-const redirectUnsupported = require('./middlewares/unsupported_browser');
 
 const app = express();
 const promRegistry = new promClient.Registry();
@@ -109,11 +108,12 @@ function App(config) {
     });
   }
 
-  const ogMeta = new require('./middlewares/og_meta')(config);
-
   router.get('/unsupported', (req, res) => {
     res.render('unsupported', { config });
   });
+
+  const ogMeta = new require('./middlewares/og_meta')(config);
+  const redirectUnsupported = new require('./middlewares/unsupported_browser')(config);
 
   router.get('/*', redirectUnsupported, ogMeta, (req, res) => {
     const userAgent = req.headers['user-agent'];

--- a/bin/app.js
+++ b/bin/app.js
@@ -11,6 +11,7 @@ const fakePbf = require('./middlewares/fake_pbf/index');
 const compression = require('compression');
 const mapStyle = require('./middlewares/map_style');
 const getReqSerializer = require('./serializers/request');
+const redirectUnsupported = require('./middlewares/unsupported_browser');
 
 const app = express();
 const promRegistry = new promClient.Registry();
@@ -114,7 +115,7 @@ function App(config) {
     res.render('unsupported', { config });
   });
 
-  router.get('/*', ogMeta, (req, res) => {
+  router.get('/*', redirectUnsupported, ogMeta, (req, res) => {
     const userAgent = req.headers['user-agent'];
     const disableMenuRule = config.server.disableBurgerMenu.userAgentRule;
     let appConfig = config;

--- a/bin/middlewares/unsupported_browser.js
+++ b/bin/middlewares/unsupported_browser.js
@@ -9,7 +9,7 @@ module.exports = function(config) {
 
   return function(req, res, next) {
     if (redirect && isUnsupported(req.headers['user-agent'])) {
-      res.redirect(302, req.baseUrl + '/unsupported');
+      res.redirect(302, config.system.baseUrl + 'unsupported');
     } else {
       next();
     }

--- a/bin/middlewares/unsupported_browser.js
+++ b/bin/middlewares/unsupported_browser.js
@@ -4,10 +4,14 @@ function isUnsupported(userAgent = '') {
   return userAgent.match('Trident'); // old IE detection
 }
 
-module.exports = function(req, res, next) {
-  if (isUnsupported(req.headers['user-agent'])) {
-    res.redirect(302, '/unsupported');
-  } else {
-    next();
-  }
+module.exports = function(config) {
+  const redirect = config.server.unsupportedBrowsers.redirect;
+
+  return function(req, res, next) {
+    if (redirect && isUnsupported(req.headers['user-agent'])) {
+      res.redirect(302, '/unsupported');
+    } else {
+      next();
+    }
+  };
 };

--- a/bin/middlewares/unsupported_browser.js
+++ b/bin/middlewares/unsupported_browser.js
@@ -9,7 +9,7 @@ module.exports = function(config) {
 
   return function(req, res, next) {
     if (redirect && isUnsupported(req.headers['user-agent'])) {
-      res.redirect(302, '/unsupported');
+      res.redirect(302, req.baseUrl + '/unsupported');
     } else {
       next();
     }

--- a/bin/middlewares/unsupported_browser.js
+++ b/bin/middlewares/unsupported_browser.js
@@ -1,0 +1,13 @@
+/* globals module */
+
+function isUnsupported(userAgent = '') {
+  return userAgent.match('Trident'); // old IE detection
+}
+
+module.exports = function(req, res, next) {
+  if (isUnsupported(req.headers['user-agent'])) {
+    res.redirect(302, '/unsupported');
+  } else {
+    next();
+  }
+};

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -19,6 +19,8 @@ server:
   # NB: `routerBaseUrl` may be different from `system.baseUrl` if a proxy is responsible for rewriting URLs
   routerBaseUrl: / # path prefix expected by the express server
   useGeoipForInitialPosition: true
+  unsupportedBrowsers:
+    redirect: false
 
 app:
   versionFlag: Beta

--- a/tests/integration/test_config.js
+++ b/tests/integration/test_config.js
@@ -11,5 +11,6 @@ config.direction.service.api = 'mapbox'; // Directions fixtures use mapbox forma
 config.events.enabled = true;
 config.system.baseUrl = '/maps/';
 config.server.routerBaseUrl = '/maps/';
+config.server.unsupportedBrowsers.redirect = true;
 
 module.exports = config;

--- a/tests/integration/tests/home.js
+++ b/tests/integration/tests/home.js
@@ -4,8 +4,18 @@ let page;
 
 beforeAll(async () => {
   const browserPage = await initBrowser();
-  page = browserPage.page;
   browser = browserPage.browser;
+});
+
+beforeEach(async () => {
+  page = await browser.newPage();
+});
+
+test('redirect unsupported browsers to dedicated page', async () => {
+  // IE11 on Win10
+  await page.setUserAgent('Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko');
+  await page.goto(APP_URL);
+  expect(page.url()).toEqual(`${APP_URL}/unsupported`);
 });
 
 test('is dom loaded', async () => {
@@ -21,6 +31,10 @@ test('is panels loaded', async () => {
 test('is map loaded', async () => {
   await page.goto(APP_URL);
   expect(await exists(page, '.mapboxgl-canvas')).toBeTruthy();
+});
+
+afterEach(async () => {
+  await page.close();
 });
 
 afterAll(async () => {


### PR DESCRIPTION
## Description
Follow-up to https://github.com/Qwant/erdapfel/pull/1030.
Now that we have set up a page for unsupported browsers, let's redirect to it when we detect it's an old IE.
I used an express middleware for that, so it's easy to make it grow and maintain without complexifying the default app route implementation.