### PR TITLE
Change Terms of Service link label in menu

### DIFF
--- a/src/panel/Menu.jsx
+++ b/src/panel/Menu.jsx
@@ -71,7 +71,8 @@ const Menu = () => {
             outsideLink
             icon={<IconLightbulb width={16} fill={ACTION_BLUE_BASE} />}
           >
-            {_('About Qwant Maps', 'menu')}
+            <span dangerouslySetInnerHTML={{
+              __html: _('Terms of service Qwant&nbsp;Maps', 'menu') }} />
           </MenuItem>
           <MenuItem
             href="https://github.com/Qwant/qwantmaps/blob/master/contributing.md"

--- a/src/panel/menu/MenuItem.jsx
+++ b/src/panel/menu/MenuItem.jsx
@@ -13,9 +13,9 @@ const MenuItem = ({ icon, children, href, onClick, outsideLink }) =>
       target: '_blank',
     } : {})}
   >
-    <Flex>
-      {icon && <Flex className="u-mr-s">{icon}</Flex>}
-      <div style={{ flexGrow: 1 }}>{children}</div>
+    <Flex alignItems="flex-start">
+      {icon && <div className="u-mr-s">{icon}</div>}
+      <div className="u-mr-s" style={{ flexGrow: 1 }}>{children}</div>
       {outsideLink && <IconExternalLink width={16} fill={GREY_SEMI_DARKNESS} />}
     </Flex>
   </a>;

--- a/src/scss/includes/menu.scss
+++ b/src/scss/includes/menu.scss
@@ -54,6 +54,12 @@ $menuPanelWidth: 300px;
   display: block;
   padding: $spacing-m $spacing-xl-2;
   color: $grey-black;
+  
+  // Needed to ensure icons are visually aligned with the first line of text
+  svg {
+    height: 16px;
+    flex-shrink: 0;
+  }
 
   &:hover, &:active {
     text-decoration: none;


### PR DESCRIPTION
## Description
In the burger menu, replace "About Qwant Maps" by "Terms of Service Qwant Maps", which is a better information about the actual target page.

## Screenshots

|Before|After|
|---|---|
|![Capture d’écran de 2021-03-12 16-30-21](https://user-images.githubusercontent.com/243653/110961598-41d48080-8350-11eb-9f0d-4f0c688c2f80.png)|![Capture d’écran de 2021-03-12 16-30-09](https://user-images.githubusercontent.com/243653/110961623-48fb8e80-8350-11eb-815f-f6f370f6a7de.png)|

