### PR TITLE
[Bug] Fix start POI always in EN when coming from IA

### DIFF
--- a/bin/middlewares/og_meta.js
+++ b/bin/middlewares/og_meta.js
@@ -75,7 +75,7 @@ module.exports = function(config) {
   }
 
   return function(req, res, next) {
-    const placeUrlMatch = req.originalUrl.match(/place\/(.*)/);
+    const placeUrlMatch = req.originalUrl.split('?')[0].match(/place\/(.*)/);
     const locale = res.locals.language;
     let poiId;
     if (placeUrlMatch && placeUrlMatch.length > 0) {


### PR DESCRIPTION
## Description
Fix the extraction of the POI id from the url, to stop at the search params part to avoid including it in the id.

This caused [this url](https://github.com/Qwant/erdapfel/blob/master/bin/middlewares/og_meta.js#L22) to be built with two `?` characters, so Idunn ignored the language code which was behind the second one, resulting in POI data always in English even if the UI was in French.

(The whole url management in this file could be made more robust, but right now let's only fix this urgent bug)