### PR TITLE
Rebuild qwant-maps-common explicitly on 'prepare'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "erdapfel",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "workspaces": [
@@ -140,7 +141,7 @@
     },
     "local_modules/qwant-maps-common": {
       "name": "@qwant/qwant-maps-common",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "i18n-pull": "tx pull --all --force",
     "watch": "webpack --config build/webpack.config.js -w --mode=development",
     "msgmerge": "node local_modules/merge-po/index",
-    "prepare": "if [ \"$IGNORE_PREPARE\" != true ]; then node build/before_build.js; fi",
+    "prepare": "if [ \"$IGNORE_PREPARE\" != true ]; then node build/before_build.js && npm rebuild @qwant/qwant-maps-common; fi",
     "lint": "eslint src bin build tests --ext '.js,.jsx'",
     "lint-fix": "eslint --fix src bin build tests --ext '.js,.jsx'",
     "analyze": "webpack --config build/webpack.config.js --mode=production --profile --json > stats.json && webpack-bundle-analyzer stats.json public/build/javascript"


### PR DESCRIPTION
## Description
Ensure that "@qwant/qwant-maps-common" is built using rollup, before it's bundled by webpack.

## Why
Whether "qwant-maps-common" is built on install is not consistent, depending on the environment where `npm` is executed.
See https://github.com/npm/cli/issues/2900
Hopefully, the next releases of npm should bring [new features](https://github.com/npm/rfcs/blob/8167fa97a266cc2bf60cc545b382d274dc397496/accepted/0000-workspaces-part2.md) to help with the operations on workspaces.

This issue went unnoticed until now, as it seems that webpack fallbacks to "index.js" if "dist/index.js" is absent in qwant-maps-common package. 

As a result, extra bundles were built by webpack, based on the source code of "qwant-maps-common" instead of the built version: https://github.com/Qwant/erdapfel/runs/2123401448#step:5:694



