### PR TITLE
QMAPS-2051 update map style to add non breaking spaces in attribution text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "erdapfel",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "workspaces": [
@@ -14,7 +13,7 @@
       "dependencies": {
         "@babel/polyfill": "^7.8.0",
         "@qwant/map-style-builder": "github:Qwant/map-style-builder#9808391",
-        "@qwant/qwant-basic-gl-style": "^1.1.0",
+        "@qwant/qwant-basic-gl-style": "^1.3.1",
         "@turf/along": "^6.0.1",
         "@turf/bbox": "^6.0.1",
         "@turf/bearing": "^6.0.1",
@@ -2676,9 +2675,9 @@
       "link": true
     },
     "node_modules/@qwant/qwant-basic-gl-style": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@qwant/qwant-basic-gl-style/-/qwant-basic-gl-style-1.3.0.tgz",
-      "integrity": "sha512-YL4tL4rjj+AaOdrkXe9CVexUk44VB3s8c4KzxmMJAj9OSHeYCHNCPDAwrBHplQoXyQ1WPTDJCsB9v8r29nI0eQ=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@qwant/qwant-basic-gl-style/-/qwant-basic-gl-style-1.3.1.tgz",
+      "integrity": "sha512-zIjW9WgOwFOSQmKaCTvDKaGmB8PCwtyU+2PFLBmLdVR4zGWypP6evqtv8jzT0g5MgYFx1sLLKWzP+qhHIccQRA=="
     },
     "node_modules/@qwant/qwant-maps-common": {
       "resolved": "local_modules/qwant-maps-common",
@@ -22912,9 +22911,9 @@
       "version": "file:local_modules/po-js-loader"
     },
     "@qwant/qwant-basic-gl-style": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@qwant/qwant-basic-gl-style/-/qwant-basic-gl-style-1.3.0.tgz",
-      "integrity": "sha512-YL4tL4rjj+AaOdrkXe9CVexUk44VB3s8c4KzxmMJAj9OSHeYCHNCPDAwrBHplQoXyQ1WPTDJCsB9v8r29nI0eQ=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@qwant/qwant-basic-gl-style/-/qwant-basic-gl-style-1.3.1.tgz",
+      "integrity": "sha512-zIjW9WgOwFOSQmKaCTvDKaGmB8PCwtyU+2PFLBmLdVR4zGWypP6evqtv8jzT0g5MgYFx1sLLKWzP+qhHIccQRA=="
     },
     "@qwant/qwant-maps-common": {
       "version": "file:local_modules/qwant-maps-common",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.8.0",
     "@qwant/map-style-builder": "github:Qwant/map-style-builder#9808391",
-    "@qwant/qwant-basic-gl-style": "^1.1.0",
+    "@qwant/qwant-basic-gl-style": "^1.3.1",
     "@turf/along": "^6.0.1",
     "@turf/bbox": "^6.0.1",
     "@turf/bearing": "^6.0.1",


### PR DESCRIPTION
## Description
bump qwant-basic-gl-style
cf: https://github.com/Qwant/qwant-basic-gl-style/pull/114
