### PR TITLE
Force EOL settings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*  text=auto
+*  text=auto eol=lf


### PR DESCRIPTION
Make sure files are pushed/check-out with LF end-of-line mode, to prevent conversion problems for Windows users.