### PR TITLE
QMAPS-2071 fix floatinf items on the right

### DIFF
--- a/src/components/ui/FloatingItems.jsx
+++ b/src/components/ui/FloatingItems.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 const FloatingItems = ({ items, position }) => (
   <div
     className="floatingItems"
-    style={position === 'left' ? { paddingLeft: 12 } : { paddingRight: 12 }}
+    style={position === 'left' ? { paddingLeft: 12 } : { paddingRight: 12, right: 0 }}
   >
     {items}
   </div>


### PR DESCRIPTION
## Description
right floating items were stuck on the left.
add a "right: 0" css property to them