### PR TITLE
qwant-maps-common: message keys with spaces were missing due to named exports

### DIFF
--- a/local_modules/qwant-maps-common/package.json
+++ b/local_modules/qwant-maps-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwant/qwant-maps-common",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Common utilities for Qwant Maps, Instant Answers, etc.",
   "main": "dist/index.js",
   "files": [

--- a/local_modules/qwant-maps-common/rollup.config.js
+++ b/local_modules/qwant-maps-common/rollup.config.js
@@ -6,7 +6,7 @@ export default {
   input: 'index.js',
   output: {
     dir: 'dist',
-    format: 'cjs'
+    format: 'cjs',
   },
-  plugins: [commonjs(), json(), dynamicImportVars()],
+  plugins: [commonjs(), json({ namedExports: false }), dynamicImportVars()],
 };

--- a/local_modules/qwant-maps-common/src/gettext.js
+++ b/local_modules/qwant-maps-common/src/gettext.js
@@ -1,15 +1,14 @@
-import { options as i18nOptions } from "../i18next-scanner.config.js";
+import { options as i18nOptions } from '../i18next-scanner.config.js';
 
 const supportedLanguages = i18nOptions.lngs;
 const defaultLanguage = i18nOptions.defaultLng;
 const messages = {};
 supportedLanguages.forEach(lang =>
-  import(`../i18n/${lang}/resource.json`)
-    .then(resource => messages[lang] = resource)
+  import(`../i18n/${lang}/resource.json`).then(resource => (messages[lang] = resource.default))
 );
 
 class Gettext {
-  constructor(lang = defaultLanguage){
+  constructor(lang = defaultLanguage) {
     this.lang = lang;
   }
 
@@ -20,8 +19,7 @@ class Gettext {
   setLang(lang) {
     if (supportedLanguages.indexOf(lang) > -1) {
       this.lang = lang;
-    }
-    else {
+    } else {
       this.lang = defaultLanguage;
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -145,7 +145,7 @@
     },
     "local_modules/qwant-maps-common": {
       "name": "@qwant/qwant-maps-common",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^17.1.0",


### PR DESCRIPTION
## Description
Fixes an issue with translations in qwant-maps-common: keys with spaces were not available in the messages built by rollup.

## Why
The `json()` plugin in Rollup [includes named exports by default](https://github.com/rollup/plugins/tree/master/packages/json#namedexports), in addition to the `default` export.
But named exports are only used for valid JS names (i.e strings without spaces).
The correct way is to use the "default" export when loading the module.


