### PR TITLE
Use the preloaded POI (if any) center as initial map position 

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -29,7 +29,16 @@ function Scene() {
   this.savedLocation = null;
 }
 
+const getPoiView = poi => ({
+  center: poi.geometry.center,
+  zoom: getBestZoom(poi),
+  bounds: poi.geometry.bbox,
+});
+
 Scene.prototype.getMapInitOptions = function (locationHash) {
+  if (window.hotLoadPoi) {
+    return getPoiView(window.hotLoadPoi);
+  }
   if (locationHash) {
     return {
       zoom: locationHash.zoom,

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -89,6 +89,8 @@ Scene.prototype.initMapBox = async function (locationHash) {
     locale,
     ...(await this.getMapInitOptions(locationHash)),
   });
+  // @MAPBOX: This method isn't implemented by the Mapbox-GL mock
+  this.mb.setPadding = this.mb.setPadding || (() => {});
   this.mb.setPadding(getCurrentMapPaddings());
 
   this.popup.init(this.mb);

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -3,7 +3,7 @@ import PoiPopup from './poi_popup';
 import MobileCompassControl from '../mapbox/mobile_compass_control';
 import ExtendedControl from '../mapbox/extended_nav_control';
 import { map as mapConfig } from 'config/constants.yml';
-import { getMapPaddings, getMapCenterOffset, isPositionUnderUI } from 'src/panel/layouts';
+import { getCurrentMapPaddings, isPositionUnderUI } from 'src/panel/layouts';
 import nconf from '@qwant/nconf-getter';
 import MapPoi from './poi/map_poi';
 import { getLastLocation, setLastLocation } from 'src/adapters/store';
@@ -47,7 +47,6 @@ Scene.prototype.getMapInitOptions = function (locationHash) {
     return {
       bounds: window.initialBbox,
       fitBoundsOptions: {
-        padding: this.getCurrentPaddings(),
         maxZoom: 9,
       },
     };
@@ -81,6 +80,7 @@ Scene.prototype.initMapBox = async function (locationHash) {
     locale,
     ...(await this.getMapInitOptions(locationHash)),
   });
+  this.mb.setPadding(getCurrentMapPaddings());
 
   this.popup.init(this.mb);
   window.map = this;
@@ -240,7 +240,7 @@ Scene.prototype.initMapBox = async function (locationHash) {
   });
 
   listen('fit_map', (item, forceAnimate) => {
-    this.fitMap(item, this.getCurrentPaddings(), forceAnimate);
+    this.fitMap(item, forceAnimate);
   });
 
   listen('ensure_poi_visible', (poi, options) => {
@@ -278,14 +278,11 @@ Scene.prototype.initMapBox = async function (locationHash) {
   listen('mobile_direction_button_visibility', visible => {
     this.mobileButtonVisibility('.direction_shortcut', visible);
   });
-};
 
-Scene.prototype.getCurrentPaddings = () =>
-  getMapPaddings({
-    isMobile: isMobileDevice(),
-    isDirectionsActive: !!document.querySelector('.directions-open'),
-    isIframe: window.no_ui,
+  listen('update_map_paddings', () => {
+    this.mb.setPadding(getCurrentMapPaddings());
   });
+};
 
 Scene.prototype.clickOnMap = function (lngLat, clickedFeature, { longTouch = false } = {}) {
   // Instantiate the place clicked as a PoI
@@ -345,11 +342,7 @@ Scene.prototype.isBBoxInExtendedViewport = function (bbox) {
   );
 };
 
-Scene.prototype.fitBbox = function (
-  bbox,
-  padding = { left: 0, top: 0, right: 0, bottom: 0 },
-  forceAnimate
-) {
+Scene.prototype.fitBbox = function (bbox, forceAnimate) {
   // normalise bbox
   if (bbox instanceof Array) {
     bbox = new LngLatBounds(bbox);
@@ -358,19 +351,19 @@ Scene.prototype.fitBbox = function (
   // Animate if the zoom is big enough and if the BBox is (partially or fully) in
   // the extended viewport.
   const animate = forceAnimate || (this.mb.getZoom() > 10 && this.isBBoxInExtendedViewport(bbox));
-  this.mb.fitBounds(bbox, { padding, animate });
+  this.mb.fitBounds(bbox, { animate });
 };
 
 // Move the map to focus on an item
-Scene.prototype.fitMap = function (item, padding, forceAnimate) {
+Scene.prototype.fitMap = function (item, forceAnimate) {
   // BBox
   if (item instanceof LngLatBounds || Array.isArray(item)) {
-    this.fitBbox(item, padding, forceAnimate);
+    this.fitBbox(item, forceAnimate);
   } else {
     // PoI
     if (item.bbox) {
       // poi Bbox
-      this.fitBbox(item.bbox, padding, forceAnimate);
+      this.fitBbox(item.bbox, forceAnimate);
     } else {
       // poi center
       const flyOptions = {
@@ -379,13 +372,6 @@ Scene.prototype.fitMap = function (item, padding, forceAnimate) {
         screenSpeed: 1.5,
         animate: false,
       };
-
-      if (padding) {
-        flyOptions.offset = [
-          (padding.left - padding.right) / 2,
-          (padding.top - padding.bottom) / 2,
-        ];
-      }
 
       if (forceAnimate || (this.mb.getZoom() > 10 && this.isWindowedPoi(item))) {
         flyOptions.animate = true;
@@ -397,7 +383,7 @@ Scene.prototype.fitMap = function (item, padding, forceAnimate) {
 
 Scene.prototype.ensureMarkerIsVisible = function (poi, options) {
   if (poi.bbox) {
-    this.fitBbox(poi.bbox, options.padding || this.getCurrentPaddings());
+    this.fitBbox(poi.bbox);
     return;
   }
   const isMobile = isMobileDevice();
@@ -410,7 +396,6 @@ Scene.prototype.ensureMarkerIsVisible = function (poi, options) {
   this.mb.flyTo({
     center: poi.latLon,
     zoom: getBestZoom(poi),
-    offset: getMapCenterOffset({ isMobile, isIframe: window.no_ui }),
     maxDuration: 1200,
   });
 };

--- a/src/panel/RootComponent.jsx
+++ b/src/panel/RootComponent.jsx
@@ -24,6 +24,7 @@ const RootComponent = ({ burgerMenuEnabled, router }) => {
           fire('move_mobile_bottom_ui', 0);
         });
       }
+      fire('update_map_paddings');
     };
 
     mobileDeviceMediaQuery.addListener(deviceChanged);

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -109,7 +109,7 @@ export default class DirectionPanel extends React.Component {
     }
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     const marginTop = this.directionPanelRef.current
       ? this.directionPanelRef.current.offsetHeight + MARGIN_TOP_OFFSET
       : 0;
@@ -125,6 +125,10 @@ export default class DirectionPanel extends React.Component {
       this.updateUrl({ params: { details: null }, replace: true });
       this.setState({ activePreviewRoute: null });
     }
+
+    if (this.state.routes.length !== 0 && prevState.routes.length === 0) {
+      fire('update_map_paddings');
+    }
   }
 
   componentWillUnmount() {
@@ -132,6 +136,7 @@ export default class DirectionPanel extends React.Component {
     unListen(this.dragPointHandler);
     unListen(this.setPointHandler);
     document.body.classList.remove('directions-open');
+    fire('update_map_paddings');
   }
 
   async setTextInput(which, poi) {

--- a/src/panel/layouts.js
+++ b/src/panel/layouts.js
@@ -1,7 +1,7 @@
 import { isMobileDevice } from '../libs/device';
-import { listen } from 'src/libs/customEvents';
 
 const DESKTOP_PANEL_WIDTH = 400;
+const MOBILE_BOTTOM_PADDING = 180;
 const ADDITIONAL_PADDING = 50;
 const DESKTOP_SIDE_PANEL = {
   top: ADDITIONAL_PADDING,
@@ -10,12 +10,7 @@ const DESKTOP_SIDE_PANEL = {
   bottom: 45,
 };
 
-let mobileBottomPanelHeight = 0;
-listen('move_mobile_bottom_ui', height => {
-  mobileBottomPanelHeight = height;
-});
-
-export function getMapPaddings({ isMobile, isDirectionsActive, isIframe }) {
+function computeMapPaddings({ isMobile, isDirectionsActive, isIframe }) {
   // iframe: no paddings
   if (isIframe) {
     return { bottom: 0, top: 0, left: 0, right: 0 };
@@ -26,12 +21,19 @@ export function getMapPaddings({ isMobile, isDirectionsActive, isIframe }) {
   const topUIElement = isDirectionsActive ? '.direction-panel' : '.top_bar';
   const topUIHeight = document.querySelector(topUIElement)?.clientHeight || 0;
   return {
-    bottom: mobileBottomPanelHeight + ADDITIONAL_PADDING / 2,
+    bottom: MOBILE_BOTTOM_PADDING,
     top: topUIHeight + ADDITIONAL_PADDING / 2,
-    right: 70,
+    right: 20,
     left: 20,
   };
 }
+
+export const getCurrentMapPaddings = () =>
+  computeMapPaddings({
+    isMobile: isMobileDevice(),
+    isDirectionsActive: !!document.querySelector('.directions-open'),
+    isIframe: window.no_ui,
+  });
 
 export function getVisibleBbox(mb, isIframe) {
   const bbox = mb.getBounds();
@@ -56,10 +58,6 @@ export function getVisibleBbox(mb, isIframe) {
   bbox.setNorthEast(ne);
   bbox.setSouthWest(sw);
   return bbox;
-}
-
-export function getMapCenterOffset({ isMobile, isIframe }) {
-  return isMobile || isIframe ? [0, 0] : [(DESKTOP_PANEL_WIDTH + ADDITIONAL_PADDING) / 2, 0];
 }
 
 export function isPositionUnderUI({ x, y }, { isMobile }) {


### PR DESCRIPTION
## Description
When a POI has been preloaded on the server side, use its center (or bbox) as initial map view.

The first commit is a refacto of the map padding management, so that it's simpler and consistent across all map view operations. Instead of passing explicit paddings on each `fitBounds`, `jumpTo`, etc. we set global paddings on the map and let MapBox-GL do its stuff.
Here, it guarantees the view from the initial center/zoom will be the same as when the POIPanel centers on the POI. 

## Why
When arriving on Maps with a single POI in the url (typically when coming from Qwant Search), prevent the "jump" from the initial map position to the POI center (happening because we center the map when the POI data is loaded asynchronously by the front).
As the POI is already preloaded on the server side, we can use its position as soon as the map loads, so there is no map change when the POI Panel re-fetch the data.
It shows we could probably avoid this fetch completely in this case, but let's focus on fixing the visual problem here.