### PR TITLE
Fix display of public transport roadmap line

### DIFF
--- a/src/libs/colors.js
+++ b/src/libs/colors.js
@@ -1,6 +1,7 @@
-// Compute a light rgba background color based on an icon's rgb color
-// Color is in #rrggbb format, background is #rrggbbaa where alpha is equal to '28' (0.157)
-export const getLightBackground = color => color + '28';
+import Color from 'color';
+
+// Compute a light, non-transparent background color based on an icon's color
+export const getLightBackground = color => Color(color).mix(Color('white'), 0.85).hex();
 
 export const ACTION_BLUE_BASE = '#1a6aff';
 export const ACTION_BLUE_DARK = '#1050c5';

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -138,6 +138,7 @@
   display: flex;
   justify-content: center;
   width: 60px;
+  z-index: 1;
 }
 
 .itinerary_roadmap {


### PR DESCRIPTION
## Description
Part of the problem was we generate light variant colors as transparent colors. So I changed that, and then simply changing the `z-index` of the icons hides the problematic dotted line part.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran de 2021-04-02 16-57-10](https://user-images.githubusercontent.com/243653/113427347-24d22100-93d5-11eb-8c2b-dc5d75dcbf9a.png)|![Capture d’écran de 2021-04-02 16-56-17](https://user-images.githubusercontent.com/243653/113427352-2865a800-93d5-11eb-8d9f-9dd7a4ed99ff.png)|
