### PR TITLE
Introduce a React hook for easy access to config

### DIFF
--- a/src/components/PoiPopup.jsx
+++ b/src/components/PoiPopup.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 import ReviewScore from 'src/components/ReviewScore';
 import OpeningHour from 'src/components/OpeningHour';
 import OsmSchedule from 'src/adapters/osm_schedule';
-import nconf from '@qwant/nconf-getter';
 import PoiTitle from 'src/components/PoiTitle';
 import Address from 'src/components/ui/Address';
-
-const covid19Enabled = (nconf.get().covid19 || {}).enabled;
+import { useConfig } from 'src/hooks';
 
 const PoiPopup = ({ poi }) => {
+  const { enabled: covid19Enabled } = useConfig('covid19');
+
   const reviews = poi.blocksByType && poi.blocksByType.grades;
   const openingHours = poi.blocksByType && poi.blocksByType.opening_hours;
 

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,0 +1,1 @@
+export { useConfig } from './useConfig';

--- a/src/hooks/useConfig.js
+++ b/src/hooks/useConfig.js
@@ -1,0 +1,10 @@
+import nconf from '@qwant/nconf-getter';
+
+const config = nconf.get();
+
+export const useConfig = subSet => {
+  if (subSet) {
+    return config[subSet] || {};
+  }
+  return config;
+};

--- a/src/panel/Menu.jsx
+++ b/src/panel/Menu.jsx
@@ -8,14 +8,13 @@ import Telemetry from 'src/libs/telemetry';
 import { Flex, CloseButton } from 'src/components/ui';
 import { IconMenu, IconApps } from 'src/components/ui/icons';
 import { DeviceContext } from 'src/libs/device';
-import nconf from '@qwant/nconf-getter';
-
-const displayProducts = nconf.get().burgerMenu?.products;
+import { useConfig } from 'src/hooks';
 
 const Menu = () => {
   const [openedMenu, setOpenedMenu] = useState(null);
   const menuContainer = useRef(document.createElement('div'));
   const isMobile = useContext(DeviceContext);
+  const displayProducts = useConfig('burgerMenu');
 
   useEffect(() => {
     const current = menuContainer.current;

--- a/src/panel/Menu.jsx
+++ b/src/panel/Menu.jsx
@@ -14,7 +14,7 @@ const Menu = () => {
   const [openedMenu, setOpenedMenu] = useState(null);
   const menuContainer = useRef(document.createElement('div'));
   const isMobile = useContext(DeviceContext);
-  const displayProducts = useConfig('burgerMenu');
+  const displayProducts = useConfig('burgerMenu').products;
 
   useEffect(() => {
     const current = menuContainer.current;

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -98,7 +98,7 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
     return () => {
       unListen(mapMoveHandler);
     };
-  }, [poiFilters, initialLoading]);
+  }, [poiFilters, initialLoading, maxPlaces]);
 
   useEffect(() => {
     window.execOnMapLoaded(() => {

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -8,7 +8,7 @@ import PoiItemList from './PoiItemList';
 import PoiItemListPlaceholder from './PoiItemListPlaceholder';
 import CategoryPanelError from './CategoryPanelError';
 import Telemetry from 'src/libs/telemetry';
-import nconf from '@qwant/nconf-getter';
+import { useConfig } from 'src/hooks';
 import IdunnPoi from 'src/adapters/poi/idunn_poi';
 import { getVisibleBbox } from 'src/panel/layouts';
 import { fire, listen, unListen } from 'src/libs/customEvents';
@@ -20,8 +20,6 @@ import { BackToQwantButton } from 'src/components/BackToQwantButton';
 import { shouldShowBackToQwant } from 'src/libs/url_utils';
 import { PanelNav, SourceFooter } from 'src/components/ui';
 
-const categoryConfig = nconf.get().category;
-const MAX_PLACES = Number(categoryConfig.maxPlaces);
 const DEBOUNCE_WAIT = 100;
 
 function fitMap(bbox) {
@@ -62,6 +60,7 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
   const [dataSource, setDataSource] = useState('');
   const [initialLoading, setInitialLoading] = useState(true);
   const isMobile = useContext(DeviceContext);
+  const { maxPlaces } = useConfig('category');
 
   useEffect(() => {
     const fetchData = debounce(
@@ -72,7 +71,7 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
         const extendBbox = initialLoading;
         const { places, source, bbox: contentBbox, bbox_extended } = await IdunnPoi.poiCategoryLoad(
           boundsToString(currentBounds),
-          MAX_PLACES,
+          maxPlaces,
           category,
           query,
           extendBbox

--- a/src/panel/menu/AppMenu.jsx
+++ b/src/panel/menu/AppMenu.jsx
@@ -6,11 +6,11 @@ import Telemetry from 'src/libs/telemetry';
 import { Divider } from 'src/components/ui';
 import { Heart, IconLightbulb, IconEdit, IconApps } from 'src/components/ui/icons';
 import { PINK_DARK, ACTION_BLUE_BASE } from 'src/libs/colors';
-import nconf from '@qwant/nconf-getter';
-
-const { baseUrl } = nconf.get().system;
+import { useConfig } from 'src/hooks';
 
 const AppMenu = ({ close, openProducts }) => {
+  const { baseUrl } = useConfig('system');
+
   const navTo = (url, options) => {
     close();
     window.app.navigateTo(url, options);

--- a/src/panel/poi/blocks/Covid19.jsx
+++ b/src/panel/poi/blocks/Covid19.jsx
@@ -1,13 +1,10 @@
 /* globals _ */
 import React, { Fragment } from 'react';
-import nconf from '@qwant/nconf-getter';
-
+import { useConfig } from 'src/hooks';
 import TimeTable from './TimeTable';
 import OsmSchedule from 'src/adapters/osm_schedule';
 import Telemetry from 'src/libs/telemetry';
 import Button from 'src/components/ui/Button';
-
-const covidConf = nconf.get().covid19;
 
 const getContent = ({ status, opening_hours, note, contribute_url }) => {
   const additionalInfo = note && (
@@ -85,19 +82,21 @@ const getContent = ({ status, opening_hours, note, contribute_url }) => {
 };
 
 /* eslint-disable */
-const LocalizedWarning = ({ countryCode }) => (
-  <div>
+const LocalizedWarning = ({ countryCode }) => {
+  const { frInformationUrl } = useConfig('covid19');
+
+  return <div>
     <p>{_('Please comply with government travel restrictions.', 'covid19')}</p>
     {countryCode === 'FR' && (
       <p>
         {_('More information at', 'covid19')}{' '}
-        <a rel="noopener noreferrer" href={covidConf.frInformationUrl}>
+        <a rel="noopener noreferrer" href={frInformationUrl}>
           gouvernement.fr/info-coronavirus
         </a>
       </p>
     )}
   </div>
-);
+};
 
 const LegalWarning = ({ countryCode }) => (
   <div className="covid19-legalWarning">

--- a/src/panel/service/ServicePanelMobile.jsx
+++ b/src/panel/service/ServicePanelMobile.jsx
@@ -3,12 +3,12 @@ import React, { Fragment } from 'react';
 import Panel from 'src/components/ui/Panel';
 import CategoryList from 'src/components/CategoryList';
 import Action from 'src/components/ui/MainActionButton';
-import nconf from '@qwant/nconf-getter';
+import { useConfig } from 'src/hooks';
 import Telemetry from 'src/libs/telemetry';
 
-const directionConf = nconf.get().direction;
-
 const ServicePanelMobile = () => {
+  const directionConf = useConfig('direction');
+
   return (
     <Panel
       resizable


### PR DESCRIPTION
## Description
Add a `useConfig` hook for easy and more natural access to the config from React components, without having to use `nconf-getter` each time.

As it's the most common case to access only a subset of the config, `useConfig` accepts an optional argument to return only the designated part.

In the future, other hooks can be added to the `/hooks` folder and index file.
