### PR TITLE
Use Node v12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
-        node-version: "10.x"
+        node-version: '12'
 
     - name: Build
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-stretch-slim as base
+FROM node:12-stretch-slim as base
 
 ENV PROJECT_DIR=/srv/maps-tileview/
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can define your environment variables within a `.env` file, at the root dire
 You will need
 
 - npm 7
-- Node.js 10
+- Node.js 12
 
 Then you can build and run Erdapfel with the following commands:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,10 @@
         "webpack-cli": "^3.3.12",
         "yaml-jest": "^1.0.5",
         "yaml-loader": "^0.5.0"
+      },
+      "engines": {
+        "node": "^12",
+        "npm": ">=7"
       }
     },
     "local_modules/config-sanitizer-loader": {

--- a/package.json
+++ b/package.json
@@ -125,5 +125,9 @@
       "eslint --fix",
       "git add"
     ]
+  },
+  "engines": {
+    "node": "^12",
+    "npm": ">=7"
   }
 }


### PR DESCRIPTION
## Description
Update the base Docker image to Node v12.
Also add `engines` npm hints matching the current versions needed to build and run Erdapfel.

## Why
Node 10 is reaching its end of life at the end of the month.

We are not migrating directly to Node v14 yet because `chokidar@2`, a depencendy of Webpack 4, may break on it (https://github.com/webpack/watchpack/issues/137).
We'll address that separately.