### PR TITLE
 Define `useDevice` hook for easy access to device context

### DIFF
--- a/src/components/ui/Panel.jsx
+++ b/src/components/ui/Panel.jsx
@@ -301,7 +301,7 @@ class Panel extends React.Component {
 
     return (
       <DeviceContext.Consumer>
-        {isMobile => (
+        {({ isMobile }) => (
           <div
             className={classnames('panel', size, className, {
               'panel--holding': holding,

--- a/src/components/ui/SourceFooter.jsx
+++ b/src/components/ui/SourceFooter.jsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useRef, useContext } from 'react';
 import ReactDOM from 'react-dom';
-import { DeviceContext } from 'src/libs/device';
+import { useDevice } from 'src/hooks';
 import { PanelContext } from 'src/libs/panelContext';
 
 const SourceFooter = ({ children }) => {
   const portalContainer = useRef(document.createElement('div'));
-  const { isMobile } = useContext(DeviceContext);
+  const { isMobile } = useDevice();
   const { size: panelSize } = useContext(PanelContext);
 
   useEffect(() => {

--- a/src/components/ui/SourceFooter.jsx
+++ b/src/components/ui/SourceFooter.jsx
@@ -5,7 +5,7 @@ import { PanelContext } from 'src/libs/panelContext';
 
 const SourceFooter = ({ children }) => {
   const portalContainer = useRef(document.createElement('div'));
-  const isMobile = useContext(DeviceContext);
+  const { isMobile } = useContext(DeviceContext);
   const { size: panelSize } = useContext(PanelContext);
 
   useEffect(() => {

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import debounce from 'lodash.debounce';
 import { bool, string, func, object } from 'prop-types';
 
 import SuggestsDropdown from 'src/components/ui/SuggestsDropdown';
 import { fetchSuggests, getInputValue, selectItem, modifyList } from 'src/libs/suggest';
-import { DeviceContext } from 'src/libs/device';
+import { useDevice } from 'src/hooks';
 
 const SUGGEST_DEBOUNCE_WAIT = 100;
 
@@ -25,7 +25,7 @@ const Suggest = ({
   const [isOpen, setIsOpen] = useState(false);
   const [lastQuery, setLastQuery] = useState('');
   const [isLoading, setIsLoading] = useState(true);
-  const { isMobile } = useContext(DeviceContext);
+  const { isMobile } = useDevice();
 
   const close = () => {
     setIsOpen(false);

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -25,7 +25,7 @@ const Suggest = ({
   const [isOpen, setIsOpen] = useState(false);
   const [lastQuery, setLastQuery] = useState('');
   const [isLoading, setIsLoading] = useState(true);
-  const isMobile = useContext(DeviceContext);
+  const { isMobile } = useContext(DeviceContext);
 
   const close = () => {
     setIsOpen(false);

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,1 +1,2 @@
 export { useConfig } from './useConfig';
+export { useDevice } from './useDevice';

--- a/src/hooks/useDevice.js
+++ b/src/hooks/useDevice.js
@@ -1,0 +1,4 @@
+import { useContext } from 'react';
+import { DeviceContext } from 'src/libs/device';
+
+export const useDevice = () => useContext(DeviceContext);

--- a/src/libs/device.js
+++ b/src/libs/device.js
@@ -6,4 +6,4 @@ export function isMobileDevice() {
   return mobileDeviceMediaQuery.matches;
 }
 
-export const DeviceContext = React.createContext(isMobileDevice());
+export const DeviceContext = React.createContext({ isMobile: isMobileDevice() });

--- a/src/panel/Menu.jsx
+++ b/src/panel/Menu.jsx
@@ -1,5 +1,5 @@
 /* globals _ */
-import React, { Fragment, useEffect, useState, useRef, useContext } from 'react';
+import React, { Fragment, useEffect, useState, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import cx from 'classnames';
 import AppMenu from './menu/AppMenu';
@@ -7,13 +7,12 @@ import ProductsDrawer from './menu/ProductsDrawer';
 import Telemetry from 'src/libs/telemetry';
 import { Flex, CloseButton } from 'src/components/ui';
 import { IconMenu, IconApps } from 'src/components/ui/icons';
-import { DeviceContext } from 'src/libs/device';
-import { useConfig } from 'src/hooks';
+import { useConfig, useDevice } from 'src/hooks';
 
 const Menu = () => {
   const [openedMenu, setOpenedMenu] = useState(null);
   const menuContainer = useRef(document.createElement('div'));
-  const { isMobile } = useContext(DeviceContext);
+  const { isMobile } = useDevice();
   const displayProducts = useConfig('burgerMenu').products;
 
   useEffect(() => {

--- a/src/panel/Menu.jsx
+++ b/src/panel/Menu.jsx
@@ -13,7 +13,7 @@ import { useConfig } from 'src/hooks';
 const Menu = () => {
   const [openedMenu, setOpenedMenu] = useState(null);
   const menuContainer = useRef(document.createElement('div'));
-  const isMobile = useContext(DeviceContext);
+  const { isMobile } = useContext(DeviceContext);
   const displayProducts = useConfig('burgerMenu').products;
 
   useEffect(() => {

--- a/src/panel/RootComponent.jsx
+++ b/src/panel/RootComponent.jsx
@@ -34,7 +34,7 @@ const RootComponent = ({ burgerMenuEnabled, router }) => {
   });
 
   return (
-    <DeviceContext.Provider value={isMobile}>
+    <DeviceContext.Provider value={{ isMobile }}>
       <PanelManager
         router={router}
         searchBarInputNode={document.getElementById('search')}

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -59,7 +59,7 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
   const [pois, setPois] = useState([]);
   const [dataSource, setDataSource] = useState('');
   const [initialLoading, setInitialLoading] = useState(true);
-  const isMobile = useContext(DeviceContext);
+  const { isMobile } = useContext(DeviceContext);
   const { maxPlaces } = useConfig('category');
 
   useEffect(() => {

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -1,5 +1,5 @@
 /* global _ */
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Panel from 'src/components/ui/Panel';
 import debounce from 'lodash.debounce';
@@ -8,14 +8,13 @@ import PoiItemList from './PoiItemList';
 import PoiItemListPlaceholder from './PoiItemListPlaceholder';
 import CategoryPanelError from './CategoryPanelError';
 import Telemetry from 'src/libs/telemetry';
-import { useConfig } from 'src/hooks';
+import { useConfig, useDevice } from 'src/hooks';
 import IdunnPoi from 'src/adapters/poi/idunn_poi';
 import { getVisibleBbox } from 'src/panel/layouts';
 import { fire, listen, unListen } from 'src/libs/customEvents';
 import { boundsFromFlatArray, parseBboxString, boundsToString } from 'src/libs/bounds';
 import classnames from 'classnames';
 import { sources } from 'config/constants.yml';
-import { DeviceContext } from 'src/libs/device';
 import { BackToQwantButton } from 'src/components/BackToQwantButton';
 import { shouldShowBackToQwant } from 'src/libs/url_utils';
 import { PanelNav, SourceFooter } from 'src/components/ui';
@@ -59,7 +58,7 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
   const [pois, setPois] = useState([]);
   const [dataSource, setDataSource] = useState('');
   const [initialLoading, setInitialLoading] = useState(true);
-  const { isMobile } = useContext(DeviceContext);
+  const { isMobile } = useDevice();
   const { maxPlaces } = useConfig('category');
 
   useEffect(() => {

--- a/src/panel/category/PoiItemList.jsx
+++ b/src/panel/category/PoiItemList.jsx
@@ -1,10 +1,10 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { ItemList, Item } from 'src/components/ui/ItemList';
 import PoiItem from 'src/components/PoiItem';
-import { DeviceContext } from 'src/libs/device';
+import { useDevice } from 'src/hooks';
 
 const PoiItems = ({ pois, selectPoi, highlightMarker }) => {
-  const { isMobile } = useContext(DeviceContext);
+  const { isMobile } = useDevice();
 
   return (
     <ItemList hover className="category__panel__items">

--- a/src/panel/category/PoiItemList.jsx
+++ b/src/panel/category/PoiItemList.jsx
@@ -4,7 +4,7 @@ import PoiItem from 'src/components/PoiItem';
 import { DeviceContext } from 'src/libs/device';
 
 const PoiItems = ({ pois, selectPoi, highlightMarker }) => {
-  const isMobile = useContext(DeviceContext);
+  const { isMobile } = useContext(DeviceContext);
 
   return (
     <ItemList hover className="category__panel__items">

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -411,7 +411,7 @@ export default class DirectionPanel extends React.Component {
 
     return (
       <DeviceContext.Consumer>
-        {isMobile =>
+        {({ isMobile }) =>
           isMobile ? (
             <Fragment>
               {!activePreviewRoute && (

--- a/src/panel/direction/Route.jsx
+++ b/src/panel/direction/Route.jsx
@@ -1,7 +1,7 @@
-import React, { useContext, Fragment } from 'react';
+import React, { Fragment } from 'react';
 import RouteSummary from './RouteSummary';
 import RoadMap from './RoadMap';
-import { DeviceContext } from 'src/libs/device';
+import { useDevice } from 'src/hooks';
 
 const Route = ({
   id,
@@ -14,7 +14,7 @@ const Route = ({
   toggleDetails,
   selectRoute,
 }) => {
-  const { isMobile } = useContext(DeviceContext);
+  const { isMobile } = useDevice();
 
   return (
     <Fragment>

--- a/src/panel/direction/Route.jsx
+++ b/src/panel/direction/Route.jsx
@@ -14,7 +14,7 @@ const Route = ({
   toggleDetails,
   selectRoute,
 }) => {
-  const isMobile = useContext(DeviceContext);
+  const { isMobile } = useContext(DeviceContext);
 
   return (
     <Fragment>

--- a/src/panel/direction/RoutesList.jsx
+++ b/src/panel/direction/RoutesList.jsx
@@ -1,6 +1,5 @@
-import React, { useContext } from 'react';
-
-import { DeviceContext } from 'src/libs/device';
+import React from 'react';
+import { useDevice } from 'src/hooks';
 import { Item, ItemList } from 'src/components/ui/ItemList';
 import PlaceholderText from 'src/components/ui/PlaceholderText';
 import Route from './Route';
@@ -16,7 +15,7 @@ const RoutesList = ({
   selectRoute,
   isLoading,
 }) => {
-  const { isMobile } = useContext(DeviceContext);
+  const { isMobile } = useDevice();
   const orderedRoutes = isMobile ? moveRouteToTop(routes, activeRouteId) : routes;
 
   return isLoading ? (

--- a/src/panel/direction/RoutesList.jsx
+++ b/src/panel/direction/RoutesList.jsx
@@ -16,7 +16,7 @@ const RoutesList = ({
   selectRoute,
   isLoading,
 }) => {
-  const isMobile = useContext(DeviceContext);
+  const { isMobile } = useContext(DeviceContext);
   const orderedRoutes = isMobile ? moveRouteToTop(routes, activeRouteId) : routes;
 
   return isLoading ? (

--- a/src/panel/menu/ProductCard.jsx
+++ b/src/panel/menu/ProductCard.jsx
@@ -5,7 +5,7 @@ import { IconAndroid, IconApple } from 'src/components/ui/icons';
 import { GREY_SEMI_DARKNESS } from 'src/libs/colors';
 
 const ProductCard = ({ logo, title, desc, link, href, mobileApps }) => {
-  const isMobile = useContext(DeviceContext);
+  const { isMobile } = useContext(DeviceContext);
 
   return (
     <div className="card-wrapper">

--- a/src/panel/menu/ProductCard.jsx
+++ b/src/panel/menu/ProductCard.jsx
@@ -1,11 +1,11 @@
-import React, { useContext } from 'react';
-import { DeviceContext } from 'src/libs/device';
+import React from 'react';
+import { useDevice } from 'src/hooks';
 import { Button } from 'src/components/ui';
 import { IconAndroid, IconApple } from 'src/components/ui/icons';
 import { GREY_SEMI_DARKNESS } from 'src/libs/colors';
 
 const ProductCard = ({ logo, title, desc, link, href, mobileApps }) => {
-  const { isMobile } = useContext(DeviceContext);
+  const { isMobile } = useDevice();
 
   return (
     <div className="card-wrapper">

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -253,7 +253,7 @@ export default class PoiPanel extends React.Component {
 
     return (
       <DeviceContext.Consumer>
-        {isMobile => (
+        {({ isMobile }) => (
           <Panel
             resizable
             fitContent={['default', 'minimized']}

--- a/src/panel/service/ServicePanel.jsx
+++ b/src/panel/service/ServicePanel.jsx
@@ -1,10 +1,10 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import ServicePanelDesktop from './ServicePanelDesktop';
 import ServicePanelMobile from './ServicePanelMobile';
-import { DeviceContext } from 'src/libs/device';
+import { useDevice } from 'src/hooks';
 
 const ServicePanel = () => {
-  const { isMobile } = useContext(DeviceContext);
+  const { isMobile } = useDevice();
   return isMobile ? <ServicePanelMobile /> : <ServicePanelDesktop />;
 };
 

--- a/src/panel/service/ServicePanel.jsx
+++ b/src/panel/service/ServicePanel.jsx
@@ -4,7 +4,7 @@ import ServicePanelMobile from './ServicePanelMobile';
 import { DeviceContext } from 'src/libs/device';
 
 const ServicePanel = () => {
-  const isMobile = useContext(DeviceContext);
+  const { isMobile } = useContext(DeviceContext);
   return isMobile ? <ServicePanelMobile /> : <ServicePanelDesktop />;
 };
 


### PR DESCRIPTION
## Description
- modify the device context so that it's an object, not a single boolean `isMobile`, so it's possible to attach other fields to it
- define a new `useDevice` hook to abstract the access to the `DeviceContext`

### Before
```jsx
import React, { useContext } from 'react';
import { DeviceContext } from 'src/libs/device';

const Plop = () => {
  const isMobile = useContext(DeviceContext);
  return <>…</>
}
```

### After
```jsx
import React from 'react';
import { useDevice } from 'src/hooks';

const Plop = () => {
  const { isMobile } = useDevice();
  return <>…</>
}
```
 
## Why
Being able to store more info in context + simplicity + similar pattern in Phoenix