### PR TITLE
QMAPS-2105 Use 'bbox' url param as initial map position

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -14,6 +14,7 @@ import { createDefaultPin } from '../adapters/icon_manager';
 import LatLonPoi from './poi/latlon_poi';
 import { isMobileDevice } from 'src/libs/device';
 import { parseMapHash, getMapHash } from 'src/libs/url_utils';
+import { parseBboxString } from 'src/libs/bounds';
 import { toUrl, getBestZoom } from 'src/libs/pois';
 import Error from 'src/adapters/error';
 import { fire, listen } from 'src/libs/customEvents';
@@ -35,7 +36,10 @@ const getPoiView = poi => ({
   bounds: poi.geometry.bbox,
 });
 
-Scene.prototype.getMapInitOptions = function (locationHash) {
+Scene.prototype.getMapInitOptions = function ({ locationHash, bbox }) {
+  if (bbox) {
+    return { bounds: parseBboxString(bbox) };
+  }
   if (window.hotLoadPoi) {
     return getPoiView(window.hotLoadPoi);
   }
@@ -66,7 +70,7 @@ Scene.prototype.getMapInitOptions = function (locationHash) {
   };
 };
 
-Scene.prototype.initMapBox = async function (locationHash) {
+Scene.prototype.initMapBox = async function ({ locationHash, bbox }) {
   window.times.initMapBox = Date.now();
 
   setRTLTextPlugin(
@@ -87,7 +91,7 @@ Scene.prototype.initMapBox = async function (locationHash) {
     maxZoom: 20,
     interactive: window.no_ui ? false : true,
     locale,
-    ...(await this.getMapInitOptions(locationHash)),
+    ...(await this.getMapInitOptions({ locationHash, bbox })),
   });
   // @MAPBOX: This method isn't implemented by the Mapbox-GL mock
   this.mb.setPadding = this.mb.setPadding || (() => {});

--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -38,7 +38,11 @@ const getPoiView = poi => ({
 
 Scene.prototype.getMapInitOptions = function ({ locationHash, bbox }) {
   if (bbox) {
-    return { bounds: parseBboxString(bbox) };
+    try {
+      return { bounds: parseBboxString(bbox) };
+    } catch (e) {
+      console.error(e);
+    }
   }
   if (window.hotLoadPoi) {
     return getPoiView(window.hotLoadPoi);

--- a/src/libs/bounds.js
+++ b/src/libs/bounds.js
@@ -1,7 +1,12 @@
-export const boundsFromFlatArray = coords => [
-  [coords[0], coords[1]],
-  [coords[2], coords[3]],
-];
+export const boundsFromFlatArray = (coords = []) => {
+  if (coords.length < 4 || coords.some(coord => typeof coord !== 'number')) {
+    throw new Error(`Malformed bounds array: ${JSON.stringify(coords)}`);
+  }
+  return [
+    [coords[0], coords[1]],
+    [coords[2], coords[3]],
+  ];
+};
 
 export const parseBboxString = bboxString =>
   boundsFromFlatArray(bboxString.split(',').map(coord => Number(coord)));

--- a/src/libs/bounds.js
+++ b/src/libs/bounds.js
@@ -1,5 +1,5 @@
 export const boundsFromFlatArray = (coords = []) => {
-  if (coords.length < 4 || coords.some(coord => typeof coord !== 'number')) {
+  if (coords.length !== 4 || coords.some(coord => typeof coord !== 'number' || isNaN(coord))) {
     throw new Error(`Malformed bounds array: ${JSON.stringify(coords)}`);
   }
   return [

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import SearchInput from '../ui_components/search_input';
 import nconf from '@qwant/nconf-getter';
 import Router from 'src/proxies/app_router';
-import { parseMapHash, joinPath, getCurrentUrl } from 'src/libs/url_utils';
+import { parseMapHash, joinPath, getCurrentUrl, parseQueryString } from 'src/libs/url_utils';
 import { listen } from 'src/libs/customEvents';
 import RootComponent from './RootComponent';
 import Telemetry from 'src/libs/telemetry';
@@ -49,9 +49,13 @@ export default class App {
 
   initMap() {
     const mapHash = parseMapHash(window.location.hash);
+    const { bbox } = parseQueryString(window.location.search);
     import(/* webpackChunkName: "map" */ '../adapters/scene').then(({ default: Scene }) => {
       const scene = new Scene();
-      scene.initMapBox(mapHash);
+      scene.initMapBox({
+        locationHash: mapHash,
+        bbox,
+      });
     });
   }
 

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -23,8 +23,12 @@ const DEBOUNCE_WAIT = 100;
 
 function fitMap(bbox) {
   if (bbox) {
-    fire('fit_map', parseBboxString(bbox));
-    return;
+    try {
+      fire('fit_map', parseBboxString(bbox));
+      return;
+    } catch (e) {
+      console.error(e);
+    }
   }
 
   const mapboxMap = window.map.mb;

--- a/tests/units/bounds.js
+++ b/tests/units/bounds.js
@@ -1,0 +1,52 @@
+import { boundsFromFlatArray, parseBboxString } from '../../src/libs/bounds';
+
+describe('Bounds utils', () => {
+  describe('boundsFromFlatArray', () => {
+    test('throws when the array is not 4-items long', () => {
+      expect(() => {
+        boundsFromFlatArray([1, 2, 3]);
+      }).toThrow(/Malformed/);
+      expect(() => {
+        boundsFromFlatArray([1, 2, 3, 4, 5]);
+      }).toThrow(/Malformed/);
+    });
+
+    test('throws when the array contains non-numbers', () => {
+      expect(() => {
+        boundsFromFlatArray([1, 2, 'foo', 3]);
+      }).toThrow(/Malformed/);
+      expect(() => {
+        boundsFromFlatArray([1, NaN, 3, 4]);
+      }).toThrow(/Malformed/);
+    });
+
+    test('returns a suitable LngLatBoundsLike object', () => {
+      expect(boundsFromFlatArray([1, 2, 3, 4])).toEqual([
+        [1, 2],
+        [3, 4],
+      ]);
+    });
+  });
+
+  describe('parseBboxString', () => {
+    test('throws on malformed strings', () => {
+      const cases = ['foobar', '1.0,2.0,3.0', '1,2,3,4,5', 'string,2,3,4'];
+      cases.map(testCase => {
+        expect(() => {
+          parseBboxString(testCase);
+        }).toThrow();
+      });
+    });
+
+    test('returns a suitable LngLatBoundsLike for correct strings', () => {
+      expect(parseBboxString('1,2,3,4')).toEqual([
+        [1, 2],
+        [3, 4],
+      ]);
+      expect(parseBboxString('2.35 , 48.85, 2.75, 49')).toEqual([
+        [2.35, 48.85],
+        [2.75, 49],
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Description
Use the `bbox` url param that can be specified by some `/places` requests arriving on Maps (for example those coming from the "Multi" instant answer) as the initial view param.

*I've not been able to prevent a remaining little jump on start, which seems to be from the bbox with no padding, to one taking into account the paddings set by `setPadding` after the map is created.
Unfortunately there is no `padding` option for the [Map instance creation](https://docs.mapbox.com/mapbox-gl-js/api/map/), and using the same paddings in the optional `fitBoundsOptions` results in an even bigger shift.*

## Why
Prevents the map initializing on a different start position before "jumping" to the bbox when the data matching the query is asynchronously fetched by the `CategoryPanel`.