### PR TITLE
[Clean-up] Split hotload poi fetch and OpenGraph meta

### DIFF
--- a/bin/app.js
+++ b/bin/app.js
@@ -112,10 +112,11 @@ function App(config) {
     res.render('unsupported', { config });
   });
 
-  const ogMeta = new require('./middlewares/og_meta')(config);
   const redirectUnsupported = new require('./middlewares/unsupported_browser')(config);
+  const preFetchPoi = new require('./middlewares/prefetch_poi')(config);
+  const ogMeta = new require('./middlewares/og_meta')(config);
 
-  router.get('/*', redirectUnsupported, ogMeta, (req, res) => {
+  router.get('/*', redirectUnsupported, preFetchPoi, ogMeta, (req, res) => {
     const userAgent = req.headers['user-agent'];
     const disableMenuRule = config.server.disableBurgerMenu.userAgentRule;
     let appConfig = config;

--- a/bin/middlewares/og_meta.js
+++ b/bin/middlewares/og_meta.js
@@ -1,95 +1,40 @@
-const axios = require('axios');
-
 module.exports = function (config) {
-  // Use url from server config if defined
-  const idunnBaseUrl = config.server.services.idunn.url || config.services.idunn.url;
-  const idunnTimeout = Number(config.server.services.idunn.timeout);
-  if (isNaN(idunnTimeout)) {
-    throw new Error(
-      `Invalid config: idunn timeout is set to "${config.server.services.idunn.timeout}"`
-    );
-  }
+  function openGraphMetas(req, res) {
+    const ogMetas = [
+      { name: 'type', content: 'website' },
+      { name: 'site_name', content: 'Qwant Maps' },
+      {
+        name: 'image',
+        content: `https://${req.get('host')}${
+          config.system.baseUrl
+        }statics/images/qwant_logo_og.png`,
+      },
+      { name: 'locale', content: res.locals.language.locale },
+      {
+        name: 'description',
+        content: res.locals._('The map that respects your privacy'),
+      },
+    ];
 
-  async function getPoi(poiId, locale) {
-    let id = poiId;
-    const atPos = poiId.indexOf('@');
-    if (atPos !== -1) {
-      id = poiId.slice(0, atPos);
+    // POI will exist if the preFetch middleware has fetched one
+    const poi = res.locals.poi;
+    if (poi) {
+      ogMetas.push({ name: 'title', content: poi.name });
+      ogMetas.push({ name: 'url', content: getUrl(req, poi) });
+    } else {
+      ogMetas.push({ name: 'title', content: 'Qwant Maps' });
+      ogMetas.push({ name: 'url', content: getUrl(req) });
     }
-
-    try {
-      const response = await axios.get(`${idunnBaseUrl}/v1/places/${id}?lang=${locale.code}`, {
-        timeout: idunnTimeout,
-      });
-      return response.data;
-    } catch (error) {
-      if (error.response && error.response.status === 404) {
-        return null;
-      }
-      throw error;
-    }
-  }
-
-  function commonMeta(locale, req, res) {
-    res.locals.ogMetas = [];
-    res.locals.ogMetas.push({ name: 'type', content: 'website' });
-    res.locals.ogMetas.push({ name: 'site_name', content: 'Qwant Maps' });
-    res.locals.ogMetas.push({
-      name: 'image',
-      content: `https://${req.get('host')}${config.system.baseUrl}statics/images/qwant_logo_og.png`,
-    });
-    res.locals.ogMetas.push({ name: 'locale', content: locale.locale });
-    res.locals.ogMetas.push({
-      name: 'description',
-      content: res.locals._('The map that respects your privacy'),
-    });
-  }
-
-  function poiMeta(poi, locale, req, res, next) {
-    commonMeta(locale, req, res);
-    res.locals.poi = poi;
-    res.locals.ogMetas.push({ name: 'title', content: poi.name });
-    res.locals.ogMetas.push({ name: 'url', content: getUrl(req, poi) });
-    next();
-  }
-
-  function homeMeta(locale, req, res, next) {
-    commonMeta(locale, req, res);
-    res.locals.ogMetas.push({ name: 'title', content: 'Qwant Maps' });
-    res.locals.ogMetas.push({ name: 'url', content: getUrl(req) });
-    next();
+    res.locals.ogMetas = ogMetas;
   }
 
   function getUrl(req, poi) {
-    let poiPath = '';
-    if (poi) {
-      poiPath = `place/${poi.id}`;
-    }
+    const poiPath = poi ? `place/${poi.id}` : '';
     return `https://${req.get('host')}${config.system.baseUrl}${poiPath}`;
   }
 
   return function (req, res, next) {
-    const placeUrlMatch = req.originalUrl.split('?')[0].match(/place\/(.*)/);
-    const locale = res.locals.language;
-    let poiId;
-    if (placeUrlMatch && placeUrlMatch.length > 0) {
-      poiId = placeUrlMatch[1];
-    }
-    if (poiId) {
-      getPoi(poiId, locale)
-        .then(poi => {
-          if (poi) {
-            poiMeta(poi, locale, req, res, next);
-          } else {
-            res.redirect(307, config.system.baseUrl);
-          }
-        })
-        .catch(error => {
-          req.logger.error({ err: error });
-          homeMeta(locale, req, res, next);
-        });
-    } else {
-      homeMeta(locale, req, res, next);
-    }
+    openGraphMetas(req, res);
+    next();
   };
 };

--- a/bin/middlewares/prefetch_poi.js
+++ b/bin/middlewares/prefetch_poi.js
@@ -43,13 +43,14 @@ module.exports = function (config) {
       .then(poi => {
         if (poi) {
           res.locals.poi = poi;
+          next();
         } else {
           res.redirect(307, config.system.baseUrl);
         }
       })
       .catch(error => {
         req.logger.error({ err: error });
-      })
-      .finally(next);
+        next();
+      });
   };
 };

--- a/bin/middlewares/prefetch_poi.js
+++ b/bin/middlewares/prefetch_poi.js
@@ -1,0 +1,55 @@
+const axios = require('axios');
+
+module.exports = function (config) {
+  // Use url from server config if defined
+  const idunnBaseUrl = config.server.services.idunn.url || config.services.idunn.url;
+  const idunnTimeout = Number(config.server.services.idunn.timeout);
+  if (isNaN(idunnTimeout)) {
+    throw new Error(
+      `Invalid config: idunn timeout is set to "${config.server.services.idunn.timeout}"`
+    );
+  }
+
+  async function getPoi(poiId, langCode) {
+    let id = poiId;
+    const atPos = poiId.indexOf('@');
+    if (atPos !== -1) {
+      id = poiId.slice(0, atPos);
+    }
+
+    try {
+      const response = await axios.get(`${idunnBaseUrl}/v1/places/${id}?lang=${langCode}`, {
+        timeout: idunnTimeout,
+      });
+      return response.data;
+    } catch (error) {
+      if (error.response && error.response.status === 404) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  return function (req, res, next) {
+    const placeUrlMatch = req.originalUrl.split('?')[0].match(/place\/(.*)/);
+    const poiId = placeUrlMatch && placeUrlMatch[1];
+
+    if (!poiId) {
+      next();
+      return;
+    }
+
+    getPoi(poiId, res.locals.language.code)
+      .then(poi => {
+        if (poi) {
+          res.locals.poi = poi;
+        } else {
+          res.redirect(307, config.system.baseUrl);
+        }
+      })
+      .catch(error => {
+        req.logger.error({ err: error });
+      })
+      .finally(next);
+  };
+};


### PR DESCRIPTION
## Description
Split our `og_meta` Express middleware into two separate middlewares with clear responsibilities, instead of doing not-so-related stuff in the same one:
 - `prefetch_poi`: parses the URL for a potential POI specified in the url and fetches it, making it available to the next step in the Express chain as `res.locals.poi` 
 - `og_meta`: writes the right OpenGraph meta info. If a POI has been pre-fetched before, uses its info.

## Why
Prefetching the bbox corresponding to a `?q=` query will have to be done in a middleware, similar to the hotload POI fetch, and I wanted to clean the situation before.
Moreover, any clean-up in this code will ease a potential switch to SSR later.