### PR TITLE
Fix vertical align of direction shortcuts

### DIFF
--- a/src/scss/includes/panels/service_panel.scss
+++ b/src/scss/includes/panels/service_panel.scss
@@ -11,6 +11,7 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
+  align-items: flex-start;
 
   .mainActionButton {
     width: 84px;
@@ -38,9 +39,7 @@
 
   .service_panel__categories,
   .service_panel__actions {
-    margin: 0 auto;
-    display: block;
-    text-align: center;
+    justify-content: center;
 
     .mainActionButton {
       width: 25%;


### PR DESCRIPTION
## Description
Fixes a vertical align bug caused by strings taking two lines, happening in German.
Instead of switching to `display:block` in mobile, just keep flexbox and align to the top of the container.
(In reality this bug probably happens only with some dev tools mobile views, as DPR is high enough on real devices to display these strings on one line, but whatever).

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran 2021-04-21 à 17 03 50](https://user-images.githubusercontent.com/243653/115420155-2f751e80-a1fb-11eb-8ae3-0ddd94a09bec.png)|![Capture d’écran 2021-04-21 à 17 01 46](https://user-images.githubusercontent.com/243653/115420165-3308a580-a1fb-11eb-83f3-54603e838328.png)|


