### PR TITLE
QMAPS-2108 Fix empty linestring error from alt route labeller

### DIFF
--- a/src/libs/route_labeler.js
+++ b/src/libs/route_labeler.js
@@ -38,10 +38,10 @@ function distinctSegment(coordinates, coordCounts) {
   if (start === -1) {
     return lineString(coordinates);
   }
-  const end =
-    start + coordinates.slice(start).findIndex(coord => coordCounts.get(asKey(coord)) !== 1);
-
-  return lineString(coordinates.slice(start, end));
+  const end = coordinates.findIndex((coord, i) => i > start && coordCounts.get(asKey(coord)) !== 1);
+  return lineString(
+    coordinates.slice(start === 0 ? start : start - 1, end === -1 ? coordinates.length : end + 1)
+  );
 }
 
 // extract the first segment of each linestring


### PR DESCRIPTION
## Description
Fix a problem in the alternative route labeller algorithm, causing an error on some public transport results, preventing the labels and POIs to be displayed.

The root cause is some public transport results are made of alternative routes whose geometry don't start or end with the same point.
![Capture d’écran de 2021-04-22 16-50-45](https://user-images.githubusercontent.com/243653/115735946-29ae4300-a38b-11eb-82a1-39d6a0bf4634.png)

It may be a Combigo edge-case. It causes the labelling algorithm to fail because in its phase where it extracts a distinct segment, it assumed all alternative geometries will share at least the start and end point. When it was not the case for the end point, it resulted in a `-1` returned as `findIndex` result and an `Array.slice` end index inferior to the start index, which caused an empty coordinate array used for a GeoJSON linestring.

I improved the robustness of the algorithm by not assuming the geometries share their start/end point.
I also fixed index issues, extracting the start/end points as part of the distinct segment, otherwise we may fall in the case of the segment with only one point, which will throw a similar error.