### PR TITLE
Simplification: use a single top bar back button

### DIFF
--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -113,25 +113,17 @@ export default class PanelManager extends React.Component {
   }
 
   updateTopBarReturnButton({ poiFilters = {}, isFromFavorite, poi = {} } = {}) {
-    const topBarReturnButton = document.querySelector('.search_form__return-to-list');
-    const backAction =
-      poiFilters.category || poiFilters.query
-        ? this.backToList
-        : isFromFavorite
-        ? this.backToFavorite
-        : () => {};
-    topBarReturnButton.onclick = e => {
-      backAction(e, poiFilters);
-    };
-
     const topBarHandle = document.querySelector('.top_bar');
-
-    // Show return arrow (on mobile) if user comes from PoI / favorites list
+    const topBarReturnButton = document.querySelector('.search_form__return');
     if (poi.name && (poiFilters.category || poiFilters.query || isFromFavorite)) {
+      const backAction =
+        poiFilters.category || poiFilters.query ? this.backToList : this.backToFavorite;
+      topBarReturnButton.onclick = e => {
+        backAction(e, poiFilters);
+      };
       topBarHandle.classList.add('top_bar--poi-from-list');
-    }
-    // Hide return button when not on a POI anymore
-    else {
+    } else {
+      topBarReturnButton.removeAttribute('onclick');
       topBarHandle.classList.remove('top_bar--poi-from-list');
     }
   }

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -132,7 +132,6 @@ export default class PanelManager extends React.Component {
     }
     // Hide return button when not on a POI anymore
     else {
-      const topBarHandle = document.querySelector('.top_bar');
       topBarHandle.classList.remove('top_bar--poi-from-list');
     }
   }

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -34,7 +34,8 @@ export default class PanelManager extends React.Component {
       ActivePanel: ServicePanel,
       options: {},
       panelSize: 'default',
-      isPanelVisible: true,
+      isSuggestOpen: false,
+      searchQuery: '',
     };
   }
 
@@ -274,21 +275,17 @@ export default class PanelManager extends React.Component {
     this.setState({ panelSize });
   };
 
-  onSuggestChange = query => {
-    this.setState(prevState => {
-      const { ActivePanel, isPanelVisible } = prevState;
-      const shouldPanelBeVisible = ActivePanel === ServicePanel && query.length === 0;
-      if (isPanelVisible !== shouldPanelBeVisible) {
-        return {
-          isPanelVisible: shouldPanelBeVisible,
-        };
-      }
-    });
+  setSuggestOpen = isOpen => {
+    if (this.state.isSuggestOpen !== isOpen) {
+      this.setState({ isSuggestOpen: isOpen });
+    }
   };
 
   render() {
-    const { ActivePanel, options, panelSize, isPanelVisible } = this.state;
+    const { ActivePanel, options, panelSize, isSuggestOpen, searchQuery } = this.state;
     const { searchBarInputNode, searchBarOutputNode } = this.props;
+
+    const isPanelVisible = !isSuggestOpen || (ActivePanel === ServicePanel && searchQuery === '');
 
     return (
       <div>
@@ -296,17 +293,9 @@ export default class PanelManager extends React.Component {
           inputNode={searchBarInputNode}
           outputNode={searchBarOutputNode}
           withCategories
-          onChange={this.onSuggestChange}
-          onOpen={() => {
-            if (isPanelVisible && ActivePanel !== ServicePanel) {
-              this.setState({ isPanelVisible: false });
-            }
-          }}
-          onClose={() => {
-            if (!isPanelVisible) {
-              this.setState({ isPanelVisible: true });
-            }
-          }}
+          onChange={searchQuery => this.setState({ searchQuery })}
+          onOpen={() => this.setSuggestOpen(true)}
+          onClose={() => this.setSuggestOpen(false)}
         />
 
         <PanelContext.Provider value={{ size: panelSize, setSize: this.setPanelSize }}>

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -75,9 +75,13 @@ export default class PanelManager extends React.Component {
   }
 
   componentDidUpdate(_prevProps, prevState) {
-    const { ActivePanel, options } = this.state;
+    const { ActivePanel, options, isSuggestOpen } = this.state;
 
-    if (prevState.ActivePanel !== ActivePanel || prevState.options !== options) {
+    if (
+      prevState.ActivePanel !== ActivePanel ||
+      prevState.options !== options ||
+      prevState.isSuggestOpen !== isSuggestOpen
+    ) {
       // Not in a "list of PoI" context (options.poiFilters is null)
       if (isNullOrEmpty(options?.poiFilters)) {
         // Markers are not persistent
@@ -119,12 +123,16 @@ export default class PanelManager extends React.Component {
     if (poi.name && (poiFilters.category || poiFilters.query || isFromFavorite)) {
       const backAction =
         poiFilters.category || poiFilters.query ? this.backToList : this.backToFavorite;
-      topBarReturnButton.onclick = e => {
+      // use the mousedown event so it's triggered before the blur event on the suggest
+      topBarReturnButton.onmousedown = e => {
+        if (this.state.isSuggestOpen) {
+          return;
+        }
         backAction(e, poiFilters);
       };
       topBarHandle.classList.add('top_bar--poi-from-list');
     } else {
-      topBarReturnButton.removeAttribute('onclick');
+      topBarReturnButton.removeAttribute('onmousedown');
       topBarHandle.classList.remove('top_bar--poi-from-list');
     }
   }

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -87,8 +87,7 @@ input[type="search"] {
 }
 
 // Return arrows
-.search_form__return,
-.search_form__return-to-list {
+.search_form__return {
   display: none;
 }
 
@@ -192,8 +191,7 @@ input[type="search"] {
     font-size: 14px;
   }
 
-  .search_form__return,
-  .search_form__return-to-list {
+  .search_form__return {
     display: none;
     font-size: 20px;
     text-align: center;
@@ -264,13 +262,10 @@ input[type="search"] {
   }
 
   // When the search field is focused (empty or not)
-  .top_bar--search_focus {
-    .search_form__input::placeholder {
-      color: $grey-semi-darkness;
-      opacity: 1;
-    }
-
-    // Show return arrow
+  .top_bar--search_focus,
+  // or we are on a POI panel coming from a list (category or favs)
+  .top_bar--poi-from-list {
+    // Show the return arrow
     .search_form__return {
       display: block;
     }
@@ -278,6 +273,13 @@ input[type="search"] {
     // ... and make room for it
     .search_form__wrapper {
       padding-left: $spacing-xxl-3;
+    }
+  }
+
+  .top_bar--search_focus {
+    .search_form__input::placeholder {
+      color: $grey-semi-darkness;
+      opacity: 1;
     }
   }
 
@@ -303,27 +305,6 @@ input[type="search"] {
     // Hide magnifying glass
     .search_form__action {
       display: none;
-    }
-  }
-
-  // When a PoI Panel is displayed
-  .top_bar--poi-from-list {
-
-    // Show the return arrow
-    .search_form__return-to-list {
-      display: block;
-    }
-
-    // If the search field is focused, hide it
-    &.top_bar--search_focus {
-      .search_form__return-to-list {
-        display: none;
-      }
-    }
-
-    // Make room for it on the left of the field
-    .search_form__wrapper {
-      padding-left: $spacing-xxl-3;
     }
   }
 }

--- a/tests/integration/helpers/autocomplete.js
+++ b/tests/integration/helpers/autocomplete.js
@@ -7,7 +7,14 @@ export default class AutocompleteHelper {
     this.page = page;
   }
 
+  async typeAndSubmit(word) {
+    await this.page.focus(SEARCH_INPUT_SELECTOR);
+    await this.page.keyboard.type(word);
+    await this.page.keyboard.press('Enter');
+  }
+
   async typeAndWait(word) {
+    await this.page.focus(SEARCH_INPUT_SELECTOR);
     await this.page.keyboard.type(word);
     await this.page.waitForSelector(SUGGEST_SELECTOR);
   }

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -32,10 +32,7 @@ test('search with no suggest', async () => {
   responseHandler.addPreparedResponse(mockAutocompleteEmpty, /autocomplete\?q=Goodbye/);
   await page.goto(APP_URL);
   await autocompleteHelper.typeAndWait('Goodbye');
-  const title = await page.evaluate(() => {
-    return document.querySelector('.autocomplete_error').innerText;
-  });
-  expect(title).toEqual('No result found');
+  expect(await exists(page, '.autocomplete_error')).toBeTruthy();
 });
 
 test('search has lang in query', async () => {
@@ -82,7 +79,6 @@ test('keyboard navigation', async () => {
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete/);
   await page.goto(APP_URL);
   await autocompleteHelper.typeAndWait(TypedSearch);
-  await page.waitForSelector('.autocomplete_suggestions');
   await page.waitFor(100);
   await autocompleteHelper.pressDown();
   await page.waitFor(100);
@@ -159,7 +155,6 @@ test('move to on click', async () => {
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
   const { center: map_position_before } = await getMapView(page);
   await autocompleteHelper.typeAndWait('Hello');
-  await page.waitForSelector('.autocomplete_suggestions');
   await page.click('.autocomplete_suggestions li:nth-child(3)');
   const { center: map_position_after } = await getMapView(page);
   expect(map_position_before).not.toEqual(map_position_after);
@@ -171,7 +166,6 @@ test('center on select', async () => {
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete/);
   await page.goto(APP_URL);
   await autocompleteHelper.typeAndWait('Hello');
-  await page.waitForSelector('.autocomplete_suggestions');
   await page.click('.autocomplete_suggestion:nth-child(1)');
   const { center, zoom } = await getMapView(page);
   expect(center).toEqual({ lat: 5, lng: 30 });
@@ -195,7 +189,7 @@ test('favorite search', async () => {
   await page.goto(APP_URL);
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=Hello/);
   await storePoi(page, { title: 'hello' });
-  await page.keyboard.type('Hello');
+  await autocompleteHelper.typeAndWait('Hello');
   expect(await exists(page, '.autocomplete_suggestion--favorite')).toBeTruthy();
 });
 
@@ -204,8 +198,7 @@ test('suggestions should not reappear after fast submit', async () => {
     delay: 300,
   });
   await page.goto(APP_URL);
-  await page.keyboard.type('paris');
-  await page.keyboard.press('Enter');
+  await autocompleteHelper.typeAndSubmit('paris');
   await page.waitFor(600);
   await page.waitForSelector('.autocomplete_suggestions', { hidden: true });
 });
@@ -213,8 +206,7 @@ test('suggestions should not reappear after fast submit', async () => {
 test('check template', async () => {
   responseHandler.addPreparedResponse(mockAutocompleteAllTypes, /autocomplete\?q=type/);
   await page.goto(APP_URL);
-  await page.keyboard.type('type');
-  await page.waitForSelector('.autocomplete_suggestion');
+  await autocompleteHelper.typeAndWait('type');
 
   const lines = await page.evaluate(() => {
     return Array.from(document.querySelectorAll('.autocomplete_suggestion')).map(rawSuggest => {
@@ -266,8 +258,7 @@ test('Retrieve restaurant category when we search "restau"', async () => {
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=restau/);
 
   await page.goto(APP_URL);
-  await page.keyboard.type(searchQuery);
-  await page.waitForSelector('.autocomplete_suggestion');
+  await autocompleteHelper.typeAndWait(searchQuery);
 
   const [firstLine, suggestionId] = await page.evaluate(() => {
     return [
@@ -288,8 +279,7 @@ test('Retrieve no category when we search "barcelona", not even "bar"', async ()
   responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete\?q=barcelona/);
 
   await page.goto(APP_URL);
-  await page.keyboard.type(searchQuery);
-  await page.waitForSelector('.autocomplete_suggestion');
+  await autocompleteHelper.typeAndWait(searchQuery);
 
   const firstLine = await page.evaluate(() => {
     return document.querySelector(

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -49,7 +49,6 @@
         ></button>
         <div class="search_form__wrapper empty">
           <div class="search_form__return icon-arrow-left"></div>
-          <div class="search_form__return-to-list icon-arrow-left"></div>
           <input id="search" type="search" class="search_form__input" spellcheck="false" required placeholder="<%= _('Search on Qwant Maps') %>" autocomplete="off">
           <button id="clear_button_mobile" class="search_form__clear icon-x" type="button" onmousedown="clearSearch(event)" title="<%= _('Clear', 'search bar') %>"></button>
           <input type="submit" value="" class="search_form__action" onclick="submitSearch()" title="<%= _('Search') %>">


### PR DESCRIPTION
## Description
Follow-up to https://github.com/Qwant/erdapfel/pull/1051.
In that previous PR, a second arrow-left button was added in the top bar static markup, to manage specifically the case of navigating back from POI to category/list. The existing button acting as a neutral area to blur the suggest input field wasn't reused, even if it had exactly the same style.

In this PR, we refactor this button part and the state management of `<PanelManager>` so we don't need two buttons. The same DOM element is used for both actions (back and suggest blur), the switch between them being controlled by the state.

(I also tweaked autocomplete integration tests, after noticing they behaved erratically from one run to another, and differently between CI and local).

## Why
Less HTML/JS/CSS, consistency, and not diverging too much from the target architecture of the [TopBar as a React component](https://github.com/Qwant/erdapfel/pull/997), which will update its DOM and event handler dynamically, rendering only what's necessary.