### PR TITLE
[Clean-up] Client simplifications after server-side `?q=` redirect

### DIFF
--- a/src/libs/suggest.js
+++ b/src/libs/suggest.js
@@ -12,7 +12,7 @@ import { suggestResults } from 'src/adapters/suggest_sources';
 const geocoderConfig = nconf.get().services.geocoder;
 const SUGGEST_MAX_ITEMS = geocoderConfig.maxItems;
 
-export const selectItem = (selectedItem, { query, replaceUrl = false, fromQueryParams } = {}) => {
+export const selectItem = (selectedItem, { query, replaceUrl = false } = {}) => {
   if (selectedItem instanceof Poi) {
     window.app.navigateTo(
       `/place/${toUrl(selectedItem)}`,
@@ -31,8 +31,6 @@ export const selectItem = (selectedItem, { query, replaceUrl = false, fromQueryP
       category: selectedItem.category ? selectedItem.category.name : null,
       has_full_text_query: !!selectedItem.fullTextQuery,
       has_place: !!selectedItem.place,
-      from_url_query: !!fromQueryParams?.q,
-      url_client: fromQueryParams?.client || null,
     });
     window.app.navigateTo(`/places/${selectedItem.toQueryString()}`, {}, { replace: replaceUrl });
   } else if (!selectedItem) {

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -217,15 +217,6 @@ export default class PanelManager extends React.Component {
       });
     }
 
-    router.addRoute('Direct search query', '/([?].*)', queryString => {
-      const params = parseQueryString(queryString);
-      if (params.q) {
-        SearchInput.executeSearch(params.q, { fromQueryParams: params });
-      } else {
-        router.routeUrl('/');
-      }
-    });
-
     // Default matching route
     router.addRoute('Services', '/?', (_, options = {}) => {
       this.setState({

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -19,8 +19,6 @@ import Suggest from 'src/components/ui/Suggest';
 
 const directionConf = nconf.get().direction;
 
-const directSearchRouteName = 'Direct search query';
-
 export default class PanelManager extends React.Component {
   static propTypes = {
     router: PropTypes.object.isRequired,
@@ -42,14 +40,13 @@ export default class PanelManager extends React.Component {
   componentDidMount() {
     const initialUrlPathName = window.location.pathname;
     const initialQueryParams = parseQueryString(window.location.search);
-    const initialRoute = this.initRouter();
+    this.initRouter();
     this.initTopBar();
 
     Telemetry.add(Telemetry.APP_START, {
       language: window.getLang(),
       is_mobile: isMobileDevice(),
       url_pathname: initialUrlPathName,
-      direct_search: initialRoute.name === directSearchRouteName && !!initialQueryParams['q'],
       url_client: initialQueryParams['client'] || null,
     });
 
@@ -220,7 +217,7 @@ export default class PanelManager extends React.Component {
       });
     }
 
-    router.addRoute(directSearchRouteName, '/([?].*)', queryString => {
+    router.addRoute('Direct search query', '/([?].*)', queryString => {
       const params = parseQueryString(queryString);
       if (params.q) {
         SearchInput.executeSearch(params.q, { fromQueryParams: params });

--- a/src/ui_components/search_input.js
+++ b/src/ui_components/search_input.js
@@ -89,17 +89,16 @@ export default class SearchInput {
     };
   }
 
-  static async executeSearch(query, { fromQueryParams } = {}) {
+  static async executeSearch(query) {
     window.__searchInput.searchInputHandle.value = query;
     const results = await fetchSuggests(query, {
       withCategories: true,
-      useFocus: !fromQueryParams, // Ignore map position for a query passed in URL
+      useFocus: true,
     });
 
     selectItem(results[0] || null, {
       query,
       replaceUrl: true,
-      fromQueryParams,
     });
     window.__searchInput.searchInputHandle.blur();
   }

--- a/tests/__data__/autocomplete.json
+++ b/tests/__data__/autocomplete.json
@@ -1,6 +1,14 @@
 {
   "type": "FeatureCollection",
   "geocoding": {"version": "0.1.0", "query": ""},
+  "intentions": [
+    {
+      "filter": {
+        "bbox": [7.0, 43.5, 7.5, 44.0],
+        "category": "restaurant"
+      }
+    }
+  ],
   "features": [{
     "type": "Feature",
     "geometry": {"coordinates": [30, 5], "type": "Point"},

--- a/tests/__data__/autocomplete.json
+++ b/tests/__data__/autocomplete.json
@@ -1,14 +1,6 @@
 {
   "type": "FeatureCollection",
   "geocoding": {"version": "0.1.0", "query": ""},
-  "intentions": [
-    {
-      "filter": {
-        "bbox": [7.0, 43.5, 7.5, 44.0],
-        "category": "restaurant"
-      }
-    }
-  ],
   "features": [{
     "type": "Feature",
     "geometry": {"coordinates": [30, 5], "type": "Point"},

--- a/tests/__data__/autocomplete_nlu.json
+++ b/tests/__data__/autocomplete_nlu.json
@@ -1,0 +1,113 @@
+{
+  "type": "FeatureCollection",
+  "geocoding": {"version": "0.1.0", "query": ""},
+  "intentions": [
+    {
+      "filter": {
+        "bbox": [7.0, 43.5, 7.5, 44.0],
+        "category": "restaurant"
+      }
+    }
+  ],
+  "features": [{
+    "type": "Feature",
+    "geometry": {"coordinates": [30, 5], "type": "Point"},
+    "properties": {
+      "geocoding": {
+        "id": "osm:node:4872758213",
+        "type": "poi",
+        "label": "test result 1",
+        "name": "test result 1",
+        "postcode": null,
+        "city": null,
+        "citycode": null,
+        "administrative_regions": [{
+          "id": "admin:osm:relation:421866",
+          "insee": "",
+          "level": 4,
+          "label": "Київ, Україна",
+          "name": "Київ",
+          "zip_codes": [],
+          "weight": 0.02024299523736607,
+          "coord": {"lon": 30.5240501, "lat": 50.4501071},
+          "admin_type": "Unknown",
+          "zone_type": "state"
+        }, {
+          "id": "admin:osm:relation:1755013",
+          "insee": "",
+          "level": 7,
+          "label": "Печерський район, Київ, Україна",
+          "name": "Печерський район",
+          "zip_codes": [],
+          "weight": 0.0,
+          "coord": {"lon": 30.54803619877768, "lat": 50.4271602204523},
+          "admin_type": "Unknown",
+          "zone_type": "city_district"
+        }, {
+          "id": "admin:osm:relation:60199",
+          "insee": "",
+          "level": 2,
+          "label": "Україна",
+          "name": "Україна",
+          "zip_codes": [],
+          "weight": 0.0,
+          "coord": {"lon": 30.5240501, "lat": 50.4501071},
+          "admin_type": "Unknown",
+          "zone_type": "country"
+        }],
+        "poi_types": [{"id": "shop", "name": "shop"}],
+        "properties": [{"key": "name", "value": "Dsquared2"}, {
+          "key": "name_int",
+          "value": "Dsquared2"
+        }, {"key": "name:latin", "value": "Dsquared2"}, {"key": "shop", "value": "boutique"}, {
+          "key": "poi_subclass",
+          "value": "boutique"
+        }, {"key": "poi_class", "value": "shop"}],
+        "address": {
+          "id": "23567113",
+          "type": "street",
+          "label": "Басейна вулиця",
+          "name": "Басейна вулиця",
+          "street": "Басейна вулиця",
+          "postcode": null,
+          "city": null,
+          "citycode": null,
+          "administrative_regions": [{
+            "id": "admin:osm:relation:421866",
+            "insee": "",
+            "level": 4,
+            "label": "Київ, Україна",
+            "name": "Київ",
+            "zip_codes": [],
+            "weight": 0.001477283270562542,
+            "coord": {"lon": 30.5240501, "lat": 50.4501071},
+            "admin_type": "Unknown",
+            "zone_type": "state"
+          }, {
+            "id": "admin:osm:relation:1755013",
+            "insee": "",
+            "level": 7,
+            "label": "Печерський район, Київ, Україна",
+            "name": "Печерський район",
+            "zip_codes": [],
+            "weight": 0.00012098323285593304,
+            "coord": {"lon": 30.54803619877768, "lat": 50.4271602204523},
+            "admin_type": "Unknown",
+            "zone_type": "city_district"
+          }, {
+            "id": "admin:osm:relation:60199",
+            "insee": "",
+            "level": 2,
+            "label": "Україна",
+            "name": "Україна",
+            "zip_codes": [],
+            "weight": 0.05005734322235657,
+            "coord": {"lon": 30.5240501, "lat": 50.4501071},
+            "admin_type": "Unknown",
+            "zone_type": "country"
+          }]
+        }
+      }
+    }
+  }]
+}

--- a/tests/integration/server_start.js
+++ b/tests/integration/server_start.js
@@ -29,6 +29,27 @@ nock(/idunn_test\.test/)
   .get(/osm:way:2403/)
   .reply(404);
 
+const noResultAutocomplete = require('../__data__/autocomplete_empty.json');
+nock(/idunn_test\.test/)
+  .persist(true)
+  .get('/v1/autocomplete')
+  .query(params => params.q === 'gibberish')
+  .reply(200, JSON.stringify(noResultAutocomplete));
+
+const intentionAutocomplete = require('../__data__/autocomplete.json');
+nock(/idunn_test\.test/)
+  .persist(true)
+  .get('/v1/autocomplete')
+  .query(params => params.q === 'restonice')
+  .reply(200, JSON.stringify(intentionAutocomplete));
+
+const noIntentionAutocomplete = require('../__data__/autocomplete_type.json');
+nock(/idunn_test\.test/)
+  .persist(true)
+  .get('/v1/autocomplete')
+  .query(params => params.q === 'single')
+  .reply(200, JSON.stringify(noIntentionAutocomplete));
+
 global.appServer = new App(config);
 
 module.exports = async function () {

--- a/tests/integration/server_start.js
+++ b/tests/integration/server_start.js
@@ -36,7 +36,7 @@ nock(/idunn_test\.test/)
   .query(params => params.q === 'gibberish')
   .reply(200, JSON.stringify(noResultAutocomplete));
 
-const intentionAutocomplete = require('../__data__/autocomplete.json');
+const intentionAutocomplete = require('../__data__/autocomplete_nlu.json');
 nock(/idunn_test\.test/)
   .persist(true)
   .get('/v1/autocomplete')

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -1,4 +1,4 @@
-import { clearStore, initBrowser, getInputValue, getMapView, exists } from '../tools';
+import { clearStore, initBrowser, getMapView, exists } from '../tools';
 import { storePoi } from '../favorites_tools';
 import AutocompleteHelper from '../helpers/autocomplete';
 import ResponseHandler from '../helpers/response_handler';
@@ -231,25 +231,6 @@ test('check template', async () => {
   /* admin */
   expect(lines[3][0]).toEqualCaseInsensitive('Le Cannet (06110)');
   expect(lines[3][1]).toEqualCaseInsensitive("Alpes-Maritimes, Provence-Alpes-Côte d'Azur, France");
-});
-
-test('Search Query', async () => {
-  responseHandler.addPreparedResponse(mockAutocomplete, /autocomplete/);
-  await page.goto('about:blank');
-
-  const searchQuery = 'test';
-  await page.goto(`${APP_URL}/?q=${searchQuery}`);
-  const searchValue = await getInputValue(page, '#search');
-
-  // search input is filled with PoI name (not the query)
-  expect(searchValue).toEqual('test result 1');
-
-  // app navigates to first result from autocomplete
-  expect(page.url()).toEqual(`${APP_URL}/place/osm:node:4872758213@test_result_1`);
-
-  // "go back" navigates to previous page
-  await page.goBack({ waitUntil: 'networkidle0' }); // wait for potential requests to API
-  expect(page.url()).toEqual('about:blank');
 });
 
 test('Retrieve restaurant category when we search "restau"', async () => {


### PR DESCRIPTION
## Description
Simplify the routing and telemetry logic on the client following the new server-side redirection of full text queries introduced in https://github.com/Qwant/erdapfel/pull/1066, following [great advice by @amatissart](https://github.com/Qwant/erdapfel/pull/1066#pullrequestreview-644882174)
 - Remove the need for a client side redirection of `/?q=` queries as start url (as it's now done exclusively on the server)
 - Remove extra telemetry fields related to tracking this special case
 - Use `'direct-search'` as a new `client` param to track this case using the generic fields

*Note: I removed the integration test case that checked the client-side redirection on app startup, because it couldn't work anymore. I replaced it with testing the 3 cases (no result, single, multi) of server-side redirect, which required some new mocking of Idunn calls from Express.*