### PR TITLE
QMAPS-2052 add transport icons in map labels

### DIFF
--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -18,6 +18,13 @@ import { fire, listen } from 'src/libs/customEvents';
 import { getLabelPositions } from 'src/libs/route_labeler';
 import { isMobileDevice } from 'src/libs/device';
 
+const VEHICLES = {
+  TRAIN: 'train',
+  SUBWAY: 'metro',
+  BUS_CITY: 'bus',
+  TRAM: 'tram"',
+};
+
 const createMarker = (lngLat, className = '', options = {}) => {
   const element = document.createElement('div');
   element.className = className;
@@ -28,20 +35,26 @@ const createRouteLabel = (route, vehicle, { lngLat, anchor }) => {
   const element = document.createElement('div');
   let html = ``;
   if (vehicle === 'publicTransport') {
-    let nbIcons = 0;
-    let summaryItem;
-    let vehicle;
     html += `<div>`;
-    for (summaryItem of route.summary) {
-      if (summaryItem.mode !== 'WALK' && nbIcons < 3) {
-        vehicle = {
-          TRAIN: 'train',
-          SUBWAY: 'metro',
-          BUS_CITY: 'bus',
-          TRAM: 'tram"',
-        }[summaryItem.mode];
-        html += `<div class="publicTransportLabelItem roadmapIcon roadmapIcon--${vehicle}"></div>`;
-        nbIcons++;
+    let nbIcons = 0;
+    const summaryItems = route.summary.filter(item => item.mode !== 'WALK');
+    if (summaryItems.length > 3) {
+      html += `<div class="publicTransportLabelItem roadmapIcon roadmapIcon--${
+        VEHICLES[summaryItems[0].mode]
+      }"></div>`;
+      html += `<div class="publicTransportLabelItem roadmapIcon roadmapIcon--ellipsis"></div>`;
+      html += `<div class="publicTransportLabelItem roadmapIcon roadmapIcon--${
+        VEHICLES[summaryItems[summaryItems.length - 1].mode]
+      }"></div>`;
+    } else {
+      let summaryItem;
+      let vehicle;
+      for (summaryItem of summaryItems) {
+        if (summaryItem.mode !== 'WALK' && nbIcons < 3) {
+          vehicle = VEHICLES[summaryItem.mode];
+          html += `<div class="publicTransportLabelItem roadmapIcon roadmapIcon--${vehicle}"></div>`;
+          nbIcons++;
+        }
       }
     }
     html += `</div>`;

--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -1,32 +1,18 @@
 import React from 'react';
-import classnames from 'classnames';
+import RouteLabel from 'src/panel/direction/RouteLabel';
 import { Marker, LngLatBounds } from 'mapbox-gl--ENV';
 import bbox from '@turf/bbox';
 import { normalizeToFeatureCollection } from 'src/libs/geojson';
 import { map } from '../../config/constants.yml';
 import LatLonPoi from '../adapters/poi/latlon_poi';
 import { prepareRouteColor, getRouteStyle, setActiveRouteStyle } from './route_styles';
-import {
-  getAllSteps,
-  getAllStops,
-  originDestinationCoords,
-  formatDuration,
-  formatDistance,
-  getVehicleIcon,
-} from 'src/libs/route_utils';
+import { getAllSteps, getAllStops, originDestinationCoords } from 'src/libs/route_utils';
 import Error from '../adapters/error';
 import nconf from '@qwant/nconf-getter';
 import { fire, listen } from 'src/libs/customEvents';
 import { getLabelPositions } from 'src/libs/route_labeler';
 import { isMobileDevice } from 'src/libs/device';
 import renderStaticReact from 'src/libs/renderStaticReact';
-
-const VEHICLES = {
-  TRAIN: 'train',
-  SUBWAY: 'metro',
-  BUS_CITY: 'bus',
-  TRAM: 'tram"',
-};
 
 const createMarker = (lngLat, className = '', options = {}) => {
   const element = document.createElement('div');
@@ -36,61 +22,10 @@ const createMarker = (lngLat, className = '', options = {}) => {
 
 const createRouteLabel = (route, vehicle, { lngLat, anchor }) => {
   const element = document.createElement('div');
-  let content;
-  if (vehicle === 'publicTransport') {
-    const summaryItems = route.summary.filter(item => item.mode !== 'WALK');
-    if (summaryItems.length > 3) {
-      content = (
-        <div>
-          <div
-            className={classnames(
-              'publicTransportLabelItem',
-              'roadmapIcon',
-              'roadmapIcon--' + VEHICLES[summaryItems[0].mode]
-            )}
-          ></div>
-          <div className="publicTransportLabelItem roadmapIcon roadmapIcon--ellipsis"></div>
-          <div
-            className={classnames(
-              'publicTransportLabelItem',
-              'roadmapIcon',
-              'roadmapIcon--' + VEHICLES[summaryItems[summaryItems.length - 1].mode]
-            )}
-          ></div>
-        </div>
-      );
-    } else {
-      content = (
-        <div>
-          {summaryItems.map(item => {
-            if (item.mode !== 'WALK') {
-              const stepVehicle = VEHICLES[item.mode];
-              return (
-                <div
-                  className={classnames(
-                    'publicTransportLabelItem',
-                    'roadmapIcon',
-                    'roadmapIcon--' + stepVehicle
-                  )}
-                ></div>
-              );
-            }
-          })}
-        </div>
-      );
-    }
-  } else {
-    content = <div className={classnames('routeLabel-vehicleIcon', getVehicleIcon(vehicle))}></div>;
-  }
-  const durationAndDistance = (
-    <div>
-      <div className="routeLabel-duration">{formatDuration(route.duration)}</div>
-      <div className="routeLabel-distance">{formatDistance(route.distance)}</div>
-    </div>
+  element.innerHTML = renderStaticReact(
+    <RouteLabel route={route} vehicle={vehicle} anchor={anchor} />
   );
-  element.innerHTML = renderStaticReact(content) + renderStaticReact(durationAndDistance);
-  element.className = `routeLabel routeLabel--${anchor} routeLabel--${vehicle}`;
-  element.dataset.id = route.id;
+  element.className = 'routeLabel-marker';
   element.onclick = () => {
     fire('select_road_map', route.id);
   };

--- a/src/adapters/scene_direction.js
+++ b/src/adapters/scene_direction.js
@@ -26,13 +26,35 @@ const createMarker = (lngLat, className = '', options = {}) => {
 
 const createRouteLabel = (route, vehicle, { lngLat, anchor }) => {
   const element = document.createElement('div');
-  element.innerHTML = `
-    <div class="routeLabel-vehicleIcon ${getVehicleIcon(vehicle)}"></div>
+  let html = ``;
+  if (vehicle === 'publicTransport') {
+    let nbIcons = 0;
+    let summaryItem;
+    let vehicle;
+    html += `<div>`;
+    for (summaryItem of route.summary) {
+      if (summaryItem.mode !== 'WALK' && nbIcons < 3) {
+        vehicle = {
+          TRAIN: 'train',
+          SUBWAY: 'metro',
+          BUS_CITY: 'bus',
+          TRAM: 'tram"',
+        }[summaryItem.mode];
+        html += `<div class="publicTransportLabelItem roadmapIcon roadmapIcon--${vehicle}"></div>`;
+        nbIcons++;
+      }
+    }
+    html += `</div>`;
+  } else {
+    html += `<div class="routeLabel-vehicleIcon ${getVehicleIcon(vehicle)}"></div>`;
+  }
+  html += `
     <div>
       <div class="routeLabel-duration">${formatDuration(route.duration)}</div>
       <div class="routeLabel-distance">${formatDistance(route.distance)}</div>
     </div>
   `;
+  element.innerHTML = html;
   element.className = `routeLabel routeLabel--${anchor} routeLabel--${vehicle}`;
   element.dataset.id = route.id;
   element.onclick = () => {

--- a/src/panel/direction/RouteLabel.jsx
+++ b/src/panel/direction/RouteLabel.jsx
@@ -5,7 +5,7 @@ const VEHICLES = {
   TRAIN: 'train',
   SUBWAY: 'metro',
   BUS_CITY: 'bus',
-  TRAM: 'tram"',
+  TRAM: 'tram',
 };
 
 const PublicTransportIcon = ({ mode }) => (
@@ -28,7 +28,9 @@ const PublicTransportStepIcons = ({ route }) => {
   return (
     <div>
       <PublicTransportIcon mode={nonWalkLegs[0].mode} />
-      <div className="publicTransportLabelItem roadmapIcon roadmapIcon--ellipsis" />
+      <div className="publicTransportLabelItem roadmapIcon u-text--caption roadmapIcon--inbetween">
+        <div>+{nonWalkLegs.length - 2}</div>
+      </div>
       <PublicTransportIcon mode={nonWalkLegs[nonWalkLegs.length - 1].mode} />
     </div>
   );

--- a/src/panel/direction/RouteLabel.jsx
+++ b/src/panel/direction/RouteLabel.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { formatDistance, formatDuration, getVehicleIcon } from 'src/libs/route_utils';
+
+const VEHICLES = {
+  TRAIN: 'train',
+  SUBWAY: 'metro',
+  BUS_CITY: 'bus',
+  TRAM: 'tram"',
+};
+
+const PublicTransportIcon = ({ mode }) => (
+  <div className={`publicTransportLabelItem roadmapIcon roadmapIcon--${VEHICLES[mode]}`} />
+);
+
+const PublicTransportStepIcons = ({ route }) => {
+  const nonWalkLegs = route.legs.filter(leg => leg.mode !== 'WALK');
+
+  if (nonWalkLegs.length <= 3) {
+    return (
+      <div>
+        {nonWalkLegs.map((leg, index) => (
+          <PublicTransportIcon key={index} mode={leg.mode} />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <PublicTransportIcon mode={nonWalkLegs[0].mode} />
+      <div className="publicTransportLabelItem roadmapIcon roadmapIcon--ellipsis" />
+      <PublicTransportIcon mode={nonWalkLegs[nonWalkLegs.length - 1].mode} />
+    </div>
+  );
+};
+
+const RouteLabel = ({ route, vehicle, anchor }) => {
+  const isPublicTransport = vehicle === 'publicTransport';
+  return (
+    <div data-id={route.id} className={`routeLabel routeLabel--${anchor} routeLabel--${vehicle}`}>
+      {isPublicTransport ? (
+        <PublicTransportStepIcons route={route} />
+      ) : (
+        <div className={`routeLabel-vehicleIcon ${getVehicleIcon(vehicle)}`} />
+      )}
+      <div>
+        <div className="routeLabel-duration">{formatDuration(route.duration)}</div>
+        {!isPublicTransport && (
+          <div className="routeLabel-distance">{formatDistance(route.distance)}</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default RouteLabel;

--- a/src/scss/includes/routeLabel.scss
+++ b/src/scss/includes/routeLabel.scss
@@ -122,10 +122,6 @@
     padding-top: 2px;
   }
 
-  &.active .routeLabel-duration {
-    padding-top: 10px;
-  }
-
   .routeLabel-distance {
     display: none;
   }

--- a/src/scss/includes/routeLabel.scss
+++ b/src/scss/includes/routeLabel.scss
@@ -130,3 +130,13 @@
 .directions-stepByStep .routeLabel {
   display: none;
 }
+
+@media (max-width: 640px) {
+  .routeLabel {
+    display: block;
+
+    div {
+      text-align: center;
+    }
+  }
+}

--- a/src/scss/includes/routeLabel.scss
+++ b/src/scss/includes/routeLabel.scss
@@ -1,12 +1,16 @@
+.routeLabel-marker {
+  z-index: 1;
+}
+
 .routeLabel {
   background-color: $grey-lighter;
   color: $grey-semi-darkness;
   border-radius: 6px;
   padding: 4px 8px;
-  z-index: 1;
   cursor: pointer;
   box-shadow: $shadow;
   display: flex;
+  align-items: center;
 
   &-vehicleIcon {
     display: none;
@@ -114,16 +118,6 @@
     &.active::after {
       border-left-color: white;
     }
-  }
-}
-
-.routeLabel--publicTransport {
-  .routeLabel-duration {
-    padding-top: 2px;
-  }
-
-  .routeLabel-distance {
-    display: none;
   }
 }
 

--- a/src/scss/includes/routeLabel.scss
+++ b/src/scss/includes/routeLabel.scss
@@ -143,7 +143,7 @@
     width: 36px;
 
     div {
-      background: $grey-bright;
+      background: $grey-light;
       display: inline-block;
       height: 18px;
       line-height: 18px;
@@ -157,6 +157,16 @@
 
     &:after {
       padding-left: 32px;
+    }
+  }
+}
+
+.routeLabel.active {
+  .publicTransportLabelItem {
+    &.roadmapIcon--inbetween {
+      div {
+        background: $grey-bright;
+      }
     }
   }
 }

--- a/src/scss/includes/routeLabel.scss
+++ b/src/scss/includes/routeLabel.scss
@@ -125,8 +125,34 @@
   display: none;
 }
 
+.publicTransportLabelItem {
+
+  display: inline-block;
+  vertical-align: top;
+  width: 30px;
+
+  &:not(:last-child):after {
+    content: '›';
+    padding: 0 0 0 27px;
+    font-size: 24px;
+    color: $grey-grey;
+  }
+
+  &.roadmapIcon--ellipsis {
+    &:before {
+      content: '...';
+      padding: 0 4px 0 8px;
+      font-size: 16px;
+      color: $grey-grey;
+    }
+    &:after {
+      padding: 0;
+    }
+  }
+}
+
 @media (max-width: 640px) {
-  .routeLabel {
+  .routeLabel--publicTransport {
     display: block;
 
     div {

--- a/src/scss/includes/routeLabel.scss
+++ b/src/scss/includes/routeLabel.scss
@@ -138,15 +138,25 @@
     color: $grey-grey;
   }
 
-  &.roadmapIcon--ellipsis {
-    &:before {
-      content: '...';
-      padding: 0 4px 0 8px;
-      font-size: 16px;
-      color: $grey-grey;
+  &.roadmapIcon--inbetween {
+    line-height: 20px;
+    width: 36px;
+
+    div {
+      background: $grey-bright;
+      display: inline-block;
+      height: 18px;
+      line-height: 18px;
+      width: 20px;
+      text-align: center;
+      border-radius: 1px;
+      position: absolute;
+      margin-left: 8px;
+      margin-top: 3px;
     }
+
     &:after {
-      padding: 0;
+      padding-left: 32px;
     }
   }
 }

--- a/src/scss/includes/routes.scss
+++ b/src/scss/includes/routes.scss
@@ -35,29 +35,3 @@
     }
   }
 }
-
-.publicTransportLabelItem {
-
-  display: inline-block;
-  vertical-align: top;
-  width: 30px;
-
-  &:not(:last-child):after {
-    content: '›';
-    padding: 0 0 0 27px;
-    font-size: 24px;
-    color: $grey-grey;
-  }
-
-  &.roadmapIcon--ellipsis {
-    &:before {
-      content: '...';
-      padding: 0 4px 0 8px;
-      font-size: 16px;
-      color: $grey-grey;
-    }
-    &:after {
-      padding: 0;
-    }
-  }
-}

--- a/src/scss/includes/routes.scss
+++ b/src/scss/includes/routes.scss
@@ -48,4 +48,16 @@
     font-size: 24px;
     color: $grey-grey;
   }
+
+  &.roadmapIcon--ellipsis {
+    &:before {
+      content: '...';
+      padding: 0 4px 0 8px;
+      font-size: 16px;
+      color: $grey-grey;
+    }
+    &:after {
+      padding: 0;
+    }
+  }
 }

--- a/src/scss/includes/routes.scss
+++ b/src/scss/includes/routes.scss
@@ -35,3 +35,17 @@
     }
   }
 }
+
+.publicTransportLabelItem {
+
+  display: inline-block;
+  vertical-align: top;
+  width: 30px;
+
+  &:not(:last-child):after {
+    content: '›';
+    padding: 0 0 0 27px;
+    font-size: 24px;
+    color: $grey-grey;
+  }
+}


### PR DESCRIPTION
## Description
- Add public transport icons into map labels
- 3 icons max, excluding "WALK". 4th and more are omitted
- icons can be repeated (ex: bus > bus > bus)
- small, dark ">" icons between each
- maybe put the duration on the line below on mobile
- if more than 4 vehicles: put "..." in the middle (deprecated)
- UPDATE: replace "..." with a little square containing "+2", "+3", etc.
- We may need to adjust bbox padding on desktop

## Screenshots
![image](https://user-images.githubusercontent.com/1225909/116260793-4ecdf780-a777-11eb-8d8c-6bf72f6a74dc.png)
![image](https://user-images.githubusercontent.com/1225909/116260930-72913d80-a777-11eb-91d1-db7497e8424e.png)
![image](https://user-images.githubusercontent.com/1225909/116899662-2000c700-ac38-11eb-8839-904695e04fd5.png)


