### PR TITLE
QMAPS-2019 Add start/end times on public transport result summaries 

### DIFF
--- a/src/adapters/osm_schedule.js
+++ b/src/adapters/osm_schedule.js
@@ -1,3 +1,5 @@
+import { getTimeFormatter } from 'src/libs/time';
+
 function OsmSchedule(scheduleResponse) {
   if (!scheduleResponse) {
     return null;
@@ -10,17 +12,6 @@ function OsmSchedule(scheduleResponse) {
     scheduleResponse.next_transition_datetime
   );
   this.status = scheduleResponse.status;
-}
-
-function getIntlLocales() {
-  const lang = window.getLang();
-  const locales = [lang.locale].concat(lang.fallback || []);
-  // Intl expects '-' in locales, such as "en-GB"
-  return locales.map(l => l.replace(/_/g, '-'));
-}
-
-function getTimeFormatter() {
-  return Intl.DateTimeFormat(getIntlLocales(), { hour: '2-digit', minute: '2-digit' });
 }
 
 /**
@@ -50,7 +41,7 @@ function toLocaleOpeningHours(hours) {
     return hours.map(hour => {
       const beginningHour = hourToDate(hour.beginning);
       const endHour = hourToDate(hour.end);
-      const timeFormatter = getTimeFormatter();
+      const timeFormatter = getTimeFormatter({ hour: '2-digit', minute: '2-digit' });
       return {
         beginning: timeFormatter.format(beginningHour),
         end: timeFormatter.format(endHour),
@@ -61,7 +52,7 @@ function toLocaleOpeningHours(hours) {
 }
 
 function translateSchedule(days) {
-  const dayNameFormatter = Intl.DateTimeFormat(getIntlLocales(), { weekday: 'long' });
+  const dayNameFormatter = getTimeFormatter({ weekday: 'long' });
   const getDayName = dow => {
     /* 2018-01-01 is a Monday */
     return dayNameFormatter.format(new Date(2018, 0, dow));

--- a/src/libs/time.js
+++ b/src/libs/time.js
@@ -1,0 +1,10 @@
+function getIntlLocales() {
+  const lang = window.getLang();
+  const locales = [lang.locale].concat(lang.fallback || []);
+  // Intl expects '-' in locales, such as "en-GB"
+  return locales.map(l => l.replace(/_/g, '-'));
+}
+
+export function getTimeFormatter(format = {}) {
+  return Intl.DateTimeFormat(getIntlLocales(), format);
+}

--- a/src/libs/time.js
+++ b/src/libs/time.js
@@ -9,6 +9,6 @@ export function getTimeFormatter(format = {}) {
   return Intl.DateTimeFormat(getIntlLocales(), format);
 }
 
-export function stripTimeZone(utcString) {
-  return utcString.substring(0, 19);
+export function stripTimeZone(isoString) {
+  return isoString.substring(0, 19);
 }

--- a/src/libs/time.js
+++ b/src/libs/time.js
@@ -8,3 +8,7 @@ function getIntlLocales() {
 export function getTimeFormatter(format = {}) {
   return Intl.DateTimeFormat(getIntlLocales(), format);
 }
+
+export function stripTimeZone(utcString) {
+  return utcString.substring(0, 19);
+}

--- a/src/panel/direction/RouteStartEndTimes.jsx
+++ b/src/panel/direction/RouteStartEndTimes.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { getTimeFormatter } from 'src/libs/time';
+import { stripTimeZone, getTimeFormatter } from 'src/libs/time';
 
 const RouteStartEndTimes = ({ start, end, className }) => {
   if (!start || !end) {
@@ -12,7 +12,9 @@ const RouteStartEndTimes = ({ start, end, className }) => {
 
   return (
     <div className={cx('u-bold', className)}>
-      {timeFormatter.format(new Date(start))} - {timeFormatter.format(new Date(end))}
+      {timeFormatter.format(new Date(stripTimeZone(start)))}
+      {' - '}
+      {timeFormatter.format(new Date(stripTimeZone(end)))}
     </div>
   );
 };

--- a/src/panel/direction/RouteStartEndTimes.jsx
+++ b/src/panel/direction/RouteStartEndTimes.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+import { getTimeFormatter } from 'src/libs/time';
+
+const RouteStartEndTimes = ({ start, end, className }) => {
+  if (!start || !end) {
+    return null;
+  }
+
+  const timeFormatter = getTimeFormatter({ hour: '2-digit', minute: '2-digit' });
+
+  return (
+    <div className={cx('u-bold', className)}>
+      {timeFormatter.format(new Date(start))} - {timeFormatter.format(new Date(end))}
+    </div>
+  );
+};
+
+RouteStartEndTimes.propTypes = {
+  start: PropTypes.string,
+  end: PropTypes.string,
+};
+
+export default RouteStartEndTimes;

--- a/src/panel/direction/RouteSummary.jsx
+++ b/src/panel/direction/RouteSummary.jsx
@@ -28,12 +28,7 @@ const RouteSummary = ({
         selectRoute(id);
       }}
     >
-      <RouteSummaryInfo
-        isFastest={id === 0}
-        route={route}
-        vehicle={vehicle}
-        showDistance={vehicle !== 'publicTransport'}
-      />
+      <RouteSummaryInfo isFastest={id === 0} route={route} vehicle={vehicle} />
 
       {isActive && (
         <Button

--- a/src/panel/direction/RouteSummaryInfo.jsx
+++ b/src/panel/direction/RouteSummaryInfo.jsx
@@ -2,18 +2,25 @@
 import React from 'react';
 
 import RouteVia from './RouteVia';
+import RouteStartEndTimes from './RouteStartEndTimes';
 import { Badge } from 'src/components/ui';
 import { formatDuration, formatDistance } from 'src/libs/route_utils';
 
-const RouteSummaryInfo = ({ isFastest, route, vehicle, showDistance = false }) => (
+const RouteSummaryInfo = ({ isFastest, route, vehicle }) => (
   <div>
     <div className="u-text--title u-mb-xxxs route-summary-info-duration">
       {formatDuration(route.duration)}
     </div>
 
+    {vehicle === 'publicTransport' && (
+      <RouteStartEndTimes className="u-mb-xs" start={route.start_time} end={route.end_time} />
+    )}
+
     <RouteVia className="u-mb-xs" route={route} vehicle={vehicle} />
 
-    {showDistance && <Badge className="u-mr-xs">{formatDistance(route.distance)}</Badge>}
+    {vehicle !== 'publicTransport' && (
+      <Badge className="u-mr-xs">{formatDistance(route.distance)}</Badge>
+    )}
 
     {isFastest && <span className="u-text--subtitle">{_('Fastest route')}</span>}
   </div>


### PR DESCRIPTION
## Description
Use the new `start_time` and `end_time` fields provided by the API on public transport results to format and display them in the summary cards.

## Screenshots
|Before|After|
|---|---|
|![Screen%20Shot%202021-04-29%20at%2011 59 03](https://user-images.githubusercontent.com/243653/116534045-5bbb2a00-a8e2-11eb-8a7e-7f68ba9fc9ff.png)|![Screen%20Shot%202021-04-29%20at%2011 56 24](https://user-images.githubusercontent.com/243653/116534052-5d84ed80-a8e2-11eb-895d-a46a204776e7.png)|

