### PR TITLE
Fix non-working debounce on main Suggest

### DIFF
--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -61,6 +61,9 @@ const Suggest = ({
       close();
     };
 
+    // @WARNING: don't use anonymous functions as onClear/onChange props,
+    // otherwise this side-effect will be re-run at each render,
+    // recreating this each time so queries won't be properly debounced
     const fetchItems = debounce(value => {
       if (currentQuery) {
         currentQuery.abort();

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -265,6 +265,10 @@ export default class PanelManager extends React.Component {
     }
   };
 
+  setSearchQuery = searchQuery => {
+    this.setState({ searchQuery });
+  };
+
   render() {
     const { ActivePanel, options, panelSize, isSuggestOpen, searchQuery } = this.state;
     const { searchBarInputNode, searchBarOutputNode } = this.props;
@@ -277,7 +281,7 @@ export default class PanelManager extends React.Component {
           inputNode={searchBarInputNode}
           outputNode={searchBarOutputNode}
           withCategories
-          onChange={searchQuery => this.setState({ searchQuery })}
+          onChange={this.setSearchQuery}
           onOpen={() => this.setSuggestOpen(true)}
           onClose={() => this.setSuggestOpen(false)}
         />


### PR DESCRIPTION
## Description
Don't use an anonymous function as `onChange` prop on `Suggest`, so the `useEffect` hooks depending on it doesn't get rerun at each render.
This solves an issue where the query was run at each character instead of being debounced.
