### PR TITLE
QMAPS-2018 Add total walking time for public transport routes

### DIFF
--- a/src/panel/direction/RouteSummaryInfo.jsx
+++ b/src/panel/direction/RouteSummaryInfo.jsx
@@ -6,6 +6,19 @@ import RouteStartEndTimes from './RouteStartEndTimes';
 import { Badge } from 'src/components/ui';
 import { formatDuration, formatDistance } from 'src/libs/route_utils';
 
+const RouteWalkingTime = ({ route }) => {
+  const walkingTime = route.legs
+    .filter(leg => leg.mode === 'WALK')
+    .reduce((sum, leg) => sum + leg.duration, 0);
+
+  return (
+    <span className="u-text--subtitle u-mr-s">
+      <i className="icon-foot u-mr-xxs" style={{ fontSize: 11 }} />
+      {formatDuration(walkingTime)}
+    </span>
+  );
+};
+
 const RouteSummaryInfo = ({ isFastest, route, vehicle }) => (
   <div>
     <div className="u-text--title u-mb-xxxs route-summary-info-duration">
@@ -21,6 +34,8 @@ const RouteSummaryInfo = ({ isFastest, route, vehicle }) => (
     {vehicle !== 'publicTransport' && (
       <Badge className="u-mr-xs">{formatDistance(route.distance)}</Badge>
     )}
+
+    {vehicle === 'publicTransport' && <RouteWalkingTime route={route} />}
 
     {isFastest && <span className="u-text--subtitle">{_('Fastest route')}</span>}
   </div>


### PR DESCRIPTION
## Description
Add the total walking time in route summaries for public transport routes.

I'm not so sure about the design though… Seems to me it can be misleading to have the "Fastest route indication" so close, like it refers to this value.

![Capture d’écran de 2021-04-29 19-18-40](https://user-images.githubusercontent.com/243653/116592211-0867cc80-a920-11eb-87ff-a3c4517f9744.png)
