### PR TITLE
QMAPS-2124 Fix main search input behavior

### DIFF
--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -60,13 +60,9 @@ export default class PanelManager extends React.Component {
   }
 
   componentDidUpdate(_prevProps, prevState) {
-    const { ActivePanel, options, isSuggestOpen } = this.state;
+    const { ActivePanel, options } = this.state;
 
-    if (
-      prevState.ActivePanel !== ActivePanel ||
-      prevState.options !== options ||
-      prevState.isSuggestOpen !== isSuggestOpen
-    ) {
+    if (prevState.ActivePanel !== ActivePanel || prevState.options !== options) {
       // Not in a "list of PoI" context (options.poiFilters is null)
       if (isNullOrEmpty(options?.poiFilters)) {
         // Markers are not persistent

--- a/tests/integration/helpers/autocomplete.js
+++ b/tests/integration/helpers/autocomplete.js
@@ -1,5 +1,5 @@
 const SUGGEST_SELECTOR = '.autocomplete_suggestions li';
-const SEARCH_INPUT_SELECTOR = '#search';
+export const SEARCH_INPUT_SELECTOR = '#search';
 import { getInputValue } from '../tools';
 
 export default class AutocompleteHelper {

--- a/tests/integration/tests/autocomplete.desktop.js
+++ b/tests/integration/tests/autocomplete.desktop.js
@@ -1,5 +1,5 @@
 import { clearStore, initBrowser, getMapView, exists } from '../tools';
-import AutocompleteHelper from '../helpers/autocomplete';
+import AutocompleteHelper, { SEARCH_INPUT_SELECTOR } from '../helpers/autocomplete';
 import ResponseHandler from '../helpers/response_handler';
 const configBuilder = require('@qwant/nconf-builder');
 const config = configBuilder.get_without_check();
@@ -24,6 +24,24 @@ beforeEach(async () => {
   responseHandler = new ResponseHandler(page);
   await responseHandler.prepareResponse();
   responseHandler.addPreparedResponse(mockPoi, /places\/*/);
+});
+
+test('autofocus the field when typing anywhere', async () => {
+  await page.goto(APP_URL);
+  let isSearchFocused = await page.evaluate(
+    selector => document.activeElement.matches(selector),
+    SEARCH_INPUT_SELECTOR
+  );
+  expect(isSearchFocused).toEqual(false);
+
+  await page.keyboard.type('abcdefgh');
+  isSearchFocused = await page.evaluate(
+    selector => document.activeElement.matches(selector),
+    SEARCH_INPUT_SELECTOR
+  );
+  expect(isSearchFocused).toEqual(true);
+  const searchValue = await autocompleteHelper.getSearchInputValue();
+  expect(searchValue).toEqual('abcdefgh');
 });
 
 test('search and clear', async () => {


### PR DESCRIPTION
## Description
Remove a buggy side-effect introduced during the refacto in https://github.com/Qwant/erdapfel/pull/1070 which caused some focus behaviors of the main search bar to fail:
- the autofocus of the input when entering a first letter lost that first letter
- bluring the field cause its content to be cleared

I had added this while fighting with the back action in `updateTopBarReturnButton`, but using `onmousedown` solved the problem more reliably. I forgot to remove it.