### PR TITLE
Suggest clean-up and code refacto

### DIFF
--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -46,14 +46,9 @@ const Suggest = ({
     let currentQuery = null;
 
     const handleFocus = () => {
-      if (inputNode.value === '') {
+      if (inputNode.value === '' || isMobile) {
         setIsOpen(true);
-        fetchItems('');
-      } else {
-        if (isMobile) {
-          setIsOpen(true);
-          fetchItems(inputNode.value);
-        }
+        fetchItems(inputNode.value);
       }
     };
 

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -17,7 +17,6 @@ const Suggest = ({
   withCategories,
   withGeoloc,
   onSelect = selectItem,
-  onClear,
   onChange,
   className,
   onToggle,
@@ -88,17 +87,7 @@ const Suggest = ({
 
     const handleKeyDown = event => {
       if (event.key === 'Esc' || event.key === 'Escape') {
-        if (inputNode.value === '') {
-          close();
-        } else {
-          inputNode.value = '';
-          fetchItems('');
-          setIsOpen(true);
-
-          if (onClear) {
-            onClear();
-          }
-        }
+        close();
       }
     };
 
@@ -113,7 +102,7 @@ const Suggest = ({
       inputNode.removeEventListener('input', handleInput);
       inputNode.removeEventListener('keydown', handleKeyDown);
     };
-  }, [inputNode, onClear, isMobile, onChange, fetchItems]);
+  }, [inputNode, isMobile, onChange, fetchItems]);
 
   if (!isOpen) {
     return null;
@@ -150,7 +139,6 @@ Suggest.propTypes = {
   withCategories: bool,
   withGeoloc: bool,
   onSelect: func,
-  onClear: func,
   onToggle: func,
   onChange: func,
   className: string,

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -102,10 +102,10 @@ const Suggest = ({
           inputNode.value = '';
           fetchItems('');
           setIsOpen(true);
-        }
 
-        if (onClear) {
-          onClear();
+          if (onClear) {
+            onClear();
+          }
         }
       }
     };

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -24,7 +24,6 @@ const Suggest = ({
   const [items, setItems] = useState([]);
   const [isOpen, setIsOpen] = useState(false);
   const [lastQuery, setLastQuery] = useState('');
-  const [isLoading, setIsLoading] = useState(true);
   const { isMobile } = useDevice();
 
   const close = () => {
@@ -64,7 +63,6 @@ const Suggest = ({
         currentQuery.abort();
       }
 
-      setIsLoading(true);
       const query = fetchSuggests(value, {
         withCategories,
       });
@@ -76,7 +74,6 @@ const Suggest = ({
         .then(items => {
           setItems(items);
           currentQuery = null;
-          setIsLoading(false);
         })
         .catch(() => {
           /* Query aborted. Just ignore silently */
@@ -131,7 +128,6 @@ const Suggest = ({
     <SuggestsDropdown
       className={className}
       suggestItems={items}
-      isLoading={isLoading}
       onHighlight={item => {
         if (!item) {
           inputNode.value = lastQuery;
@@ -147,7 +143,6 @@ const Suggest = ({
           onSelect(item, { query: inputNode.value });
         }
       }}
-      onClear={onClear}
     />
   );
 

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -96,7 +96,7 @@ const Suggest = ({
 
     const handleKeyDown = async event => {
       if (event.key === 'Esc' || event.key === 'Escape') {
-        if (inputNode.value === '' && !isMobile) {
+        if (inputNode.value === '') {
           close();
         } else {
           inputNode.value = '';

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -86,7 +86,7 @@ const Suggest = ({
       }
     };
 
-    const handleKeyDown = async event => {
+    const handleKeyDown = event => {
       if (event.key === 'Esc' || event.key === 'Escape') {
         if (inputNode.value === '') {
           close();

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -18,8 +18,7 @@ const Suggest = ({
   onClear,
   onChange,
   className,
-  onClose,
-  onOpen,
+  onToggle,
 }) => {
   const [items, setItems] = useState([]);
   const [isOpen, setIsOpen] = useState(false);
@@ -32,14 +31,10 @@ const Suggest = ({
   };
 
   useEffect(() => {
-    if (onClose && !isOpen) {
-      onClose();
+    if (onToggle) {
+      onToggle(isOpen);
     }
-
-    if (onOpen && isOpen) {
-      onOpen();
-    }
-  }, [isOpen, onClose, onOpen]);
+  }, [isOpen, onToggle]);
 
   useEffect(() => {
     let currentQuery = null;
@@ -156,8 +151,7 @@ Suggest.propTypes = {
   withGeoloc: bool,
   onSelect: func,
   onClear: func,
-  onOpen: func,
-  onClose: func,
+  onToggle: func,
   onChange: func,
   className: string,
 };

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -36,6 +36,7 @@ const Suggest = ({
     }
   }, [isOpen, onToggle]);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const fetchItems = useCallback(
     debounce(value => {
       if (currentQuery) {

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -17,7 +17,6 @@ const Suggest = ({
   withCategories,
   withGeoloc,
   onSelect = selectItem,
-  onChange,
   className,
   onToggle,
 }) => {
@@ -79,10 +78,6 @@ const Suggest = ({
       fetchItems(value);
       setIsOpen(true);
       setLastQuery(value);
-
-      if (onChange) {
-        onChange(value);
-      }
     };
 
     const handleKeyDown = event => {
@@ -102,7 +97,7 @@ const Suggest = ({
       inputNode.removeEventListener('input', handleInput);
       inputNode.removeEventListener('keydown', handleKeyDown);
     };
-  }, [inputNode, isMobile, onChange, fetchItems]);
+  }, [inputNode, isMobile, fetchItems]);
 
   if (!isOpen) {
     return null;
@@ -140,7 +135,6 @@ Suggest.propTypes = {
   withGeoloc: bool,
   onSelect: func,
   onToggle: func,
-  onChange: func,
   className: string,
 };
 

--- a/src/components/ui/SuggestsDropdown.jsx
+++ b/src/components/ui/SuggestsDropdown.jsx
@@ -29,7 +29,9 @@ const SuggestsDropdown = ({ className = '', suggestItems, onSelect, onHighlight 
 
       if (key === 'ArrowUp') {
         e.preventDefault(); // prevent cursor returning at beggining
-        newHighlighted = suggestItems[suggestItems.indexOf(highlighted) - 1] || null;
+        newHighlighted = !highlighted
+          ? suggestItems[suggestItems.length - 1]
+          : suggestItems[suggestItems.indexOf(highlighted) - 1] || null;
       }
 
       setHighlighted(newHighlighted);

--- a/src/components/ui/SuggestsDropdown.jsx
+++ b/src/components/ui/SuggestsDropdown.jsx
@@ -11,37 +11,29 @@ const SuggestsDropdown = ({ className = '', suggestItems, onSelect, onHighlight 
     const keyDownHandler = e => {
       const { key } = e;
 
-      if (key === 'ArrowDown') {
-        const h = highlighted === null ? -1 : highlighted;
-
-        if (h < suggestItems.length - 1) {
-          setHighlighted(h + 1);
-          onHighlight(suggestItems[h + 1]);
-        } else {
-          setHighlighted(null);
-          onHighlight(null);
+      if (key === 'Enter') {
+        if (highlighted !== null) {
+          e.preventDefault(); // prevent search input submit with its current content (highlighted POI name)
+          onSelect(highlighted);
         }
+      }
+
+      if (key !== 'ArrowDown' && key !== 'ArrowUp') {
+        return;
+      }
+
+      let newHighlighted;
+      if (key === 'ArrowDown') {
+        newHighlighted = suggestItems[suggestItems.indexOf(highlighted) + 1] || null;
       }
 
       if (key === 'ArrowUp') {
         e.preventDefault(); // prevent cursor returning at beggining
-        const h = highlighted === null ? suggestItems.length : highlighted;
-
-        if (h > 0) {
-          setHighlighted(h - 1);
-          onHighlight(suggestItems[h - 1]);
-        } else {
-          setHighlighted(null);
-          onHighlight(null);
-        }
+        newHighlighted = suggestItems[suggestItems.indexOf(highlighted) - 1] || null;
       }
 
-      if (key === 'Enter') {
-        if (highlighted !== null) {
-          e.preventDefault(); // prevent search input submit with its current content (highlighted POI name)
-          onSelect(suggestItems[highlighted]);
-        }
-      }
+      setHighlighted(newHighlighted);
+      onHighlight(newHighlighted);
     };
 
     document.addEventListener('keydown', keyDownHandler);
@@ -53,18 +45,18 @@ const SuggestsDropdown = ({ className = '', suggestItems, onSelect, onHighlight 
 
   return (
     <ul className={classnames('autocomplete_suggestions', className)}>
-      {suggestItems.map((suggest, index) => (
+      {suggestItems.map((suggestItem, index) => (
         <li
           key={index}
           onMouseDown={() => {
-            onSelect(suggestItems[index]);
+            onSelect(suggestItem);
           }}
           onMouseEnter={() => {
-            setHighlighted(index);
+            setHighlighted(suggestItem);
           }}
-          className={classnames({ selected: highlighted === index })}
+          className={classnames({ selected: highlighted === suggestItem })}
         >
-          <SuggestItem item={suggest} />
+          <SuggestItem item={suggestItem} />
         </li>
       ))}
     </ul>

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -248,6 +248,8 @@ export default class PanelManager extends React.Component {
       } else {
         topBarHandle.classList.remove('top_bar--search_filled');
       }
+
+      this.setState({ searchQuery: value });
     });
   }
 
@@ -259,10 +261,6 @@ export default class PanelManager extends React.Component {
     if (this.state.isSuggestOpen !== isOpen) {
       this.setState({ isSuggestOpen: isOpen });
     }
-  };
-
-  setSearchQuery = searchQuery => {
-    this.setState({ searchQuery });
   };
 
   render() {
@@ -277,7 +275,6 @@ export default class PanelManager extends React.Component {
           inputNode={searchBarInputNode}
           outputNode={searchBarOutputNode}
           withCategories
-          onChange={this.setSearchQuery}
           onToggle={this.setSuggestOpen}
         />
 

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -278,8 +278,7 @@ export default class PanelManager extends React.Component {
           outputNode={searchBarOutputNode}
           withCategories
           onChange={this.setSearchQuery}
-          onOpen={() => this.setSuggestOpen(true)}
-          onClose={() => this.setSuggestOpen(false)}
+          onToggle={this.setSuggestOpen}
         />
 
         <PanelContext.Provider value={{ size: panelSize, setSize: this.setPanelSize }}>

--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -150,7 +150,6 @@ class DirectionInput extends React.Component {
             outputNode={document.getElementById('direction-autocomplete_suggestions')}
             withGeoloc={withGeoloc}
             onSelect={this.selectItem}
-            onClear={this.removePoint}
           />
         )}
       </div>


### PR DESCRIPTION
## Description
Multiple simplifications and clean-up in the `<Suggest>` and `<SuggestDropDown>` components.

**Best reviewed commit by commit**

(Another thing I wanted to add was to entirely remove the keyboard management from SuggestDropDown to merge it with the handlers already defined in Suggest, but I still have some problems with it, will make another separate PR later :))

## Why
The `<Suggest>` component has always been a pain point and a big source of bugs. It has a complex life cycle due to a lot of specific UX stuffs and still imperative DOM manipulation of the input fied.
This PR tries to remove part of the complexity with simpler code and better isolation of side-effects.
