### PR TITLE
QMAPS-2113 use qwant's "l" laguage cookie

### DIFF
--- a/bin/app.js
+++ b/bin/app.js
@@ -12,6 +12,8 @@ const getReqSerializer = require('./serializers/request');
 const cookieParser = require('cookie-parser');
 
 const app = express();
+app.use(cookieParser());
+
 const promRegistry = new promClient.Registry();
 
 function App(config) {
@@ -156,8 +158,6 @@ function App(config) {
       onerror: req.logger.error({ err }),
     })(err);
   });
-
-  app.use(cookieParser());
 }
 
 App.prototype.start = function (port) {

--- a/bin/app.js
+++ b/bin/app.js
@@ -9,6 +9,7 @@ const fakePbf = require('./middlewares/fake_pbf/index');
 const compression = require('compression');
 const mapStyle = require('./middlewares/map_style');
 const getReqSerializer = require('./serializers/request');
+const cookieParser = require('cookie-parser');
 
 const app = express();
 const promRegistry = new promClient.Registry();
@@ -155,6 +156,8 @@ function App(config) {
       onerror: req.logger.error({ err }),
     })(err);
   });
+
+  app.use(cookieParser());
 }
 
 App.prototype.start = function (port) {

--- a/bin/middlewares/user_language.js
+++ b/bin/middlewares/user_language.js
@@ -12,7 +12,7 @@ module.exports = function (languageConfig) {
     // If cookie "l" is set and corresponds to a supported language, use it
     if (req.cookies && req.cookies.l) {
       language = supportedLanguages.find(lang => lang.code === req.cookies.l);
-      if(language){
+      if (language) {
         res.locals.language = language;
       }
     }

--- a/bin/middlewares/user_language.js
+++ b/bin/middlewares/user_language.js
@@ -7,7 +7,14 @@ module.exports = function (languageConfig) {
   const supportedLanguages = languageConfig.supportedLanguages;
   return function (req, res, next) {
     const langHeaders = req.acceptsLanguages();
-    if (langHeaders) {
+
+    // If cookie "l" is set and corresponds to a supported language, use it
+    if (req.cookies && req.cookies.l) {
+      res.locals.language = supportedLanguages.find(lang => lang.code === req.cookies.l);
+    }
+
+    // Else, fallback to the first accepted language in the headers
+    else if (langHeaders) {
       langHeaders.some(acceptedLocale => {
         let language = supportedLanguages.find(lang => {
           const supportedLocale = lang.locale.replace(/_/g, '-');
@@ -25,9 +32,11 @@ module.exports = function (languageConfig) {
         }
       });
     }
-    /* no supported language -> set default language */
+
+    // Else, use default language
     if (!res.locals.language) {
       res.locals.language = languageConfig.defaultLanguage;
+      console.log(1, res.locals.language);
     }
     next();
   };

--- a/bin/middlewares/user_language.js
+++ b/bin/middlewares/user_language.js
@@ -36,7 +36,6 @@ module.exports = function (languageConfig) {
     // Else, use default language
     if (!res.locals.language) {
       res.locals.language = languageConfig.defaultLanguage;
-      console.log(1, res.locals.language);
     }
     next();
   };

--- a/bin/middlewares/user_language.js
+++ b/bin/middlewares/user_language.js
@@ -7,16 +7,20 @@ module.exports = function (languageConfig) {
   const supportedLanguages = languageConfig.supportedLanguages;
   return function (req, res, next) {
     const langHeaders = req.acceptsLanguages();
+    let language;
 
     // If cookie "l" is set and corresponds to a supported language, use it
     if (req.cookies && req.cookies.l) {
-      res.locals.language = supportedLanguages.find(lang => lang.code === req.cookies.l);
+      language = supportedLanguages.find(lang => lang.code === req.cookies.l);
+      if(language){
+        res.locals.language = language;
+      }
     }
 
     // Else, fallback to the first accepted language in the headers
-    else if (langHeaders) {
+    if (!res.locals.language && langHeaders) {
       langHeaders.some(acceptedLocale => {
-        let language = supportedLanguages.find(lang => {
+        language = supportedLanguages.find(lang => {
           const supportedLocale = lang.locale.replace(/_/g, '-');
           return supportedLocale === acceptedLocale;
         });
@@ -27,8 +31,7 @@ module.exports = function (languageConfig) {
         }
         if (language) {
           res.locals.language = language;
-          /* language found we interrupt array.some */
-          return true;
+          return true; // interrupt Array.some when a language is found
         }
       });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "classnames": "^2.2.6",
         "color": "^3.1.2",
         "compression": "^1.7.3",
+        "cookie-parser": "^1.4.5",
         "dotenv": "^8.2.0",
         "ejs": "^2.6.1",
         "express": "^4.16.3",
@@ -5367,6 +5368,18 @@
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
+      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
+      "dependencies": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/cookie-signature": {
@@ -23973,6 +23986,15 @@
     "cookie": {
       "version": "0.4.0",
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+    },
+    "cookie-parser": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
+      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
+      "requires": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6"
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "classnames": "^2.2.6",
     "color": "^3.1.2",
     "compression": "^1.7.3",
+    "cookie-parser": "^1.4.5",
     "dotenv": "^8.2.0",
     "ejs": "^2.6.1",
     "express": "^4.16.3",

--- a/tests/integration/tests/home.js
+++ b/tests/integration/tests/home.js
@@ -33,6 +33,36 @@ test('is map loaded', async () => {
   expect(await exists(page, '.mapboxgl-canvas')).toBeTruthy();
 });
 
+test('Use FR language setting from Qwant Search cookie', async () => {
+  await page.goto(APP_URL);
+  await page.setCookie({name: 'l', value: 'fr'});
+  await page.reload();
+  const preferedLanguage = page.evaluate(()=>{
+    return preferedLanguage
+  })
+  expect(preferedLanguage.code).toEqual('fr');
+});
+
+test('Use default language setting when Qwant Search cookie is not supported', async () => {
+  await page.goto(APP_URL);
+  await page.setCookie({name: 'l', value: 'ko'});
+  await page.reload();
+  const preferedLanguage = page.evaluate(()=>{
+    return preferedLanguage
+  })
+  expect(preferedLanguage.code).toEqual('en');
+});
+
+test('Use default language when no Qwant Search cookie is set', async () => {
+  await page.goto(APP_URL);
+  await page.deleteCookie({name: 'l'});
+  await page.reload();
+  const preferedLanguage = page.evaluate(()=>{
+    return preferedLanguage
+  })
+  expect(preferedLanguage.code).toEqual('en');
+});
+
 afterEach(async () => {
   await page.close();
 });

--- a/tests/integration/tests/home.js
+++ b/tests/integration/tests/home.js
@@ -37,9 +37,7 @@ test('Use FR language setting from Qwant Search cookie', async () => {
   await page.goto(APP_URL);
   await page.setCookie({ name: 'l', value: 'fr' });
   await page.reload();
-  const preferedLanguage = page.evaluate(() => {
-    return preferedLanguage;
-  });
+  const preferedLanguage = await page.evaluate('window.preferedLanguage');
   expect(preferedLanguage.code).toEqual('fr');
 });
 
@@ -47,9 +45,7 @@ test('Use default language setting when Qwant Search cookie is not supported', a
   await page.goto(APP_URL);
   await page.setCookie({ name: 'l', value: 'ko' });
   await page.reload();
-  const preferedLanguage = page.evaluate(() => {
-    return preferedLanguage;
-  });
+  const preferedLanguage = await page.evaluate('window.preferedLanguage');
   expect(preferedLanguage.code).toEqual('en');
 });
 
@@ -57,9 +53,7 @@ test('Use default language when no Qwant Search cookie is set', async () => {
   await page.goto(APP_URL);
   await page.deleteCookie({ name: 'l' });
   await page.reload();
-  const preferedLanguage = page.evaluate(() => {
-    return preferedLanguage;
-  });
+  const preferedLanguage = await page.evaluate('window.preferedLanguage');
   expect(preferedLanguage.code).toEqual('en');
 });
 

--- a/tests/integration/tests/home.js
+++ b/tests/integration/tests/home.js
@@ -35,31 +35,31 @@ test('is map loaded', async () => {
 
 test('Use FR language setting from Qwant Search cookie', async () => {
   await page.goto(APP_URL);
-  await page.setCookie({name: 'l', value: 'fr'});
+  await page.setCookie({ name: 'l', value: 'fr' });
   await page.reload();
-  const preferedLanguage = page.evaluate(()=>{
-    return preferedLanguage
-  })
+  const preferedLanguage = page.evaluate(() => {
+    return preferedLanguage;
+  });
   expect(preferedLanguage.code).toEqual('fr');
 });
 
 test('Use default language setting when Qwant Search cookie is not supported', async () => {
   await page.goto(APP_URL);
-  await page.setCookie({name: 'l', value: 'ko'});
+  await page.setCookie({ name: 'l', value: 'ko' });
   await page.reload();
-  const preferedLanguage = page.evaluate(()=>{
-    return preferedLanguage
-  })
+  const preferedLanguage = page.evaluate(() => {
+    return preferedLanguage;
+  });
   expect(preferedLanguage.code).toEqual('en');
 });
 
 test('Use default language when no Qwant Search cookie is set', async () => {
   await page.goto(APP_URL);
-  await page.deleteCookie({name: 'l'});
+  await page.deleteCookie({ name: 'l' });
   await page.reload();
-  const preferedLanguage = page.evaluate(()=>{
-    return preferedLanguage
-  })
+  const preferedLanguage = page.evaluate(() => {
+    return preferedLanguage;
+  });
   expect(preferedLanguage.code).toEqual('en');
 });
 

--- a/tests/integration/tests/home.js
+++ b/tests/integration/tests/home.js
@@ -9,6 +9,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   page = await browser.newPage();
+  page.setExtraHTTPHeaders({ 'Accept-Language': 'en' });
 });
 
 test('redirect unsupported browsers to dedicated page', async () => {


### PR DESCRIPTION
## Description
- Use Qwant's "l=..." cookie (if possible) as the interface language of Qwant Maps
- Fallback on the first available/useable language in the accepted-languages browser header (same as before)
- Fallback on Qwant Maps default language if nothing fits (same as before)

## Why
Better coherence with Qwant.com settings
