### PR TITLE
QMAPS-1926 Allow scroll in suggest on iOS

### DIFF
--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -11,6 +11,7 @@ import { selectItem, fetchSuggests } from 'src/libs/suggest';
 const MAPBOX_RESERVED_KEYS = ['ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown', '-', '+', '='];
 
 const TopBar = ({ value, setUserInputValue, inputRef, onSuggestToggle, backButtonAction }) => {
+  const barElement = useRef(null);
   const suggestElement = useRef(null);
   const [focused, setFocused] = useState(false);
   const { isMobile } = useDevice();
@@ -73,6 +74,18 @@ const TopBar = ({ value, setUserInputValue, inputRef, onSuggestToggle, backButto
     window.app.navigateTo('/');
   };
 
+  // this insures the top bar cannot trigger a whole body scroll on iOS
+  useEffect(() => {
+    if (isMobile) {
+      const bar = barElement.current;
+      const cancelTouchScroll = e => e.preventDefault();
+      bar.addEventListener('touchmove', cancelTouchScroll);
+      return () => {
+        bar.removeEventListener('touchmove', cancelTouchScroll);
+      };
+    }
+  }, [isMobile, barElement]);
+
   return (
     <div
       className={cx('top_bar', {
@@ -81,7 +94,7 @@ const TopBar = ({ value, setUserInputValue, inputRef, onSuggestToggle, backButto
         ['top_bar--back_action']: !!backButtonAction,
       })}
     >
-      <form onSubmit={() => false} noValidate className="search_form">
+      <form onSubmit={() => false} noValidate className="search_form" ref={barElement}>
         <button
           type="button"
           onClick={() => {

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -109,8 +109,20 @@ const Suggest = ({
       // Giving a fixed height to the container makes the content scrollable
       outputNode.style.height = window.visualViewport.height - TOP_BAR_HEIGHT + 'px';
 
+      const suggestions = document.querySelector('.autocomplete_suggestions');
+      const cancelTouchScrollIfNotOverflow = e => {
+        const hasOverflow =
+          suggestions &&
+          suggestions.getBoundingClientRect().height > outputNode.getBoundingClientRect().height;
+        if (!hasOverflow) {
+          e.preventDefault();
+        }
+      };
+      outputNode.addEventListener('touchmove', cancelTouchScrollIfNotOverflow);
+
       return () => {
         outputNode.style.height = 'auto';
+        outputNode.removeEventListener('touchmove', cancelTouchScrollIfNotOverflow);
       };
     }
   }, [isMobile, items, dropdownVisible, outputNode]);

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useCallback } from 'react';
 import ReactDOM from 'react-dom';
 import debounce from 'lodash.debounce';
 import { bool, string, func, object } from 'prop-types';
-
+import { useDevice } from 'src/hooks';
 import SuggestsDropdown from 'src/components/ui/SuggestsDropdown';
 import { fetchSuggests, getInputValue, modifyList } from 'src/libs/suggest';
 
@@ -25,6 +25,7 @@ const Suggest = ({
   const [highlighted, setHighlighted] = useState(null);
   const [hasFocus, setHasFocus] = useState(false);
   const dropdownVisible = hasFocus && isOpen && outputNode;
+  const { isMobile } = useDevice();
 
   const close = () => {
     setIsOpen(false);
@@ -100,6 +101,19 @@ const Suggest = ({
         );
     }
   };
+
+  useEffect(() => {
+    if (isMobile && dropdownVisible && window.visualViewport) {
+      const TOP_BAR_HEIGHT = 60;
+      // visualViewport.height is the real visible height, not including the virtual keyboard.
+      // Giving a fixed height to the container makes the content scrollable
+      outputNode.style.height = window.visualViewport.height - TOP_BAR_HEIGHT + 'px';
+
+      return () => {
+        outputNode.style.height = 'auto';
+      };
+    }
+  }, [isMobile, items, dropdownVisible, outputNode]);
 
   return (
     <>

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -107,10 +107,14 @@ const Suggest = ({
     // in particular taking the virtual keyboard into account.
     // See https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API
     if (isMobile && dropdownVisible && window.visualViewport) {
-      const TOP_BAR_HEIGHT = 60;
-      // visualViewport.height is the real visible height, not including the virtual keyboard.
-      // Giving a fixed height to the container makes the content scrollable
-      outputNode.style.height = window.visualViewport.height - TOP_BAR_HEIGHT + 'px';
+      const setDropdownFixedHeight = () => {
+        const TOP_BAR_HEIGHT = 60;
+        // visualViewport.height is the real visible height, not including the virtual keyboard.
+        // Giving a fixed height to the container makes the content scrollable
+        outputNode.style.height = window.visualViewport.height - TOP_BAR_HEIGHT + 'px';
+      };
+      setDropdownFixedHeight();
+      visualViewport.addEventListener('resize', setDropdownFixedHeight);
 
       const suggestions = document.querySelector('.autocomplete_suggestions');
       const cancelTouchScrollIfNotOverflow = e => {
@@ -125,6 +129,7 @@ const Suggest = ({
 
       return () => {
         outputNode.style.height = 'auto';
+        visualViewport.removeEventListener('resize', setDropdownFixedHeight);
         outputNode.removeEventListener('touchmove', cancelTouchScrollIfNotOverflow);
       };
     }

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -103,6 +103,9 @@ const Suggest = ({
   };
 
   useEffect(() => {
+    // If available we use the Visual Viewport API, which informs about the visible page area,
+    // in particular taking the virtual keyboard into account.
+    // See https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API
     if (isMobile && dropdownVisible && window.visualViewport) {
       const TOP_BAR_HEIGHT = 60;
       // visualViewport.height is the real visible height, not including the virtual keyboard.

--- a/src/scss/includes/direction-panel.scss
+++ b/src/scss/includes/direction-panel.scss
@@ -37,7 +37,7 @@
       top: 64px;
       width: 100vw;
       background-color: $background;
-      overflow-y: scroll;
+      overflow-y: auto;
     }
   }
 

--- a/src/scss/includes/direction-panel.scss
+++ b/src/scss/includes/direction-panel.scss
@@ -36,6 +36,8 @@
       position: fixed;
       top: 64px;
       width: 100vw;
+      background-color: $background;
+      overflow-y: scroll;
     }
   }
 

--- a/src/scss/includes/direction.scss
+++ b/src/scss/includes/direction.scss
@@ -311,10 +311,6 @@ button.direction_shortcut {
     }
   }
 
-  .autocomplete_suggestions {
-    height: 100vh;
-  }
-
   // Step by step mobile view
   .itinerary_mobile_step_by_step {
 

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -222,7 +222,7 @@ input[type="search"] {
 
   .search_form__result {
     background-color: $background;
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 
   $formWidthTransitionDuration: .3s;

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -220,8 +220,9 @@ input[type="search"] {
     display: none;
   }
 
-  .top_bar .autocomplete_suggestions {
-    height: 100vh;
+  .search_form__result {
+    background-color: $background;
+    overflow-y: scroll;
   }
 
   $formWidthTransitionDuration: .3s;

--- a/src/scss/includes/z_index.scss
+++ b/src/scss/includes/z_index.scss
@@ -26,10 +26,6 @@
   z-index: 2;
 }
 
-.autocomplete_suggestions {
-  z-index: 999;
-}
-
 .top_bar {
   z-index: 2;
 }


### PR DESCRIPTION
## Description
Make it possible to scroll suggest results on iOS.
Previously, the whole page content scrolled. This was due to the virtual keyboard on iOS browsers not changing the viewport height. As a result, the list of suggestions fit entirely on the screen height (even if half of it was behind the keyboard) so it wasn't scrollable.
Here, we use a recent web API, [Visual Viewport](https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API), which is supported in Safari 13+ and gives access to the real visible height, without the space taken by the keyboard. We use it to give a fixed height to the suggest list, so it becomes scrollable.

We also have to manage the case of an empty list or a list too small to be scrollable. In that case, the dropdown background element will scroll the page like before. So there is a special test for that to detect if the suggestions overflow their container or not. If not, we simply cancel any `touchmove` action.

|Before|After|
|---|---|
|https://user-images.githubusercontent.com/243653/119379835-41e1ec80-bcc0-11eb-888d-1c59b814256f.MOV|https://user-images.githubusercontent.com/243653/119379907-532af900-bcc0-11eb-9a70-ebfedb19da74.MOV|
