### PR TITLE
Fulltext query: use specialized `search` enpoint

### DIFF
--- a/bin/middlewares/fullText_query.js
+++ b/bin/middlewares/fullText_query.js
@@ -10,7 +10,7 @@ module.exports = function (config) {
   }
 
   const idunnBaseUrl = config.server.services.idunn.url || config.services.idunn.url;
-  const geocoderUrl = idunnBaseUrl + '/v1/autocomplete';
+  const geocoderUrl = idunnBaseUrl + '/v1/search';
   const useNlu = config.services.geocoder.useNlu;
 
   const categories = yaml.readSync('../../config/categories.yml');

--- a/tests/__data__/search_type.json
+++ b/tests/__data__/search_type.json
@@ -1,0 +1,118 @@
+{
+  "type": "FeatureCollection",
+  "geocoding": {"version": "0.1.0", "query": ""},
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "coordinates": [
+          4.359352,
+          43.84274
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "geocoding": {
+          "id": "addr:4.359352;43.84274",
+          "type": "house",
+          "label": "37 Rue Robert (Nîmes)",
+          "name": "37 Rue Robert",
+          "housenumber": "37",
+          "street": "Rue Robert",
+          "postcode": "30000",
+          "city": "Nîmes",
+          "citycode": "30189",
+          "administrative_regions": [
+            {
+              "id": "admin:osm:relation:2202162",
+              "insee": "",
+              "level": 2,
+              "label": "France",
+              "name": "France",
+              "zip_codes": [],
+              "weight": 0.015618298409952112,
+              "coord": {
+                "lon": 2.3514992,
+                "lat": 48.8566101
+              },
+              "bbox": [
+                -5.4534286,
+                41.2632185,
+                9.8678344,
+                51.268318
+              ],
+              "admin_type": "Unknown",
+              "zone_type": "country"
+            },
+            {
+              "id": "admin:osm:relation:3792883",
+              "insee": "76",
+              "level": 4,
+              "label": "Occitanie, France",
+              "name": "Occitanie",
+              "zip_codes": [],
+              "weight": 0.0030751822769848129,
+              "coord": {
+                "lon": 1.4442469,
+                "lat": 43.6044622
+              },
+              "bbox": [
+                -0.3272334,
+                42.3327551,
+                4.8455335,
+                45.0466382
+              ],
+              "admin_type": "Unknown",
+              "zone_type": "state"
+            },
+            {
+              "id": "admin:osm:relation:7461",
+              "insee": "30",
+              "level": 6,
+              "label": "Gard, Occitanie, France",
+              "name": "Gard",
+              "zip_codes": [],
+              "weight": 0.000989824164894286,
+              "coord": {
+                "lon": 4.3600687,
+                "lat": 43.8374249
+              },
+              "bbox": [
+                3.2618961,
+                43.460197,
+                4.8455335,
+                44.4596601
+              ],
+              "admin_type": "Unknown",
+              "zone_type": "state_district"
+            },
+            {
+              "id": "admin:osm:relation:378685",
+              "insee": "30189",
+              "level": 8,
+              "label": "Nîmes (30000-30900), Gard, Occitanie, France",
+              "name": "Nîmes",
+              "zip_codes": [
+                "30000",
+                "30900"
+              ],
+              "weight": 0.000989824164894286,
+              "coord": {
+                "lon": 4.3600687,
+                "lat": 43.8374249
+              },
+              "bbox": [
+                4.235670799999999,
+                43.7412659,
+                4.4496605,
+                43.9230177
+              ],
+              "admin_type": "City",
+              "zone_type": "city"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/integration/server_start.js
+++ b/tests/integration/server_start.js
@@ -29,26 +29,26 @@ nock(/idunn_test\.test/)
   .get(/osm:way:2403/)
   .reply(404);
 
-const noResultAutocomplete = require('../__data__/autocomplete_empty.json');
+const noResultSearch = require('../__data__/autocomplete_empty.json');
 nock(/idunn_test\.test/)
   .persist(true)
-  .get('/v1/autocomplete')
+  .get('/v1/search')
   .query(params => params.q === 'gibberish')
-  .reply(200, JSON.stringify(noResultAutocomplete));
+  .reply(200, JSON.stringify(noResultSearch));
 
-const intentionAutocomplete = require('../__data__/autocomplete_nlu.json');
+const intentionSearch = require('../__data__/autocomplete_nlu.json');
 nock(/idunn_test\.test/)
   .persist(true)
-  .get('/v1/autocomplete')
+  .get('/v1/search')
   .query(params => params.q === 'restonice')
-  .reply(200, JSON.stringify(intentionAutocomplete));
+  .reply(200, JSON.stringify(intentionSearch));
 
-const noIntentionAutocomplete = require('../__data__/autocomplete_type.json');
+const noIntentionSearch = require('../__data__/search_type.json');
 nock(/idunn_test\.test/)
   .persist(true)
-  .get('/v1/autocomplete')
+  .get('/v1/search')
   .query(params => params.q === 'single')
-  .reply(200, JSON.stringify(noIntentionAutocomplete));
+  .reply(200, JSON.stringify(noIntentionSearch));
 
 global.appServer = new App(config);
 

--- a/tests/integration/tests/server.js
+++ b/tests/integration/tests/server.js
@@ -163,7 +163,8 @@ describe('Full text queries (?q= param)', () => {
       .expect(res => {
         const redirectUrl = res.get('Location');
         const [_, poiID] = /\/place\/([^?]*)/.exec(redirectUrl) || [];
-        if (poiID !== '110401125') throw new Error(`Bad POI redirection ${redirectUrl}`);
+        if (poiID !== 'addr:4.359352;43.84274')
+          throw new Error(`Bad POI redirection ${redirectUrl}`);
       })
       .end(done);
   });


### PR DESCRIPTION
## Description
Use the new endpoint `search` introduced in Idunn by https://github.com/Qwant/idunn/pull/224 (and enriched by https://github.com/Qwant/idunn/pull/226) intended to give more relevant results when the `maps` tab is clicked from Qwant search.

This new endpoints has the exact same input/output format as `autocomplete` except that its result will contain at most one item, which should have passed more quality checks than the first result of a regular autocomplete query.

## Screenshots
Typically, when searching "rue de Rennes, Paris", the first result was "rue de Paris, Rennes", the new endpoints introduces some validation on the order of the queries.
| [https://localhost:3000?q=rue de Rennes, Paris](https://localhost:3000?q=rue%20de%20Rennes,%20Paris) | [https://www.qwant.com/maps?q=rue de Rennes, Paris](https://www.qwant.com/maps?q=rue%20de%20Rennes,%20Paris) |
|---|---|
| ![Screen Shot 2021-05-18 at 11 01 06](https://user-images.githubusercontent.com/1173464/118462885-71f92080-b6ff-11eb-9a4c-fbf3f56e91e5.png) | ![Screen Shot 2021-05-18 at 11 01 10](https://user-images.githubusercontent.com/1173464/118463029-97862a00-b6ff-11eb-8ecc-58628632c8e3.png) |
