### PR TITLE
Convert PanelManager to a functional component

### DIFF
--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -177,26 +177,16 @@ const PanelManager = ({ router }) => {
 
   const backToList = (e, poiFilters) => {
     e.stopPropagation();
-    const queryObject = {};
-    const mappingParams = {
-      query: 'q',
-      category: 'type',
+    const { query, category, ...rest } = poiFilters;
+    const queryObject = {
+      q: query,
+      type: category,
+      ...rest,
     };
-
-    for (const name in poiFilters) {
-      if (!poiFilters[name]) {
-        continue;
-      }
-      const key = mappingParams[name];
-      queryObject[key || name] = poiFilters[name];
-    }
-
-    const params = buildQueryString(queryObject);
-    const uri = `/places/${params}`;
 
     Telemetry.add(Telemetry.POI_BACKTOLIST);
     fire('restore_location');
-    window.app.navigateTo(uri);
+    window.app.navigateTo(`/places/${buildQueryString(queryObject)}`);
   };
 
   const backToFavorite = e => {

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -1,6 +1,5 @@
-import React from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import nconf from '@qwant/nconf-getter';
 import FavoritesPanel from './favorites/FavoritesPanel';
 import PoiPanel from './poi/PoiPanel';
 import ServicePanel from './service/ServicePanel';
@@ -9,93 +8,174 @@ import DirectionPanel from 'src/panel/direction/DirectionPanel';
 import Telemetry from 'src/libs/telemetry';
 import CategoryService from 'src/adapters/category_service';
 import { parseQueryString, getCurrentUrl, buildQueryString } from 'src/libs/url_utils';
-import { fire, listen } from 'src/libs/customEvents';
+import { fire, listen, unListen } from 'src/libs/customEvents';
 import { isNullOrEmpty } from 'src/libs/object';
-import { isMobileDevice } from 'src/libs/device';
 import { PanelContext } from 'src/libs/panelContext.js';
 import NoResultPanel from 'src/panel/NoResultPanel';
 import TopBar from 'src/components/TopBar';
+import { useConfig, useDevice } from 'src/hooks';
 
-const directionConf = nconf.get().direction;
-
-export default class PanelManager extends React.Component {
-  static propTypes = {
-    router: PropTypes.object.isRequired,
-  };
-
-  constructor(props) {
-    super(props);
-    this.state = {
-      ActivePanel: ServicePanel,
-      options: {},
-      panelSize: 'default',
-      isSuggestOpen: false,
-      appInputValue: '',
-      userInputValue: '',
-    };
-
-    this.mainSearchInputRef = React.createRef();
+function getTopBarAppValue({ poiFilters = {}, poi = {}, query } = {}) {
+  if (poi.name) {
+    return poi.name;
   }
+  if (poiFilters.category) {
+    return CategoryService.getCategoryByName(poiFilters.category)?.getInputValue();
+  }
+  return poiFilters.query || query || '';
+}
 
-  componentDidMount() {
+const PanelManager = ({ router }) => {
+  const directionConf = useConfig('direction');
+  const { isMobile } = useDevice();
+
+  const [panelOptions, setPanelOptions] = useState({
+    ActivePanel: ServicePanel,
+    options: {},
+    panelSize: 'default',
+  });
+  const [isSuggestOpen, setIsSuggestOpen] = useState(false);
+  const [topBarValue, setTopBarValue] = useState('');
+  const setPanelSize = useCallback(
+    panelSize => {
+      setPanelOptions({ ...panelOptions, panelSize });
+    },
+    [panelOptions]
+  );
+
+  const mainSearchInputRef = useRef(null);
+
+  useEffect(() => {
+    window.times.appRendered = Date.now();
+
     const initialUrlPathName = window.location.pathname;
     const initialQueryParams = parseQueryString(window.location.search);
-    this.initRouter();
 
     Telemetry.add(Telemetry.APP_START, {
       language: window.getLang(),
-      is_mobile: isMobileDevice(),
+      is_mobile: isMobile,
       url_pathname: initialUrlPathName,
       url_client: initialQueryParams['client'] || null,
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  // Disable ESlint plugin so we don't need to add 'isMobile' as effect dependency,
+  // to prevent sending the event again if the user resizes the app
 
-    window.times.appRendered = Date.now();
+  useEffect(() => {
+    if (isMobile) {
+      const minimizePanelOnMapInteraction = listen('map_user_interaction', () => {
+        if (panelOptions.panelSize !== 'minimized') {
+          setPanelSize('minimized');
+        }
+        fire('restart_idle_timeout');
+      });
+      return () => {
+        unListen(minimizePanelOnMapInteraction);
+      };
+    }
+  }, [isMobile, panelOptions.panelSize, setPanelSize]);
 
-    listen('map_user_interaction', () => {
-      if (isMobileDevice() && this.state.panelSize !== 'minimized') {
-        this.setState({ panelSize: 'minimized' });
-      }
-      fire('restart_idle_timeout');
+  useEffect(() => {
+    router.addRoute('Category', '/places/(.*)', placesParams => {
+      const { type: category, q: query, ...otherOptions } = parseQueryString(placesParams);
+      setPanelOptions({
+        ActivePanel: CategoryPanel,
+        options: {
+          poiFilters: {
+            category,
+            query,
+          },
+          ...otherOptions,
+        },
+        panelSize: 'default',
+      });
     });
-  }
 
-  componentDidUpdate(_prevProps, prevState) {
-    const { ActivePanel, options } = this.state;
+    router.addRoute('noresult', '/noresult', (routeParams, options) => {
+      const { q: query } = parseQueryString(routeParams);
+      setPanelOptions({
+        ActivePanel: NoResultPanel,
+        panelSize: 'default',
+        options: {
+          ...options,
+          query,
+          resetInput: () => {
+            setTopBarValue('');
+            mainSearchInputRef.current.select();
+          },
+        },
+      });
+    });
 
-    if (prevState.ActivePanel !== ActivePanel || prevState.options !== options) {
-      // Not in a "list of PoI" context (options.poiFilters is null)
-      if (isNullOrEmpty(options?.poiFilters)) {
-        // Markers are not persistent
-        fire('remove_category_markers');
+    router.addRoute('POI', '/place/(.*)', async (urlPart, options = {}) => {
+      const [poi, params] = urlPart.split('?');
+      const { q: query } = parseQueryString(params);
+      const poiId = poi.split('@')[0];
+      setPanelOptions({
+        ActivePanel: PoiPanel,
+        options: {
+          ...options,
+          query,
+          poiId,
+          backToList,
+          backToFavorite,
+        },
+        panelSize: 'default',
+      });
+    });
+
+    router.addRoute('Favorites', '/favs', () => {
+      setPanelOptions({
+        ActivePanel: FavoritesPanel,
+        options: {},
+        panelSize: 'default',
+      });
+    });
+
+    if (directionConf.enabled) {
+      const isPublicTransportActive =
+        (directionConf.publicTransport && directionConf.publicTransport.enabled) ||
+        parseQueryString(document.location.search)['pt'] === 'true';
+
+      router.addRoute('Routes', '/routes(?:/?)(.*)', (routeParams, options) => {
+        const params = parseQueryString(routeParams);
+        params.details = params.details === 'true';
+        params.activeRouteId = Number(params.selected) || 0;
+        setPanelOptions({
+          ActivePanel: DirectionPanel,
+          options: { ...params, ...options, isPublicTransportActive },
+          panelSize: 'default',
+        });
+      });
+    }
+
+    // Default matching route
+    router.addRoute('Services', '/?', (_, options = {}) => {
+      setPanelOptions({
+        ActivePanel: ServicePanel,
+        options,
+        panelSize: 'default',
+      });
+      if (options?.focusSearch) {
+        mainSearchInputRef.current.select();
       }
+    });
 
-      // Handle search bar's style and text content
-      this.updateSearchBarContent(options);
+    router.routeUrl(getCurrentUrl(), window.history.state || {});
+  }, [router, directionConf]);
+
+  useEffect(() => {
+    setTopBarValue(getTopBarAppValue(panelOptions.options));
+
+    // Not in a "list of PoI" context (options.poiFilters is null)
+    if (isNullOrEmpty(panelOptions.options?.poiFilters)) {
+      // Markers are not persistent
+      fire('remove_category_markers');
     }
-  }
+  }, [panelOptions.ActivePanel, panelOptions.options]);
 
-  updateSearchBarContent({ poiFilters = {}, poi = {}, query } = {}) {
-    let appInputValue = '';
-    if (poi.name) {
-      appInputValue = poi.name;
-    } else if (poiFilters.category) {
-      const categoryLabel = CategoryService.getCategoryByName(poiFilters.category)?.getInputValue();
-      appInputValue = categoryLabel;
-    } else if (poiFilters.query) {
-      appInputValue = poiFilters.query;
-    } else if (query) {
-      appInputValue = query;
-    } else {
-      appInputValue = '';
-    }
-    this.setState({ appInputValue, userInputValue: '' });
-  }
-
-  setUserInputValue = value => {
-    this.setState({ userInputValue: value, appInputValue: '' });
-  };
-
-  backToList(e, poiFilters) {
+  const backToList = (e, poiFilters) => {
     e.stopPropagation();
     const queryObject = {};
     const mappingParams = {
@@ -117,124 +197,21 @@ export default class PanelManager extends React.Component {
     Telemetry.add(Telemetry.POI_BACKTOLIST);
     fire('restore_location');
     window.app.navigateTo(uri);
-  }
+  };
 
-  backToFavorite(e) {
+  const backToFavorite = e => {
     e.stopPropagation();
     Telemetry.add(Telemetry.POI_BACKTOFAVORITE);
     window.app.navigateTo('/favs');
-  }
-
-  initRouter() {
-    const router = this.props.router;
-
-    router.addRoute('Category', '/places/(.*)', placesParams => {
-      const { type: category, q: query, ...otherOptions } = parseQueryString(placesParams);
-      this.setState({
-        ActivePanel: CategoryPanel,
-        options: {
-          poiFilters: {
-            category,
-            query,
-          },
-          ...otherOptions,
-        },
-        panelSize: 'default',
-      });
-    });
-
-    router.addRoute('noresult', '/noresult(?:/?)(.*)', (routeParams, options) => {
-      const { q: query } = parseQueryString(routeParams);
-      this.setState({
-        ActivePanel: NoResultPanel,
-        panelSize: 'default',
-        options: {
-          ...options,
-          query,
-          resetInput: () => {
-            this.setState({ appInputValue: '' });
-            this.mainSearchInputRef.current.select();
-          },
-        },
-      });
-    });
-
-    router.addRoute('POI', '/place/(.*)', async (urlPart, options = {}) => {
-      const [poi, params] = urlPart.split('?');
-      const { q: query } = parseQueryString(params);
-      const poiId = poi.split('@')[0];
-      this.setState({
-        ActivePanel: PoiPanel,
-        options: {
-          ...options,
-          query,
-          poiId,
-          backToList: this.backToList,
-          backToFavorite: this.backToFavorite,
-        },
-        panelSize: 'default',
-      });
-    });
-
-    router.addRoute('Favorites', '/favs', () => {
-      this.setState({
-        ActivePanel: FavoritesPanel,
-        options: {},
-        panelSize: 'default',
-      });
-    });
-
-    if (directionConf.enabled) {
-      const isPublicTransportActive =
-        (directionConf.publicTransport && directionConf.publicTransport.enabled) ||
-        parseQueryString(document.location.search)['pt'] === 'true';
-
-      router.addRoute('Routes', '/routes(?:/?)(.*)', (routeParams, options) => {
-        const params = parseQueryString(routeParams);
-        params.details = params.details === 'true';
-        params.activeRouteId = Number(params.selected) || 0;
-        this.setState({
-          ActivePanel: DirectionPanel,
-          options: { ...params, ...options, isPublicTransportActive },
-          panelSize: 'default',
-        });
-      });
-    }
-
-    // Default matching route
-    router.addRoute('Services', '/?', (_, options = {}) => {
-      this.setState({
-        ActivePanel: ServicePanel,
-        options,
-        panelSize: 'default',
-      });
-      if (options?.focusSearch) {
-        this.mainSearchInputRef.current.select();
-      }
-    });
-
-    // Route the initial URL
-    return router.routeUrl(getCurrentUrl(), window.history.state || {});
-  }
-
-  setPanelSize = panelSize => {
-    this.setState({ panelSize });
   };
 
-  setSuggestOpen = isOpen => {
-    if (this.state.isSuggestOpen !== isOpen) {
-      this.setState({ isSuggestOpen: isOpen });
-    }
-  };
-
-  getTopBarReturnAction = () => {
-    const { poi, poiFilters = {}, isFromFavorite } = this.state.options;
+  const getTopBarReturnAction = () => {
+    const { poi, poiFilters = {}, isFromFavorite } = panelOptions.options;
     if (poi?.name && (poiFilters?.category || poiFilters?.query || isFromFavorite)) {
-      const backAction =
-        poiFilters.category || poiFilters.query ? this.backToList : this.backToFavorite;
+      const backAction = poiFilters.category || poiFilters.query ? backToList : backToFavorite;
       // use the mousedown event so it's triggered before the blur event on the suggest
       return event => {
-        if (this.state.isSuggestOpen) {
+        if (isSuggestOpen) {
           return;
         }
         backAction(event, poiFilters);
@@ -243,38 +220,34 @@ export default class PanelManager extends React.Component {
     return null;
   };
 
-  render() {
-    const {
-      ActivePanel,
-      options,
-      panelSize,
-      isSuggestOpen,
-      appInputValue,
-      userInputValue,
-    } = this.state;
+  const { ActivePanel, options, panelSize } = panelOptions;
+  const isPanelVisible = !isSuggestOpen || (ActivePanel === ServicePanel && !topBarValue);
 
-    const isPanelVisible = !isSuggestOpen || (ActivePanel === ServicePanel && !userInputValue);
+  return (
+    <div>
+      <TopBar
+        value={topBarValue}
+        setUserInputValue={setTopBarValue}
+        ref={mainSearchInputRef}
+        onSuggestToggle={setIsSuggestOpen}
+        backButtonAction={getTopBarReturnAction()}
+      />
+      <PanelContext.Provider value={{ size: panelSize, setSize: setPanelSize }}>
+        {/*
+          The panel container is made hidden using "display: none;" to avoid unnecessary
+          mounts and unmounts of the ActivePanel, that would have inappropriate side effects
+          on map markers, requests to server, etc.
+        */}
+        <div className="panel_container" style={{ display: !isPanelVisible ? 'none' : null }}>
+          <ActivePanel {...options} />
+        </div>
+      </PanelContext.Provider>
+    </div>
+  );
+};
 
-    return (
-      <div>
-        <TopBar
-          value={appInputValue || userInputValue}
-          setUserInputValue={this.setUserInputValue}
-          ref={this.mainSearchInputRef}
-          onSuggestToggle={this.setSuggestOpen}
-          backButtonAction={this.getTopBarReturnAction()}
-        />
-        <PanelContext.Provider value={{ size: panelSize, setSize: this.setPanelSize }}>
-          {/*
-            The panel container is made hidden using "display: none;" to avoid unnecessary
-            mounts and unmounts of the ActivePanel, that would have inappropriate side effects
-            on map markers, requests to server, etc.
-          */}
-          <div className="panel_container" style={{ display: !isPanelVisible ? 'none' : null }}>
-            <ActivePanel {...options} />
-          </div>
-        </PanelContext.Provider>
-      </div>
-    );
-  }
-}
+PanelManager.propTypes = {
+  router: PropTypes.object.isRequired,
+};
+
+export default PanelManager;

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -20,7 +20,7 @@ function getTopBarAppValue({ poiFilters = {}, poi = {}, query } = {}) {
     return poi.name;
   }
   if (poiFilters.category) {
-    return CategoryService.getCategoryByName(poiFilters.category)?.getInputValue();
+    return CategoryService.getCategoryByName(poiFilters.category)?.getInputValue() || '';
   }
   return poiFilters.query || query || '';
 }

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -45,6 +45,7 @@ const PanelManager = ({ router }) => {
 
   const mainSearchInputRef = useRef(null);
 
+  // Telemetry
   useEffect(() => {
     window.times.appRendered = Date.now();
 
@@ -62,6 +63,7 @@ const PanelManager = ({ router }) => {
   // Disable ESlint plugin so we don't need to add 'isMobile' as effect dependency,
   // to prevent sending the event again if the user resizes the app
 
+  // Panel auto-minimization on mobile
   useEffect(() => {
     if (isMobile) {
       const minimizePanelOnMapInteraction = listen('map_user_interaction', () => {
@@ -76,6 +78,7 @@ const PanelManager = ({ router }) => {
     }
   }, [isMobile, panelOptions.panelSize, setPanelSize]);
 
+  // Definition of url routes to panels
   useEffect(() => {
     router.addRoute('Category', '/places/(.*)', placesParams => {
       const { type: category, q: query, ...otherOptions } = parseQueryString(placesParams);
@@ -162,9 +165,11 @@ const PanelManager = ({ router }) => {
       }
     });
 
+    // Route the initial URL
     router.routeUrl(getCurrentUrl(), window.history.state || {});
   }, [router, directionConf]);
 
+  // Effects on panel change
   useEffect(() => {
     setTopBarValue(getTopBarAppValue(panelOptions.options));
 


### PR DESCRIPTION
## Description
Following the [React implementation of the top bar](https://github.com/Qwant/erdapfel/pull/997) and while it's still fresh, I converted the PanelManager to a functional component.

## Why
- Clarifying the side effects and state transitions
- Use our hooks `useDevice` and `useConfig`
- Good occasion to simplify some old or recent things 
