### PR TITLE
Refine geolocation params to (try to) avoid bugs

### DIFF
--- a/src/adapters/poi/specials/navigator_geolocalisation_poi.js
+++ b/src/adapters/poi/specials/navigator_geolocalisation_poi.js
@@ -9,7 +9,6 @@ export const navigatorGeolocationStatus = {
   UNKNOWN: 'unknown',
   FORBIDDEN: 'forbidden',
 };
-
 export default class NavigatorGeolocalisationPoi extends Poi {
   constructor() {
     super('geolocalisation', _('Your position', 'direction'), 'geoloc');
@@ -40,7 +39,11 @@ export default class NavigatorGeolocalisationPoi extends Poi {
           }
           reject(error);
         },
-        { timeout: 3000 }
+        {
+          timeout: 3000,
+          maximumAge: 300000, // five minutes
+          enableHighAccuracy: true,
+        }
       );
     });
   }


### PR DESCRIPTION
## Description
Pass an explicit `maximumAge` parameter to the `getCurrentPosition` call made in direction form, to allow the browser to reuse a "recent" position if it currently has one in cache.
(Also use `enableHighAccuracy`, which seems relevant for the directions.)

## Why
Chromium/Webkit-based browsers seem to have issues with the geolocation.
https://bugs.chromium.org/p/chromium/issues/detail?id=586015
The default `maximumAge` is `0`, in theory forcing `getCurrentPosition` to request a fresh position each time, but apparently this process may fail if a `watchPosition` is running and hasn't updated the position recently (hinting about another level of internal cache mechanism…).
By using an explicit `maximumAge` value, the browser is allowed to re-use immediately a previous position without requesting a new one, reducing the number of cases when it will fail.
The 5 minutes value is a trade-off, it should match a majority of use cases of the app while ignoring really too old positions…