### PR TITLE
QMAPS-2131 Reuse query param from url in search field

### DIFF
--- a/src/libs/suggest.js
+++ b/src/libs/suggest.js
@@ -35,7 +35,7 @@ export const selectItem = (selectedItem, { query, replaceUrl = false } = {}) => 
     window.app.navigateTo(`/places/${selectedItem.toQueryString()}`, {}, { replace: replaceUrl });
   } else if (!selectedItem) {
     // No result
-    window.app.navigateTo('/noresult', { query }, { replace: replaceUrl });
+    window.app.navigateTo(`/noresult/?q=${query}`, {}, { replace: replaceUrl });
   }
 };
 

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -143,12 +143,14 @@ export default class PanelManager extends React.Component {
       });
     });
 
-    router.addRoute('noresult', '/noresult', (_, options) => {
+    router.addRoute('noresult', '/noresult(?:/?)(.*)', (routeParams, options) => {
+      const { q: query } = parseQueryString(routeParams);
       this.setState({
         ActivePanel: NoResultPanel,
         panelSize: 'default',
         options: {
           ...options,
+          query,
           resetInput: () => {
             this.setState({ appInputValue: '' });
             this.mainSearchInputRef.current.select();
@@ -157,12 +159,15 @@ export default class PanelManager extends React.Component {
       });
     });
 
-    router.addRoute('POI', '/place/([^?]+)', async (poiUrl, options = {}) => {
-      const poiId = poiUrl.split('@')[0];
+    router.addRoute('POI', '/place/(.*)', async (urlPart, options = {}) => {
+      const [poi, params] = urlPart.split('?');
+      const { q: query } = parseQueryString(params);
+      const poiId = poi.split('@')[0];
       this.setState({
         ActivePanel: PoiPanel,
         options: {
           ...options,
+          query,
           poiId,
           backToList: this.backToList,
           backToFavorite: this.backToFavorite,


### PR DESCRIPTION
## Description
When a query parameter (`?q=`) has been used to access the app (for example coming from search), use this to fill the search field.