### PR TITLE
New 'useI18n' hook to manage languages and localized urls

### DIFF
--- a/config/constants.yml
+++ b/config/constants.yml
@@ -33,6 +33,13 @@ languages:
         - es
   defaultLanguage: *default
 
+localizedUrls:
+  en:
+    aboutHome: https://about.qwant.com
+    aboutPrivacy: https://about.qwant.com/legal/privacy
+    aboutMapsToS: https://about.qwant.com/legal/terms-of-service/qwant-maps/
+    contributing: https://github.com/Qwant/qwantmaps/blob/master/contributing.md
+
 # Map
 map:
   zoom: 2

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -90,10 +90,3 @@ events:
 covid19:
   enabled: false
   frInformationUrl:  https://www.gouvernement.fr/info-coronavirus
-
-externalUrls:
-  about:
-    home: https://about.qwant.com
-    privacy: https://about.qwant.com/legal/privacy
-    mapsToS: https://about.qwant.com/legal/terms-of-service/qwant-maps/
-  contributing: https://github.com/Qwant/qwantmaps/blob/master/contributing.md

--- a/src/components/BetaInfoBox.jsx
+++ b/src/components/BetaInfoBox.jsx
@@ -1,9 +1,9 @@
-/* global _ */
 import React, { useState } from 'react';
 import Alert from './ui/Alert';
 import { Button } from './ui';
 import { get, set } from 'src/adapters/store';
 import { parseQueryString } from '../libs/url_utils';
+import { useI18n } from 'src/hooks';
 
 const initialQueryParams = parseQueryString(window.location.search);
 
@@ -15,10 +15,11 @@ const BetaInfoBox = () => {
     set('beta_popup_closed', 1);
     setClosed(true);
   };
+  const { lang, _ } = useI18n();
 
   return (
     // Show beta popup if browser language is not french, if popup hasn't already been closed, and if the user comes from an IA
-    window.getLang().code.indexOf('fr') === -1 &&
+    lang !== 'fr' &&
     !closed &&
     isUserFromSearch && (
       <Alert

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,2 +1,3 @@
 export { useConfig } from './useConfig';
 export { useDevice } from './useDevice';
+export { useI18n } from './useI18n';

--- a/src/hooks/useI18n.js
+++ b/src/hooks/useI18n.js
@@ -1,3 +1,9 @@
+import { localizedUrls } from 'config/constants.yml';
+
+const getLocalizedUrl = lang => urlName => {
+  return localizedUrls?.[lang]?.[urlName] || localizedUrls?.['en']?.[urlName];
+};
+
 export const useI18n = () => {
   const { locale, code: lang } = window.getLang();
 
@@ -5,5 +11,6 @@ export const useI18n = () => {
     _: window._,
     locale,
     lang,
+    getLocalizedUrl: getLocalizedUrl(lang),
   };
 };

--- a/src/hooks/useI18n.js
+++ b/src/hooks/useI18n.js
@@ -1,0 +1,9 @@
+export const useI18n = () => {
+  const { locale, code: lang } = window.getLang();
+
+  return {
+    _: window._,
+    locale,
+    lang,
+  };
+};

--- a/src/modals/GeolocationModal.jsx
+++ b/src/modals/GeolocationModal.jsx
@@ -1,16 +1,16 @@
-/* global _ */
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Modal from 'src/components/ui/Modal';
 import { listen } from 'src/libs/customEvents';
 import { Button, CloseButton } from 'src/components/ui';
 import classnames from 'classnames';
-import { useConfig } from 'src/hooks';
+import { useI18n } from 'src/hooks';
 
 let hasPermissionModalOpenedOnce = false;
 
 const GeolocationModal = ({ status, onClose, onAccept }) => {
-  const aboutPrivacyUrl = useConfig('externalUrls').about.privacy;
+  const { getLocalizedUrl, _ } = useI18n();
+  const aboutPrivacyUrl = getLocalizedUrl('aboutPrivacy');
 
   /* eslint-disable max-len */
   const pendingOnDirectionsText = _(

--- a/src/panel/menu/AppMenu.jsx
+++ b/src/panel/menu/AppMenu.jsx
@@ -1,4 +1,3 @@
-/* globals _ */
 import React from 'react';
 import PropTypes from 'prop-types';
 import MenuItem from './MenuItem';
@@ -6,14 +5,11 @@ import Telemetry from 'src/libs/telemetry';
 import { Divider } from 'src/components/ui';
 import { Heart, IconLightbulb, IconEdit, IconApps } from 'src/components/ui/icons';
 import { PINK_DARK, ACTION_BLUE_BASE } from 'src/libs/colors';
-import { useConfig } from 'src/hooks';
+import { useConfig, useI18n } from 'src/hooks';
 
 const AppMenu = ({ close, openProducts }) => {
   const { baseUrl } = useConfig('system');
-  const {
-    contributing,
-    about: { mapsToS },
-  } = useConfig('externalUrls');
+  const { getLocalizedUrl, _ } = useI18n();
 
   const navTo = (url, options) => {
     close();
@@ -34,7 +30,7 @@ const AppMenu = ({ close, openProducts }) => {
         {_('My favorites', 'menu')}
       </MenuItem>
       <MenuItem
-        href={mapsToS}
+        href={getLocalizedUrl('aboutMapsToS')}
         outsideLink
         icon={<IconLightbulb width={16} fill={ACTION_BLUE_BASE} />}
       >
@@ -45,7 +41,7 @@ const AppMenu = ({ close, openProducts }) => {
         />
       </MenuItem>
       <MenuItem
-        href={contributing}
+        href={getLocalizedUrl('contributing')}
         outsideLink
         icon={<IconEdit width={16} fill={ACTION_BLUE_BASE} />}
       >

--- a/src/panel/menu/ProductsDrawer.jsx
+++ b/src/panel/menu/ProductsDrawer.jsx
@@ -1,11 +1,10 @@
-/* globals _ */
 import React from 'react';
 import { Flex } from 'src/components/ui';
-import { useConfig } from 'src/hooks/useConfig';
+import { useI18n } from 'src/hooks';
 import ProductCard from './ProductCard';
 
 const ProductsDrawer = () => {
-  const aboutQwantUrl = useConfig('externalUrls').about.home;
+  const { getLocalizedUrl, _ } = useI18n();
 
   return (
     <>
@@ -45,7 +44,12 @@ const ProductsDrawer = () => {
           }}
         />
       </div>
-      <a href={aboutQwantUrl} target="_blank" rel="noopener noreferrer" className="card u-mb-l">
+      <a
+        href={getLocalizedUrl('aboutHome')}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="card u-mb-l"
+      >
         <Flex>
           <div className="u-mr-l">
             <img width="100" height="100" src="./statics/images/products/web-internaute.svg" />

--- a/src/panel/poi/blocks/Recycling.jsx
+++ b/src/panel/poi/blocks/Recycling.jsx
@@ -1,45 +1,49 @@
-/* globals _ */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Flex, Text, Meter } from 'src/components/ui';
 import { GREEN_BASE, ORANGE_BASE, RED_BASE } from 'src/libs/colors';
+import { useI18n } from 'src/hooks';
 
-const containerTypes = type => {
+const Container = ({ type, filling_level, updated_at }) => {
+  const { locale, _ } = useI18n();
+
+  const containerTypes = type => {
+    return (
+      {
+        glass: _('Glass', 'recycling'),
+        recyclable: _('Recyclable', 'recycling'),
+      }[type] || _('Unknown', 'recycling')
+    );
+  };
+
   return (
-    {
-      glass: _('Glass', 'recycling'),
-      recyclable: _('Recyclable', 'recycling'),
-    }[type] || _('Unknown', 'recycling')
+    <div className="recycling-container">
+      <Text level="caption" icon="icon_clock" className="u-mb-xs">
+        {_('Updated {datetime}', 'recycling', {
+          datetime: Intl.DateTimeFormat(locale.replace('_', '-'), {
+            year: 'numeric',
+            month: 'numeric',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: 'numeric',
+          }).format(new Date(updated_at)),
+        })}
+      </Text>
+      <Flex justifyContent="space-between">
+        <Text level="smallTitle">{containerTypes(type)}</Text>
+        <Text>{filling_level} %</Text>
+      </Flex>
+      <Meter
+        value={filling_level}
+        colors={[
+          { min: 0, color: GREEN_BASE },
+          { min: 50, color: ORANGE_BASE },
+          { min: 75, color: RED_BASE },
+        ]}
+      />
+    </div>
   );
 };
-
-const Container = ({ type, filling_level, updated_at }) => (
-  <div className="recycling-container">
-    <Text level="caption" icon="icon_clock" className="u-mb-xs">
-      {_('Updated {datetime}', 'recycling', {
-        datetime: Intl.DateTimeFormat(window.getLang().locale.replace('_', '-'), {
-          year: 'numeric',
-          month: 'numeric',
-          day: 'numeric',
-          hour: 'numeric',
-          minute: 'numeric',
-        }).format(new Date(updated_at)),
-      })}
-    </Text>
-    <Flex justifyContent="space-between">
-      <Text level="smallTitle">{containerTypes(type)}</Text>
-      <Text>{filling_level} %</Text>
-    </Flex>
-    <Meter
-      value={filling_level}
-      colors={[
-        { min: 0, color: GREEN_BASE },
-        { min: 50, color: ORANGE_BASE },
-        { min: 75, color: RED_BASE },
-      ]}
-    />
-  </div>
-);
 
 const RecyclingBlock = ({ block }) => {
   const containers = block?.containers;


### PR DESCRIPTION
## Description
Proposition to fill the need for localized urls statically defined: 
- store them in `constants.yml` (also where we define languages)
- use a React hook to expose a function to access them at runtime, with fallback to a default language

As a big bonus, the hook acts as a cleaner way than globals to access other i18n features from React components (language, translation function).
