### PR TITLE
QMAPS-1734 itinerary error messages

### DIFF
--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -41,20 +41,12 @@ const RouteResult = ({
   if (error !== 0) {
     return (
       <div className="itinerary_no-result">
-        <span className="icon-alert-triangle" />
-        <div>
+        <p className="u-mb-xs u-text--smallTitle u-center">{_("Ouch, we've lost the north 🧭")}</p>
+        <p className="u-text--subtitle u-mb-l u-center">
           {error >= 500 && error < 600
             ? _('The service is temporarily unavailable, please try again later.', 'direction')
-            : _('Qwant Maps found no results for this itinerary.', 'direction')}
-        </div>
-        {vehicle === 'publicTransport' && (
-          <div>
-            {_(
-              'We are currently testing public transport mode in a restricted set of cities.',
-              'direction'
-            )}
-          </div>
-        )}
+            : _("We couldn't find any itinerary, we are really sorry.", 'direction')}
+        </p>
       </div>
     );
   }


### PR DESCRIPTION
## Description
- change text and design of error messages when no result found or server error
- replace the beta public transport message with the "no result found" one

## Why
Design

## Screenshots
![image](https://user-images.githubusercontent.com/1225909/119472681-b9f4f480-bd4a-11eb-884d-a9abf0b9464e.png)
![image](https://user-images.githubusercontent.com/1225909/119472721-c4af8980-bd4a-11eb-8b41-3e4923d15741.png)
![image](https://user-images.githubusercontent.com/1225909/119472863-e6a90c00-bd4a-11eb-8b55-d1a20500ef12.png)

