### PR TITLE
QMAPS-2152 fix tags positions

### DIFF
--- a/src/scss/includes/routeLabel.scss
+++ b/src/scss/includes/routeLabel.scss
@@ -3,6 +3,7 @@
 }
 
 .routeLabel {
+  position: relative;
   background-color: $grey-lighter;
   color: $grey-semi-darkness;
   border-radius: 6px;


### PR DESCRIPTION
## Description
The route labels overlap the route lines, it's a recent regression
This fix should not break the recent work on public transport labels (QMAPS-2052), but I can't test it right now, the API doesn't respind.


## Screenshots
![image](https://user-images.githubusercontent.com/1225909/119684605-edb44500-be44-11eb-8ccb-54b3a3f3bba0.png)

