### PR TITLE
QMAPS-1734 Add non breaking spaces before emojis

### DIFF
--- a/src/panel/NoResultMessage.jsx
+++ b/src/panel/NoResultMessage.jsx
@@ -4,9 +4,12 @@ import React from 'react';
 const NoResultMessage = () => {
   return (
     <>
-      <p className="u-center u-mb-xs u-text--smallTitle">
-        {_('Sorry, we could not find this place 🏝️', 'suggest')}
-      </p>
+      <p
+        className="u-center u-mb-xs u-text--smallTitle"
+        dangerouslySetInnerHTML={{
+          __html: _('Sorry, we could not find this place&nbsp;🏝️', 'suggest'),
+        }}
+      />
       <p className="u-center u-text--subtitle">
         {_(
           'Please try to correct your query or rewrite it with more details about the location (city, country, …)',

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -41,7 +41,10 @@ const RouteResult = ({
   if (error !== 0) {
     return (
       <div className="itinerary_no-result">
-        <p className="u-mb-xs u-text--smallTitle u-center">{_("Ouch, we've lost the north 🧭")}</p>
+        <p
+          className="u-mb-xs u-text--smallTitle u-center"
+          dangerouslySetInnerHTML={{ __html: _("Ouch, we've lost the north&nbsp;🧭") }}
+        />
         <p className="u-text--subtitle u-mb-l u-center">
           {error >= 500 && error < 600
             ? _('The service is temporarily unavailable, please try again later.', 'direction')


### PR DESCRIPTION
## Description
Just a small tweak on the strings introduced in https://github.com/Qwant/erdapfel/pull/1092 and https://github.com/Qwant/erdapfel/pull/1093: add a non-breaking space character to avoid the situation where the emojis are alone on a new line.