### PR TITLE
Ensure the '_' i18n function keeps its name when built

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const yaml = require('node-yaml');
 const webpack = require('webpack');
 const babelConf = require('./babel.config');
+const TerserPlugin = require('terser-webpack-plugin');
 
 const getBuildMode = function (argv) {
   const isTestMode = process.env.TEST === 'true';
@@ -89,6 +90,18 @@ const mainJsChunkConfig = buildMode => {
         }
       }),
     ],
+    optimization: {
+      minimize: buildMode === 'production',
+      minimizer: [
+        new TerserPlugin({
+          terserOptions: {
+            // make sure the `_` translation function keeps its name in the minimized bundle
+            // as it's used by gettext to extract translation keys
+            mangle: { reserved: ['_'] },
+          },
+        }),
+      ],
+    },
     module: {
       rules: [
         {


### PR DESCRIPTION
## Description
Specify in the Webpack optimization config to not *mangle* (ie. replace by a generated name) the `_` identifier, as it is used by the i18n script to spot translation strings in the bundle by analyzing the code. 
This uses the config of Terser (doc: https://github.com/terser/terser#mangle-options), the tool used by default by Webpack to optimize production code.

## Why
Since https://github.com/Qwant/erdapfel/pull/1088, some files use this function as exposed by a React hook, not as a global function. Translation strings used in this file were not part of the i18n extract anymore, because the `_` const was renamed by Terser.
Global identifiers are not mangled by default, which explains it didn't need a special config until now.

## Comparison
In `public/build/javascript/bundle.js`
|Before|After|
|---|---|
|![Capture d’écran de 2021-05-28 14-52-05](https://user-images.githubusercontent.com/243653/119986577-4cec9380-bfc4-11eb-985f-2b6b1138d1ed.png)|![Capture d’écran de 2021-05-28 14-50-23](https://user-images.githubusercontent.com/243653/119986514-38100000-bfc4-11eb-8bdc-a186e4c23874.png)|

