### PR TITLE
Change error message when no matching point in area

### DIFF
--- a/src/panel/category/CategoryPanelError.jsx
+++ b/src/panel/category/CategoryPanelError.jsx
@@ -24,7 +24,7 @@ const CategoryPanelError = ({ zoomIn }) => {
         ),
       }
     : {
-        title: _("Hmm, looks like a no-man's land 🙅‍♂️", 'categories'),
+        title: _("Hmm, looks like a no-man's land 🏜️", 'categories'),
         message: _('We found no place matching your query in this area.', 'categories'),
         action: (
           <Button onClick={zoomOut} variant="tertiary">

--- a/src/panel/category/CategoryPanelError.jsx
+++ b/src/panel/category/CategoryPanelError.jsx
@@ -1,23 +1,43 @@
 /* global _ */
 import React from 'react';
+import { Button } from 'src/components/ui';
 
 const geoloc = e => {
   e.preventDefault();
   document.querySelector('.mapboxgl-ctrl-geolocate').click();
 };
 
+const zoomOut = e => {
+  e.preventDefault();
+  document.querySelector('.map_control_group__button__zoom.icon-minus').click();
+};
+
 const CategoryPanelError = ({ zoomIn }) => {
+  const { title, message, action } = zoomIn
+    ? {
+        title: _('No results found.'),
+        message: _('Please zoom in the map to see the results for this category.', 'categories'),
+        action: (
+          <Button onClick={geoloc} href="#">
+            <span className="icon-pin_geoloc" /> {_('Search around my position', 'categories')}
+          </Button>
+        ),
+      }
+    : {
+        title: _("Hmm, looks like a no-man's land 🙅‍♂️", 'categories'),
+        message: _('We found no place matching your query in this area.', 'categories'),
+        action: (
+          <Button onClick={zoomOut} variant="tertiary">
+            {_('Get some height', 'categories')}
+          </Button>
+        ),
+      };
+
   return (
-    <div className="category__panel__error">
-      <p className="u-mb-xs u-text--smallTitle">{_('No results found.')}</p>
-      <p className="u-mb-l">
-        {zoomIn
-          ? _('Please zoom in the map to see the results for this category.', 'categories')
-          : _('Please zoom out of the map.', 'categories')}
-      </p>
-      <a onClick={geoloc} href="#">
-        <span className="icon-pin_geoloc" /> {_('Search around my position', 'categories')}
-      </a>
+    <div className="category__panel__error u-center">
+      <p className="u-mb-xs u-text--smallTitle">{title}</p>
+      <p className="u-mb-s">{message}</p>
+      {action}
     </div>
   );
 };

--- a/src/scss/includes/panels/categories.scss
+++ b/src/scss/includes/panels/categories.scss
@@ -14,7 +14,7 @@
 }
 
 .category__panel__error {
-  padding: 16px 16px 32px 16px;
+  padding: $spacing-m;
 }
 
 @media (min-width: 641px) {


### PR DESCRIPTION
## Description
New wording and action for the error message when there is no matching point in the area for a "category" result.
 
## Screenshots
|Before|After|
|---|---|
|![Screen%20Shot%202021-05-31%20at%2015 25 36](https://user-images.githubusercontent.com/243653/120200326-7f94c700-c224-11eb-95b8-60c31c2a3e25.png)|![Screen%20Shot%202021-05-31%20at%2015 37 36](https://user-images.githubusercontent.com/243653/120201866-2e85d280-c226-11eb-80a2-ec27ab64800d.png)|