### PR TITLE
Fix no result query value

### DIFF
--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -95,7 +95,7 @@ const PanelManager = ({ router }) => {
       });
     });
 
-    router.addRoute('noresult', '/noresult', (routeParams, options) => {
+    router.addRoute('noresult', '/noresult(?:/?)(.*)', (routeParams, options) => {
       const { q: query } = parseQueryString(routeParams);
       setPanelOptions({
         ActivePanel: NoResultPanel,

--- a/tests/integration/tests/autocomplete.js
+++ b/tests/integration/tests/autocomplete.js
@@ -261,6 +261,13 @@ test('Retrieve no category when we search "barcelona", not even "bar"', async ()
   expect(firstLine).toEqual('test result 1');
 });
 
+test('Search input is filled with the query on no result panel', async () => {
+  const noResultQuery = 'gibberish';
+  await page.goto(`${APP_URL}/noresult?q=${noResultQuery}`);
+  const searchValue = await autocompleteHelper.getSearchInputValue();
+  expect(searchValue.trim()).toEqual(noResultQuery);
+});
+
 afterEach(async () => {
   await clearStore(page);
   responseHandler.reset();


### PR DESCRIPTION
## Description
Fix the display of the current query in the search bar when displaying the NoResultPanel.
Also add a test to prevent regression on this feature.

## Why
I don't remember why, but in https://github.com/Qwant/erdapfel/commit/c6e82a1d942aa8b9b873e036ee864b8ceb1beef0#diff-a16c9106879f7edf18989f689da63c0380eb56e792aebfa444c54f46d8c7b8f4, the part capturing search params in the no result route was removed, so the query wasn't retrieved anymore.