### PR TITLE
QMAPS-2159 fix error messages height on mobile

### DIFF
--- a/src/panel/NoResultPanel.jsx
+++ b/src/panel/NoResultPanel.jsx
@@ -13,7 +13,7 @@ const NoResultPanel = ({ resetInput }) => {
   };
 
   return (
-    <Panel close={close}>
+    <Panel close={close} fitContent="default">
       <div style={{ padding: '20px 34px' }}>
         <NoResultMessage />
         <p className="u-center u-mt-s">

--- a/src/panel/NoResultPanel.jsx
+++ b/src/panel/NoResultPanel.jsx
@@ -13,7 +13,7 @@ const NoResultPanel = ({ resetInput }) => {
   };
 
   return (
-    <Panel close={close} fitContent="default">
+    <Panel close={close} fitContent={['default']}>
       <div style={{ padding: '20px 34px' }}>
         <NoResultMessage />
         <p className="u-center u-mt-s">

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -165,6 +165,7 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
       floatingItemsLeft={[
         isMobile && shouldShowBackToQwant() && <BackToQwantButton key="back-to-qwant" isMobile />,
       ]}
+      fitContent={!pois || pois.length === 0 ? 'default' : 'minimized'}
     >
       {panelContent}
     </Panel>

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -165,7 +165,7 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
       floatingItemsLeft={[
         isMobile && shouldShowBackToQwant() && <BackToQwantButton key="back-to-qwant" isMobile />,
       ]}
-      fitContent={!pois || pois.length === 0 ? 'default' : 'minimized'}
+      fitContent={!pois || pois.length === 0 ? ['default'] : []}
     >
       {panelContent}
     </Panel>


### PR DESCRIPTION
## Description
error panels on mobile were too tall
now they're as tall as the text
NB: this fix shouldn't impact the display of these panels when there's no error

## Screenshots
![image](https://user-images.githubusercontent.com/1225909/120290177-60e50d80-c2c2-11eb-9ab2-9250b9d7eb69.png)
![image](https://user-images.githubusercontent.com/1225909/120290249-735f4700-c2c2-11eb-9480-4df5dff2e1e4.png)

