### PR TITLE
QMAPS-2155 add user feedback in itinerary list

### DIFF
--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { listen, unListen } from 'src/libs/customEvents';
 import Telemetry from 'src/libs/telemetry';
 import RoutesList from './RoutesList';
-import { SourceFooter } from 'src/components/ui';
+import { SourceFooter, UserFeedbackYesNo } from 'src/components/ui';
 
 const RouteResult = ({
   origin,
@@ -69,6 +69,7 @@ const RouteResult = ({
           selectRoute={onSelectRoute}
         />
       </div>
+      <UserFeedbackYesNo question={_('Do these results match your query?')} />
       {vehicle === 'publicTransport' && routes.length > 0 && (
         <SourceFooter>
           <a href="https://combigo.com/">{_('Results in partnership with Combigo')}</a>


### PR DESCRIPTION
## Description
Add feedback form at the bottom of itinerary lists, only if there are results
This is a beginning of implementation, as feedback's design and behavior (especially on mobile) need more work.
See QMAPS-2154


## Screenshots
![image](https://user-images.githubusercontent.com/1225909/120494513-2bbce600-c3bc-11eb-85f9-ad5456a74f3b.png)

