### PR TITLE
QMAPS-2157 feedback remember close

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -93,3 +93,4 @@ covid19:
 
 userFeedback:
   enabled: false
+  dismissDurationDays: 30

--- a/src/components/ui/UserFeedbackYesNo.jsx
+++ b/src/components/ui/UserFeedbackYesNo.jsx
@@ -4,28 +4,28 @@ import { UserFeedbackQuestion } from './index';
 import { useConfig, useI18n } from 'src/hooks';
 import { IconThumbUp, IconThumbDown } from './icons';
 import { ACTION_BLUE_BASE } from 'src/libs/colors';
-import { sendAnswer } from 'src/libs/userFeedback';
+import { sendAnswer, rememberAnswer, shouldBeDisplayed } from 'src/libs/userFeedback';
 
 const UserFeedbackYesNo = ({ questionId, context, question }) => {
-  const { enabled: userFeedBackEnabled } = useConfig('userFeedback');
+  const { enabled: userFeedBackEnabled, dismissDurationDays } = useConfig('userFeedback');
   const { _ } = useI18n();
-  // @TODO: replace by the real conditions
   const [isClosed, setClosed] = useState();
+  const display = shouldBeDisplayed(questionId, dismissDurationDays);
 
   const closeQuestion = () => {
     sendAnswer(questionId, 'dismiss', { context });
+    rememberAnswer(questionId, 'dismiss');
     setClosed(true);
   };
 
   const onAnswer = answer => () => {
     sendAnswer(questionId, answer, { context });
+    rememberAnswer(questionId, answer);
     setClosed(true);
-    // @TODO:
-    // - hide question and remember it
-    // - display thank you message
+    // @TODO: - display thank you message
   };
 
-  if (!userFeedBackEnabled || isClosed) {
+  if (!userFeedBackEnabled || !display || isClosed) {
     return null;
   }
 

--- a/src/libs/userFeedback.js
+++ b/src/libs/userFeedback.js
@@ -1,5 +1,6 @@
 import Telemetry from 'src/libs/telemetry';
 import { isMobileDevice } from 'src/libs/device';
+import { version } from 'config/constants.yml';
 
 function sendAnswer(questionId, answer, { context } = {}) {
   const { locale, code } = window.getLang();
@@ -18,4 +19,27 @@ function sendAnswer(questionId, answer, { context } = {}) {
   });
 }
 
-export { sendAnswer };
+const storagePrefix = `qmaps_v${version}_userFeedback_`;
+const dayToMs = days => days * 24 * 60 * 60 * 1000;
+
+function shouldBeDisplayed(questionId, hideForDays = 30) {
+  const previouslyAnswered = localStorage.getItem(`${storagePrefix}${questionId}`);
+  if (!previouslyAnswered) {
+    return true;
+  }
+  const { answer, date } = JSON.parse(previouslyAnswered);
+  // For now only hide further questions if the user dismissed the widget
+  if (answer !== 'dismiss') {
+    return true;
+  }
+  return Date.now() - new Date(date).getTime() > dayToMs(hideForDays);
+}
+
+function rememberAnswer(questionId, answer) {
+  localStorage.setItem(
+    `${storagePrefix}${questionId}`,
+    JSON.stringify({ answer, date: new Date().toISOString() })
+  );
+}
+
+export { sendAnswer, shouldBeDisplayed, rememberAnswer };


### PR DESCRIPTION
## Description
Implement the mechanism to keep a user feedback question hidden if the user dismissed it by clicking on the close button.
 1. when a question is answered or dismissed, store the action (yes|no|dismiss) and the current datetime in localstorage
 2. use a localstorage key based on the `questionId` so all questions across the app are independant, and dismissing one will not hide the others 
 3. before rendering the question, check if there is a stored value
  - if not, means the user previously did nothing with this question => display the question
  - if there is a value but which isn't `dismiss`, it means the user already answered this question but probably in a different context (query, route, etc.) => display the question
  - if the user previously dismissed the question, check if enough days have passed. If not, don't display the question.