### PR TITLE
QMAPS-2155 Finish user feedback on routes

### DIFF
--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -1,10 +1,12 @@
 /* globals _ */
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { listen, unListen } from 'src/libs/customEvents';
 import Telemetry from 'src/libs/telemetry';
 import RoutesList from './RoutesList';
 import { SourceFooter, UserFeedbackYesNo } from 'src/components/ui';
+import { useDevice } from 'src/hooks';
+import { PanelContext } from 'src/libs/panelContext';
 
 const RouteResult = ({
   origin,
@@ -18,6 +20,9 @@ const RouteResult = ({
   selectRoute,
   toggleDetails,
 }) => {
+  const { isMobile } = useDevice();
+  const { size: panelSize } = useContext(PanelContext);
+
   useEffect(() => {
     const routeSelectedOnMapHandler = listen('select_road_map', onSelectRoute);
     return () => {
@@ -69,7 +74,7 @@ const RouteResult = ({
           selectRoute={onSelectRoute}
         />
       </div>
-      {routes.length > 0 && (
+      {routes.length > 0 && (!isMobile || panelSize === 'maximized') && (
         <UserFeedbackYesNo question={_('Do these results match your query?')} />
       )}
       {vehicle === 'publicTransport' && routes.length > 0 && (

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -75,7 +75,11 @@ const RouteResult = ({
         />
       </div>
       {routes.length > 0 && (!isMobile || panelSize === 'maximized') && (
-        <UserFeedbackYesNo question={_('Do these results match your query?')} />
+        <UserFeedbackYesNo
+          questionId="routes"
+          context={document.location.href}
+          question={_('Do these results match your query?')}
+        />
       )}
       {vehicle === 'publicTransport' && routes.length > 0 && (
         <SourceFooter>

--- a/src/panel/direction/RouteResult.jsx
+++ b/src/panel/direction/RouteResult.jsx
@@ -69,7 +69,9 @@ const RouteResult = ({
           selectRoute={onSelectRoute}
         />
       </div>
-      <UserFeedbackYesNo question={_('Do these results match your query?')} />
+      {routes.length > 0 && (
+        <UserFeedbackYesNo question={_('Do these results match your query?')} />
+      )}
       {vehicle === 'publicTransport' && routes.length > 0 && (
         <SourceFooter>
           <a href="https://combigo.com/">{_('Results in partnership with Combigo')}</a>


### PR DESCRIPTION
## Description
Following https://github.com/Qwant/erdapfel/pull/1107 and https://github.com/Qwant/erdapfel/pull/1110, fix and add the last bits so the feature is compliant with the issue:
 - fix the rendering condition, because in https://github.com/Qwant/erdapfel/pull/1107 we forgot to check there were actually route results…
 - on mobile, only display the question in the maximized result panel
 - pass a `questionId` and a `context` prop to send full events

## Screenshots
### Desktop
![Capture d’écran de 2021-06-04 15-34-09](https://user-images.githubusercontent.com/243653/120809678-9f8cf900-c54a-11eb-9ab3-845826042d9d.png)

### Mobile
https://user-images.githubusercontent.com/243653/120809729-ab78bb00-c54a-11eb-8ccd-4cce9727b251.mp4