### PR TITLE
QMAPS-2145 Tweak scale and attribution map controls 

### DIFF
--- a/src/scss/includes/map_theme.scss
+++ b/src/scss/includes/map_theme.scss
@@ -98,7 +98,7 @@
   color: #353c52;
   background-color: transparent;
   height: 12px;
-  line-height: 10px;
+  line-height: 7px;
 }
 
 .map_control__scale_attribute_container {
@@ -132,14 +132,17 @@
   .map_control__scale_attribute_container {
     background: none;
     position: fixed;
-    left: 0px;
-    bottom: 4px;
+    left: 0;
+    bottom: 0;
     width: auto;
+    height: 48px;
+    display: flex;
+    flex-direction: row-reverse;
+    align-items: center;
     z-index: 1;
 
     .mapboxgl-ctrl.map_control__scale {
       background: none;
-      margin: 4px 5px 5px 45px;
       line-height: 10px;
       height: 13px;
       position: relative;
@@ -152,7 +155,7 @@
 
       &:before {
         content: '';
-        background: rgba(255, 255, 255, 0.9);
+        background: rgba(255, 255, 255, 0.8);
         border-radius: 10px;
         height: 20px;
         width: calc(100% + 20px);
@@ -168,33 +171,38 @@
         height: 11px;
         position: absolute;
         left: 0;
-        border: solid 2px #353c52;
+        border: solid 2px $grey-semi-darkness;
         border-top: none;
       }
     }
 
     .mapboxgl-ctrl.mapboxgl-ctrl-attrib {
       text-align: left;
-      position: fixed;
-      margin: 0;
-      bottom: -2px;
-      left: 13px;
+
+      &.mapboxgl-compact {
+        margin: 0 $spacing-s 0 0;
+      }
 
       &.mapboxgl-compact-show {
-        width: calc(100vw - 95px);
+        max-width: calc(100vw - 95px);
+        font-size: 10px;
+        line-height: 14px;
+        align-self: flex-end;
       }
 
       .mapboxgl-ctrl-attrib-button {
         top: auto;
         right: auto;
-        bottom: 0;
+        height: 20px;
+        width: 20px;
+        top: 0;
         left: 0;
-        background: url('../images/feather/info.svg') no-repeat center center rgba(255,255,255,0.8);
+        background: url('../images/feather/info.svg') no-repeat center center rgba(255,255,255,0.9);
       }
 
       &.mapboxgl-compact-show {
-        background: rgba(255, 255, 255, 0.9);
-        padding: 2px 8px 2px 28px;
+        background: rgba(255, 255, 255, 0.8);
+        padding: 3px 8px 3px 24px;
 
         .mapboxgl-ctrl-attrib-button {
           background-color: transparent;


### PR DESCRIPTION
## Description
Style adjustements to the scale and attribution controls after design review.
- Mobile:
  - the attribution and scale controls are now aligned with the center of the map button on the right
  - both controls now have the same height, translucent background color, and main color 
  - the attribution control opens to the bottom
- Desktop:
  - the scale value is spaced vertically a bit more from the scale bar

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran de 2021-06-10 16-36-33](https://user-images.githubusercontent.com/243653/121545520-e5463780-ca0a-11eb-9dfd-2c939fc1715a.png)|![Capture d’écran de 2021-06-10 16-33-12](https://user-images.githubusercontent.com/243653/121545490-deb7c000-ca0a-11eb-9ab0-6a3850f36d22.png)|
|![Capture d’écran de 2021-06-10 16-36-40](https://user-images.githubusercontent.com/243653/121545146-8bde0880-ca0a-11eb-9320-5b09c71b3b41.png)|![localhost_3000_(iPhone 6_7_8)](https://user-images.githubusercontent.com/243653/121547147-2a1e9e00-ca0c-11eb-8faf-67d37915529e.png)|
|![Capture d’écran de 2021-06-10 16-37-26](https://user-images.githubusercontent.com/243653/121544723-3a357e00-ca0a-11eb-9233-a1c63a961a4b.png)|![Capture d’écran de 2021-06-10 16-37-45](https://user-images.githubusercontent.com/243653/121544735-3c97d800-ca0a-11eb-81cf-71c0b93db035.png)|

