### PR TITLE
QMAPS-2173 fix iOS submit from keyboard

### DIFF
--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -94,7 +94,7 @@ const TopBar = ({ value, setUserInputValue, inputRef, onSuggestToggle, backButto
         ['top_bar--back_action']: !!backButtonAction,
       })}
     >
-      <form onSubmit={() => false} noValidate className="search_form" ref={barElement}>
+      <form onSubmit={onSubmit} noValidate className="search_form" ref={barElement}>
         <button
           type="button"
           onClick={() => {

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -147,13 +147,7 @@ const TopBar = ({ value, setUserInputValue, inputRef, onSuggestToggle, backButto
             type="button"
             onMouseDown={onClear}
           />
-          <input
-            className="search_form__action"
-            type="submit"
-            value=""
-            title={_('Search')}
-            onClick={onSubmit}
-          />
+          <input className="search_form__action" type="submit" value="" title={_('Search')} />
         </div>
         {isMobile && config.burgerMenu.enabled && (
           <div id="react_menu__container">


### PR DESCRIPTION
## Description
Fix a bug on iOS Safari and other browsers, where using the "Return" key of the virtual keyboard would open a new tab instead of searching for the first result.

## Why
It seems that the "Return" key of the iOS virtual keyboard is context-aware and doesn't always send a keyboard event with the "Enter" keycode, so our code based on the key pressed in `Suggest` wasn't run. Instead, the key directly triggers a `submit` event on the current `<form>`, and a real form HTTP request was sent.

Properly mapping the `submit` event on the form to the existing `onSubmit` action solves the problem.
`onSubmit` was used directly on the submit button, but this is actually a better HTML markup to put it only on the form and let the `type="submit"` attribute do its job.