### PR TITLE
User feedback: use local storage abstraction layer

### DIFF
--- a/src/libs/userFeedback.js
+++ b/src/libs/userFeedback.js
@@ -1,6 +1,6 @@
 import Telemetry from 'src/libs/telemetry';
 import { isMobileDevice } from 'src/libs/device';
-import { version } from 'config/constants.yml';
+import { set as setLocalStorageItem, get as getLocalStorageItem } from 'src/adapters/store';
 
 function sendAnswer(questionId, answer, { context } = {}) {
   const { locale, code } = window.getLang();
@@ -19,7 +19,7 @@ function sendAnswer(questionId, answer, { context } = {}) {
   });
 }
 
-const storagePrefix = `qmaps_v${version}_userFeedback_`;
+const storagePrefix = `userFeedback_`;
 const dayToMs = days => days * 24 * 60 * 60 * 1000;
 
 const answeredDuringSession = [];
@@ -28,11 +28,11 @@ function shouldBeDisplayed(questionId, hideForDays = 15) {
   if (answeredDuringSession.includes(questionId)) {
     return false;
   }
-  const previouslyAnswered = localStorage.getItem(`${storagePrefix}${questionId}`);
+  const previouslyAnswered = getLocalStorageItem(`${storagePrefix}${questionId}`);
   if (!previouslyAnswered) {
     return true;
   }
-  const { answer, date } = JSON.parse(previouslyAnswered);
+  const { answer, date } = previouslyAnswered;
   // For now only hide further questions if the user dismissed the widget
   if (answer !== 'dismiss') {
     return true;
@@ -42,10 +42,7 @@ function shouldBeDisplayed(questionId, hideForDays = 15) {
 
 function rememberAnswer(questionId, answer) {
   answeredDuringSession.push(questionId);
-  localStorage.setItem(
-    `${storagePrefix}${questionId}`,
-    JSON.stringify({ answer, date: new Date().toISOString() })
-  );
+  setLocalStorageItem(`${storagePrefix}${questionId}`, { answer, date: new Date().toISOString() });
 }
 
 export { sendAnswer, shouldBeDisplayed, rememberAnswer };


### PR DESCRIPTION
## Description
Following this remark https://github.com/Qwant/erdapfel/pull/1118/files#r649944774, use our local storage abstraction layer for user feedback instead of manipulating it directly.

## Why
Benefits of the abstraction layer:
 - security against localStorage exceptions
 - guarantee of the same prefix key
 - auto JSON (de-)serialization