### PR TITLE
QMAPS-2179 sticky feedback on mobile poi list

### DIFF
--- a/src/scss/includes/components/feedback.scss
+++ b/src/scss/includes/components/feedback.scss
@@ -1,4 +1,5 @@
 .feedback {
+  background-color: $background;
   border-top: 1px solid $grey-light;
   padding: $spacing-s $spacing-m;
 

--- a/src/scss/includes/panels/categories.scss
+++ b/src/scss/includes/panels/categories.scss
@@ -53,6 +53,17 @@
     &.panel--pj {
       padding: 0 0 36px;
     }
+
+    &:not(.maximized) {
+      .feedback {
+        display: none;
+      }
+    }
+
+    .feedback, .feedback-success {
+      position: sticky;
+      bottom: 0;
+    }
   }
 
   .category__panel__error {


### PR DESCRIPTION
## Description
Fix the user feedback block on maximized POI list, instead of making it part of the scrollable content.

## Why
Make it so that the user doesn't have to scroll to the bottom of the list to see the feedback question.

## Screenshots

https://user-images.githubusercontent.com/243653/122059409-e4d3e500-cdec-11eb-8ae2-6c53777b4760.MP4

