### PR TITLE
QMAPS-1797 new poi popup

### DIFF
--- a/src/adapters/poi_popup.js
+++ b/src/adapters/poi_popup.js
@@ -4,7 +4,7 @@ import { Popup } from 'mapbox-gl--ENV';
 import ApiPoi from './poi/idunn_poi';
 import { isMobileDevice } from 'src/libs/device';
 import ReactPoiPopup from 'src/components/PoiPopup';
-import { listen } from 'src/libs/customEvents';
+import { fire, listen } from 'src/libs/customEvents';
 
 const WAIT_BEFORE_DISPLAY = 350;
 
@@ -53,6 +53,7 @@ PoiPopup.prototype.addListener = function (layer) {
 
   this.map.on('mouseleave', layer, async () => {
     clearTimeout(this.timeOutHandler);
+    fire('start_close_popup_timeout');
   });
 };
 

--- a/src/adapters/poi_popup.js
+++ b/src/adapters/poi_popup.js
@@ -7,7 +7,7 @@ import ReactPoiPopup from 'src/components/PoiPopup';
 import { fire, listen } from 'src/libs/customEvents';
 
 const WAIT_BEFORE_DISPLAY = 350;
-const WAIT_BEFORE_CLOSE = 200;
+const WAIT_BEFORE_CLOSE = 350;
 
 function PoiPopup() {}
 

--- a/src/adapters/poi_popup.js
+++ b/src/adapters/poi_popup.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import renderStaticReact from 'src/libs/renderStaticReact';
+import ReactDOM from 'react-dom';
 import { Popup } from 'mapbox-gl--ENV';
 import ApiPoi from './poi/idunn_poi';
 import { isMobileDevice } from 'src/libs/device';
@@ -47,16 +47,11 @@ PoiPopup.prototype.addListener = function (layer) {
     }, WAIT_BEFORE_DISPLAY);
   });
 
-  this.map.on('move', () => {
-    this.close();
-  });
-
   this.map.on('click', () => {
     this.close();
   });
 
   this.map.on('mouseleave', layer, async () => {
-    this.close();
     clearTimeout(this.timeOutHandler);
   });
 };
@@ -87,8 +82,13 @@ PoiPopup.prototype.showPopup = function (poi, event) {
 
   this.popupHandle = new Popup(popupOptions)
     .setLngLat(poi.latLon)
-    .setHTML(renderStaticReact(<ReactPoiPopup poi={poi} />))
+    .setHTML('<div class="poi_popup__wrapper"/></div>')
     .addTo(this.map);
+
+  const popup_wrapper = document.querySelector('.poi_popup__wrapper');
+  if (popup_wrapper) {
+    ReactDOM.render(<ReactPoiPopup poi={poi} />, popup_wrapper);
+  }
 };
 
 PoiPopup.prototype.getPopupAnchor = function (event) {

--- a/src/adapters/poi_popup.js
+++ b/src/adapters/poi_popup.js
@@ -126,8 +126,8 @@ PoiPopup.prototype.getPopupAnchor = function (event) {
 };
 
 PoiPopup.prototype.close = function () {
-  fire('stop_close_popup_timeout');
   if (this.popupHandle) {
+    fire('stop_close_popup_timeout');
     this.popupHandle.remove();
     this.popupHandle = null;
   }

--- a/src/adapters/scene_category.js
+++ b/src/adapters/scene_category.js
@@ -87,7 +87,7 @@ export default class SceneCategory {
     this.layers.forEach(layerName => {
       this.map.on('click', layerName, this.handleLayerMarkerClick);
       if (!isMobileDevice()) {
-        this.map.on('mousemove', layerName, this.handleLayerMarkerMouseMove);
+        this.map.on('mouseover', layerName, this.handleLayerMarkerMouseOver);
         this.map.on('mouseleave', layerName, this.handleLayerMarkerMouseLeave);
       }
     });
@@ -133,19 +133,25 @@ export default class SceneCategory {
     });
   };
 
-  handleLayerMarkerMouseMove = e => {
+  handleLayerMarkerMouseOver = e => {
     this.map.getCanvas().style.cursor = 'pointer';
     const poi = this.getPointedPoi(e);
+
+    // Un-highlight the previously highlighted PoI if a new one is hovered
+    if (this.hoveredPoi) {
+      this.highlightPoiMarker(this.hoveredPoi, false);
+      fire('close_popup');
+    }
+
+    // Highlight the new PoI
     if (this.selectedPoi?.id !== poi.id) {
       this.highlightPoiMarker(poi, true);
-      fire('open_popup', this.getPointedPoi(e), e.originalEvent);
+      fire('open_popup', poi, e.originalEvent);
     }
   };
 
   handleLayerMarkerMouseLeave = () => {
     this.map.getCanvas().style.cursor = '';
-    this.highlightPoiMarker(this.hoveredPoi, false);
-    fire('close_popup');
   };
 
   addCategoryMarkers = (pois = [], poiFilters) => {
@@ -159,6 +165,7 @@ export default class SceneCategory {
   };
 
   removeCategoryMarkers = () => {
+    fire('close_popup');
     this.selectPoiMarker(null);
     this.highlightPoiMarker(this.hoveredPoi, false);
     this.layers.forEach(layerName => {

--- a/src/adapters/scene_category.js
+++ b/src/adapters/scene_category.js
@@ -155,6 +155,8 @@ export default class SceneCategory {
   };
 
   addCategoryMarkers = (pois = [], poiFilters) => {
+    // Close current OSM PoI popup, if it's still open
+    fire('close_popup');
     this.pois = pois;
     this.poiFilters = poiFilters;
     this.setOsmPoisVisibility(false);
@@ -165,6 +167,7 @@ export default class SceneCategory {
   };
 
   removeCategoryMarkers = () => {
+    // Close current PJ PoI popup, if it's still open
     fire('close_popup');
     this.selectPoiMarker(null);
     this.highlightPoiMarker(this.hoveredPoi, false);

--- a/src/components/OpeningHour.jsx
+++ b/src/components/OpeningHour.jsx
@@ -57,7 +57,6 @@ const OpeningHour = ({ schedule, showNextOpenOnly = false, className }) => {
     <span
       className={classnames(
         'openingHour',
-        'u-text--subtitle',
         {
           [`openingHour--${status}`]: status,
           'openingHour--24-7': isTwentyFourSeven,

--- a/src/components/PoiItem.jsx
+++ b/src/components/PoiItem.jsx
@@ -29,7 +29,7 @@ const PoiItem = React.memo(
             </div>
           )}
           <div className="poiItem-subclassAndHours">
-            <div className="poiItem-subclass u-text--subtitle">{subclass}</div>
+            <div className="poiItem-subclass">{subclass}</div>
             {inList && subclass && openingHours && '\u00A0⋅\u00A0'}
             {openingHours && (
               <div className="poiItem-openingHour">
@@ -38,7 +38,7 @@ const PoiItem = React.memo(
             )}
           </div>
           {inList && (
-            <div className="poiItem-address u-text--subtitle u-ellipsis">
+            <div className="poiItem-address u-ellipsis">
               <Address address={poi.address} inline omitCountry />
             </div>
           )}

--- a/src/components/PoiPopup.jsx
+++ b/src/components/PoiPopup.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Address from 'src/components/ui/Address';
 import PoiItem from './PoiItem';
 import { fire } from 'src/libs/customEvents';
 
@@ -14,8 +13,7 @@ const PoiPopup = ({ poi }) => {
         fire('close_popup');
       }}
     >
-      <PoiItem poi={poi} className="poi-panel-poiItem" withAlternativeName withOpeningHours />
-      {poi.address && <Address address={poi.address} inline omitCountry />}
+      <PoiItem poi={poi} withOpeningHours withImage inList />
     </div>
   );
 };

--- a/src/components/PoiPopup.jsx
+++ b/src/components/PoiPopup.jsx
@@ -7,6 +7,9 @@ const PoiPopup = ({ poi }) => {
   return (
     <div
       className="poi_popup"
+      onMouseEnter={() => {
+        fire('stop_close_popup_timeout');
+      }}
       onMouseLeave={() => {
         fire('close_popup');
       }}

--- a/src/components/PoiPopup.jsx
+++ b/src/components/PoiPopup.jsx
@@ -1,30 +1,18 @@
 import React from 'react';
-import ReviewScore from 'src/components/ReviewScore';
-import OpeningHour from 'src/components/OpeningHour';
-import OsmSchedule from 'src/adapters/osm_schedule';
-import PoiTitle from 'src/components/PoiTitle';
 import Address from 'src/components/ui/Address';
-import { useConfig } from 'src/hooks';
+import PoiItem from './PoiItem';
+import { fire } from 'src/libs/customEvents';
 
 const PoiPopup = ({ poi }) => {
-  const { enabled: covid19Enabled } = useConfig('covid19');
-
-  const reviews = poi.blocksByType && poi.blocksByType.grades;
-  const openingHours = poi.blocksByType && poi.blocksByType.opening_hours;
-
-  let displayedInfo = null;
-  if (reviews) {
-    displayedInfo = <ReviewScore reviews={reviews} poi={poi} />;
-  } else if (openingHours && !covid19Enabled) {
-    displayedInfo = <OpeningHour schedule={new OsmSchedule(openingHours)} />;
-  } else if (poi.address) {
-    displayedInfo = <Address address={poi.address} inline omitCountry />;
-  }
-
   return (
-    <div className="poi_popup">
-      <PoiTitle poi={poi} />
-      <div>{displayedInfo}</div>
+    <div
+      className="poi_popup"
+      onMouseLeave={() => {
+        fire('close_popup');
+      }}
+    >
+      <PoiItem poi={poi} className="poi-panel-poiItem" withAlternativeName withOpeningHours />
+      {poi.address && <Address address={poi.address} inline omitCountry />}
     </div>
   );
 };

--- a/src/scss/includes/components/poiItem.scss
+++ b/src/scss/includes/components/poiItem.scss
@@ -1,5 +1,4 @@
 .poiItem {
-  cursor: pointer;
   display: flex;
   justify-content: space-between;
 

--- a/src/scss/includes/components/poiItem.scss
+++ b/src/scss/includes/components/poiItem.scss
@@ -11,6 +11,11 @@
   &-left {
     min-width: 0;
     flex: 1;
+    color: $grey-semi-darkness;
+
+    .poiTitle {
+      color: $grey-black;
+    }
   }
 
   &-right {

--- a/src/scss/includes/panels/categories.scss
+++ b/src/scss/includes/panels/categories.scss
@@ -1,6 +1,7 @@
 .category__panel {
   .poiItem {
     padding: 16px 14px;
+    cursor: pointer;
   }
 
   .poiItem-subclassAndHours {
@@ -19,7 +20,6 @@
 
 @media (min-width: 641px) {
   .category__panel {
-
     &.panel--pj {
       .panel-content {
         overflow: hidden;
@@ -60,7 +60,8 @@
       }
     }
 
-    .feedback, .feedback-success {
+    .feedback,
+    .feedback-success {
       position: sticky;
       bottom: 0;
     }

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -1,4 +1,4 @@
-@import "../osm_contribute";
+@import '../osm_contribute';
 
 $BLOCK_PADDING: 24px;
 $BLOCK_ICON_FONT_SIZE: 16px;
@@ -8,6 +8,7 @@ $BLOCK_ICON_FONT_SIZE: 16px;
 
   &-poiItem {
     flex-grow: 1;
+    cursor: pointer;
   }
 }
 
@@ -23,8 +24,12 @@ $BLOCK_ICON_FONT_SIZE: 16px;
 }
 
 @keyframes appear {
-  0% {opacity: 0;}
-  100% {opacity: 1; }
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
 }
 
 .poi_panel__info__hour__circle {
@@ -104,7 +109,7 @@ $BLOCK_ICON_FONT_SIZE: 16px;
     right: 0;
     bottom: 0;
     padding-left: 48px;
-    background: linear-gradient(to right, rgba(255,255,255,0) 0, white 48px, white 100%);
+    background: linear-gradient(to right, rgba(255, 255, 255, 0) 0, white 48px, white 100%);
   }
 }
 
@@ -166,7 +171,7 @@ $BLOCK_ICON_FONT_SIZE: 16px;
 
 .poi_panel__block__collapse {
   cursor: pointer;
-  transition: transform .2s;
+  transition: transform 0.2s;
   font-size: 24px;
   color: $secondary_text;
   margin-left: auto;
@@ -218,7 +223,8 @@ $BLOCK_ICON_FONT_SIZE: 16px;
   }
 
   .poi_panel.panel {
-    &.default, &.minimized {
+    &.default,
+    &.minimized {
       height: auto;
       .panel-drawer {
         min-height: inherit;
@@ -250,6 +256,6 @@ $BLOCK_ICON_FONT_SIZE: 16px;
   }
 }
 
-@import "./covid";
-@import "./timetable";
-@import "./recycling";
+@import './covid';
+@import './timetable';
+@import './recycling';

--- a/src/scss/includes/popup.scss
+++ b/src/scss/includes/popup.scss
@@ -15,8 +15,19 @@
 
 .poi_popup {
   min-width: 300px;
-  border-radius: 4px;
+  border-radius: 12px;
   background: $background;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-  padding: 16px;
+  padding: $spacing-s;
+  position: relative;
+
+  &:after {
+    content: '';
+    position: absolute;
+    top: -50px;
+    left: -50px;
+    width: calc(100% + 100px);
+    height: calc(100% + 100px);
+    z-index: -1;
+  }
 }

--- a/src/scss/includes/popup.scss
+++ b/src/scss/includes/popup.scss
@@ -14,10 +14,26 @@
 }
 
 .poi_popup {
-  min-width: 300px;
+  width: 300px;
   border-radius: 12px;
   background: $background;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  box-shadow: $shadow-hover;
   padding: $spacing-s;
   position: relative;
+
+  .poiItem {
+    align-items: flex-start;
+    font-size: 12px;
+    line-height: 1.33;
+  }
+
+  .poiItem-subclassAndHours {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .poiTitle-main {
+    font-size: 14px;
+    line-height: 1.29;
+  }
 }

--- a/src/scss/includes/popup.scss
+++ b/src/scss/includes/popup.scss
@@ -20,14 +20,4 @@
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
   padding: $spacing-s;
   position: relative;
-
-  &:after {
-    content: '';
-    position: absolute;
-    top: -50px;
-    left: -50px;
-    width: calc(100% + 100px);
-    height: calc(100% + 100px);
-    z-index: -1;
-  }
 }


### PR DESCRIPTION
## Description
- when a marker is hovered on the map, make it possible to hover its popup too
- if we hover another area of the map or another pin, the current popup closes
- show the same information than the top of PoI panel (name, rating, category, hours) + the poi address inside the poi popup
- the CTA buttons will be added in another MR
- make the poi popup's border radius 12px
- make this system work for both PJ (list) and OSM (no-list) markers & popups

## Screenshots
PJ POI:

![image](https://user-images.githubusercontent.com/1225909/122189231-071f3e80-ce91-11eb-9dbb-ae46c46736bd.png)

PJ OSM:

![image](https://user-images.githubusercontent.com/1225909/122189321-21591c80-ce91-11eb-891e-3e018d4999a7.png)

Hover behavior (hover area shown in red here)

![hover](https://user-images.githubusercontent.com/1225909/122955376-59c09500-d380-11eb-8d84-75c0b7e2e99b.gif)


