### PR TITLE
QMAPS fix suggest display for ios <= 13

### DIFF
--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -225,7 +225,6 @@ input[type="search"] {
   }
 
   .search_form__result {
-    position: fixed;
     max-height: none;
     top: $top_bar_height;
     width: 100vw;


### PR DESCRIPTION
## Description
Suggest had disappeared on iOS <= 13 since https://github.com/Qwant/erdapfel/pull/1108
It's there, on top of the map, but stays hidden.
Removing the position:fixed seems to solve the problem, and not cause any regression, so here it is :)
