### PR TITLE
Service panel: replace "service" with "administration"

### DIFF
--- a/config/categories.yml
+++ b/config/categories.yml
@@ -40,7 +40,6 @@
   color: "#a125be"
   matcher:
     regex: "service|car repair|post office|townhall|police|fire station|garage|poste|bureau de poste|gendarmerie|pompiers|caserne de pompiers"
-  icon: service
 - label: _('health')
   name: health
   color: "#1777cb"
@@ -223,6 +222,8 @@
   name: sport_other
 - label: _('administration')
   name: administrative
+  color: "#6d6d76"
+  icon: town-hall
 - label: _('post box')
   name: post_box
 - label: _('playground')


### PR DESCRIPTION
## Description

In the service panel, the button for "service" is replaced with "administration", which will give better results after https://github.com/Qwant/idunn/pull/252 is merged.

I re-used the color from "services" but I'm not sure what is the rule that these colors follow, so this might require an update?

## Why

"Service" was a pretty confusing category, it was hard to define what should fit in it and even harder to build the right filter through the pagesjaunes API.

## Screenshots

![Screenshot_2021-06-17_13-43-42](https://user-images.githubusercontent.com/1173464/122390407-3ce82400-cf72-11eb-8c1c-636b67da9b7b.png)
