### PR TITLE
Service panel: give more space to category name and allow ellipsis

### DIFF
--- a/src/components/ui/MainActionButton.jsx
+++ b/src/components/ui/MainActionButton.jsx
@@ -16,7 +16,7 @@ const MainActionButton = ({ variant, label, onClick, icon, iconStyle, className,
     {...rest}
   >
     <div className={`mainActionButton-icon icon-${icon}`} style={iconStyle} />
-    <div className="mainActionButton-label">{capitalizeFirst(label)}</div>
+    <div className="mainActionButton-label u-ellipsis">{capitalizeFirst(label)}</div>
   </button>
 );
 

--- a/src/scss/includes/components/mainActionButton.scss
+++ b/src/scss/includes/components/mainActionButton.scss
@@ -1,6 +1,6 @@
 .mainActionButton {
   cursor: pointer;
-  padding: 8px 0px;
+  padding: $spacing-xs $spacing-xxxs;
   border-radius: 8px;
 
   &-label {

--- a/src/scss/includes/components/mainActionButton.scss
+++ b/src/scss/includes/components/mainActionButton.scss
@@ -1,6 +1,6 @@
 .mainActionButton {
   cursor: pointer;
-  padding: 8px;
+  padding: 8px 0px;
   border-radius: 8px;
 
   &-label {


### PR DESCRIPTION
## Description

Remove horizontal padding and allow for ellipsis for category names in the service panel.

## Why

This allows to display larger category translations while keeping it centered, ellipsis being used as a last resort if there is not enough space.

## Screenshots

| master (modified strings for showcase) | HEAD |
|-|-|
| ![Screenshot 2021-06-17 at 13-50-12 Qwant Maps](https://user-images.githubusercontent.com/1173464/122392054-d6fc9c00-cf73-11eb-9a96-4406d1cb394b.png) | ![Screenshot 2021-06-17 at 13-48-57 Qwant Maps](https://user-images.githubusercontent.com/1173464/122392078-da902300-cf73-11eb-9692-6695e8408261.png) |