### PR TITLE
Add babel.config.js in docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@
 !views/
 !language/
 !package*.json
+!babel.config.js


### PR DESCRIPTION
## Description
Following #1128, the babel configuration has been moved to the root, and needs to be included in the docker build context. 
