### PR TITLE
Add a new POI CTA for 'transactional' action on PJ POIs

### DIFF
--- a/local_modules/telemetry/index.js
+++ b/local_modules/telemetry/index.js
@@ -52,6 +52,7 @@ module.exports = {
     'poi_pages_jaunes_website',
     'poi_pages_jaunes_reviews',
     'poi_pages_jaunes_itinerary',
+    'poi_pages_jaunes_transactional',
     /* Map */
     'localise_trigger',
     /* Covid-19 */

--- a/public/images/remix/calendar-2-line.svg
+++ b/public/images/remix/calendar-2-line.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor"><path fill="none" d="M0 0h24v24H0z"/><path d="M17 3h4a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h4V1h2v2h6V1h2v2zm3 8H4v8h16v-8zm-5-6H9v2H7V5H4v4h16V5h-3v2h-2V5zm-9 8h2v2H6v-2zm5 0h2v2h-2v-2zm5 0h2v2h-2v-2z"/></svg>

--- a/public/images/remix/file-list-2-line.svg
+++ b/public/images/remix/file-list-2-line.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor"><path fill="none" d="M0 0h24v24H0z"/><path d="M20 22H4a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1h16a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1zm-1-2V4H5v16h14zM8 7h8v2H8V7zm0 4h8v2H8v-2zm0 4h5v2H8v-2z"/></svg>

--- a/src/components/ui/icons.js
+++ b/src/components/ui/icons.js
@@ -10,6 +10,8 @@ export { default as IconMenu } from '../../../public/images/remix/menu-line.svg'
 export { default as IconApps } from '../../../public/images/remix/apps-line.svg';
 export { default as IconThumbUp } from '../../../public/images/remix/thumb-up-line.svg';
 export { default as IconThumbDown } from '../../../public/images/remix/thumb-down-line.svg';
+export { default as IconCalendar } from '../../../public/images/remix/calendar-2-line.svg';
+export { default as IconFileList } from '../../../public/images/remix/file-list-2-line.svg';
 
 export { default as IconAndroid } from '../../../public/images/mobile/android.svg';
 export { default as IconApple } from '../../../public/images/mobile/i-os.svg';

--- a/src/panel/poi/ActionButtons.jsx
+++ b/src/panel/poi/ActionButtons.jsx
@@ -3,8 +3,56 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Telemetry from 'src/libs/telemetry';
 import { Flex, ShareMenu, Button } from 'src/components/ui';
-import { Heart } from 'src/components/ui/icons';
+import { Heart, IconCalendar, IconFileList } from 'src/components/ui/icons';
 import { PINK_DARK } from 'src/libs/colors';
+
+const TransactionalButton = ({ poi }) => {
+  const { booking_url, appointment_url, quotation_request_url } =
+    poi?.blocksByType?.transactional || {};
+
+  let icon;
+  let label;
+  let url;
+  if (booking_url) {
+    icon = <IconCalendar width={16} />;
+    url = booking_url;
+    label = _('Booking', 'poi panel');
+  } else if (appointment_url) {
+    icon = <IconCalendar width={16} />;
+    url = appointment_url;
+    label = _('Appointment', 'poi panel');
+  } else if (quotation_request_url) {
+    icon = <IconFileList width={16} />;
+    url = quotation_request_url;
+    label = _('Request for quotation', 'poi panel');
+  } else {
+    return null;
+  }
+
+  const sendTelemetryEvent = () => {
+    Telemetry.sendPoiEvent(
+      poi,
+      'transactional',
+      Telemetry.buildInteractionData({
+        id: poi.id,
+        source: poi.meta?.source,
+        template: 'single',
+        zone: 'detail',
+        element: 'transactional',
+      })
+    );
+  };
+
+  return (
+    <Button
+      icon={icon}
+      href={url}
+      rel="noopener noreferrer external"
+      title={label}
+      onClick={sendTelemetryEvent}
+    />
+  );
+};
 
 const ActionButtons = ({
   poi,
@@ -48,6 +96,8 @@ const ActionButtons = ({
           title={_('Call', 'poi panel')}
         />
       )}
+
+      <TransactionalButton poi={poi} />
 
       <Button
         className="poi_panel__action__favorite"


### PR DESCRIPTION
## Description
Add a new item in the POI CTA bar, linking to Pages Jaunes "transactional" action (booking, appointment, or RFQ), depending on what is available.

## Screenshots

(Tooltips are platform dependant and only shown here for the button titles :))

Booking:
![Capture d’écran de 2021-06-18 16-56-26](https://user-images.githubusercontent.com/243653/122580387-3206bf80-d056-11eb-9875-394c2c2d8b66.png)
Appointment:
![Capture d’écran de 2021-06-18 16-58-04](https://user-images.githubusercontent.com/243653/122580724-8e69df00-d056-11eb-8f65-47792bd2b0d1.png)
RFQ:
![Capture d’écran de 2021-06-18 16-58-34](https://user-images.githubusercontent.com/243653/122580672-7f832c80-d056-11eb-8c8e-944ce2ff0eca.png)
