### PR TITLE
Properly ignore intention about unknown category in fullText_query middleware

### DIFF
--- a/bin/middlewares/fullText_query.js
+++ b/bin/middlewares/fullText_query.js
@@ -19,7 +19,7 @@ module.exports = function (config) {
   const isIntentionValid = intention =>
     intention &&
     intention.filter &&
-    (intention.filter.q || isCategoryValid(intention.filter.category));
+    (!intention.filter.category || isCategoryValid(intention.filter.category));
 
   // @TODO: import it from client lib src/libs/url_utils.js when possible
   const removeNullEntries = obj =>

--- a/bin/middlewares/fullText_query.js
+++ b/bin/middlewares/fullText_query.js
@@ -13,8 +13,13 @@ module.exports = function (config) {
   const geocoderUrl = idunnBaseUrl + '/v1/search';
   const useNlu = config.services.geocoder.useNlu;
 
+  // @TODO: share intention validation with src/adapters/intention.js
   const categories = yaml.readSync('../../config/categories.yml');
   const isCategoryValid = type => categories.find(category => category.name === type);
+  const isIntentionValid = intention =>
+    intention &&
+    intention.filter &&
+    (intention.filter.q || isCategoryValid(intention.filter.category));
 
   // @TODO: import it from client lib src/libs/url_utils.js when possible
   const removeNullEntries = obj =>
@@ -33,13 +38,13 @@ module.exports = function (config) {
       timeout: idunnTimeout,
     });
     const intention = (response.data.intentions || [])[0];
-    if (intention && intention.filter) {
+    if (isIntentionValid(intention)) {
       const { q, bbox, category } = intention.filter;
       const params = new URLSearchParams(
         removeNullEntries({
           q,
           bbox: bbox && bbox.join(','),
-          type: isCategoryValid(category) ? category : null,
+          type: category,
           client,
         })
       );

--- a/src/adapters/intention.js
+++ b/src/adapters/intention.js
@@ -3,13 +3,14 @@ import { buildQueryString } from 'src/libs/url_utils';
 
 export default class Intention {
   constructor({ filter, description }) {
+    this.filter = filter;
     this.category = CategoryService.getCategoryByName(filter.category);
     this.fullTextQuery = filter.q;
     this.bbox = filter.bbox;
     this.place = description.place;
   }
 
-  isValid = () => this.category || this.fullTextQuery;
+  isValid = () => !this.filter.category || this.category;
 
   toQueryString = () =>
     buildQueryString({


### PR DESCRIPTION
## Description
The intention validation used on server side is made consistent with the implementation defined in "src/adapters/intention.js"

## Why
The validation will transparently ignore intentions that refer to an unknown category. This is more robust and allows new categories to be defined on the back end without disturbing the application.


