### PR TITLE
Service panel: fix "administration" ordering

### DIFF
--- a/config/categories.yml
+++ b/config/categories.yml
@@ -35,11 +35,10 @@
   matcher:
     regex: "cine|leisures?|loisirs?|cin[ée](?:ma)?s?|ugc|path[ée]|th[ée]atres?|parcs?\\s+(?:(?:d')?attractions?|(de\\s+)?loisirs?)|royal kids|laser game|escape game|goolfy|laserquest|max aventure|prizoners|get out !|recreakid|kartings?"
   icon: cinema
-- label: _('service')
-  name: service
-  color: "#a125be"
-  matcher:
-    regex: "service|car repair|post office|townhall|police|fire station|garage|poste|bureau de poste|gendarmerie|pompiers|caserne de pompiers"
+- label: _('administration')
+  name: administrative
+  color: "#6d6d76"
+  icon: town-hall
 - label: _('health')
   name: health
   color: "#1777cb"
@@ -74,6 +73,11 @@
 # Only categories with 'icon' are visible as action buttons.
 # Below are the categories that are only accessible
 # via queries (with detected intention) or URL
+- label: _('service')
+  name: service
+  color: "#a125be"
+  matcher:
+    regex: "service|car repair|post office|townhall|police|fire station|garage|poste|bureau de poste|gendarmerie|pompiers|caserne de pompiers"
 - label: _('french restaurant')
   name: food_french
 - label: _('pizzeria')
@@ -220,10 +224,6 @@
   name: shop_travel_agency
 - label: _('sport')
   name: sport_other
-- label: _('administration')
-  name: administrative
-  color: "#6d6d76"
-  icon: town-hall
 - label: _('post box')
   name: post_box
 - label: _('playground')


### PR DESCRIPTION
In https://github.com/Qwant/erdapfel/pull/1126, the category "service" was removed from the service panel and replaced with "administration". This change omitted to preserve the order of categories which may be meaningful, so this PR is just here to fix that.

![Screenshot_2021-06-24_15-00-29](https://user-images.githubusercontent.com/1173464/123267121-f1e38900-d4fc-11eb-881a-f7a9b8e459c3.png)
