### PR TITLE
QMAPS-2178 add popup buttons

### DIFF
--- a/src/components/PoiPopup.jsx
+++ b/src/components/PoiPopup.jsx
@@ -2,13 +2,13 @@ import React, { useState } from 'react';
 import PoiItem from './PoiItem';
 import { fire } from 'src/libs/customEvents';
 import ActionButtons from '../panel/poi/ActionButtons';
-import nconf from '@qwant/nconf-getter';
 import Telemetry from '../libs/telemetry';
 import { addToFavorites, isInFavorites, removeFromFavorites } from '../adapters/store';
+import { useConfig } from '../hooks';
 
 const PoiPopup = ({ poi }) => {
   const [inFavorites, setInFavorites] = useState(isInFavorites(poi));
-  const isDirectionActive = nconf.get().direction.enabled;
+  const isDirectionActive = useConfig('direction').enabled;
 
   const openDirection = () => {
     Telemetry.sendPoiEvent(poi, 'itinerary');

--- a/src/components/PoiPopup.jsx
+++ b/src/components/PoiPopup.jsx
@@ -1,8 +1,46 @@
 import React from 'react';
 import PoiItem from './PoiItem';
 import { fire } from 'src/libs/customEvents';
+import ActionButtons from '../panel/poi/ActionButtons';
+import nconf from '@qwant/nconf-getter';
+import Telemetry from '../libs/telemetry';
+import { addToFavorites, isInFavorites, removeFromFavorites } from '../adapters/store';
 
 const PoiPopup = ({ poi }) => {
+  const isDirectionActive = nconf.get().direction.enabled;
+
+  const openDirection = () => {
+    Telemetry.sendPoiEvent(poi, 'itinerary');
+    window.app.navigateTo('/routes/', { poi });
+  };
+
+  const onClickPhoneNumber = () => {
+    const source = poi.meta && poi.meta.source;
+    if (source) {
+      Telemetry.sendPoiEvent(
+        poi,
+        'phone',
+        Telemetry.buildInteractionData({
+          id: poi.id,
+          source,
+          template: 'single',
+          zone: 'detail',
+          element: 'phone',
+        })
+      );
+    }
+  };
+
+  const toggleStorePoi = () => {
+    const inFavorites = isInFavorites(poi);
+    Telemetry.sendPoiEvent(poi, 'favorite', { stored: !inFavorites });
+    if (inFavorites) {
+      removeFromFavorites(poi);
+    } else {
+      addToFavorites(poi);
+    }
+  };
+
   return (
     <div
       className="poi_popup"
@@ -13,7 +51,17 @@ const PoiPopup = ({ poi }) => {
         fire('close_popup');
       }}
     >
-      <PoiItem poi={poi} withOpeningHours withImage inList />
+      <div className="u-mb-s">
+        <PoiItem poi={poi} withOpeningHours withImage inList />
+      </div>
+      <ActionButtons
+        poi={poi}
+        isDirectionActive={isDirectionActive}
+        openDirection={openDirection}
+        onClickPhoneNumber={onClickPhoneNumber}
+        isPoiInFavorite={isInFavorites(poi)}
+        toggleStorePoi={toggleStorePoi}
+      />
     </div>
   );
 };

--- a/src/components/PoiPopup.jsx
+++ b/src/components/PoiPopup.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PoiItem from './PoiItem';
 import { fire } from 'src/libs/customEvents';
 import ActionButtons from '../panel/poi/ActionButtons';
@@ -7,6 +7,7 @@ import Telemetry from '../libs/telemetry';
 import { addToFavorites, isInFavorites, removeFromFavorites } from '../adapters/store';
 
 const PoiPopup = ({ poi }) => {
+  const [inFavorites, setInFavorites] = useState(isInFavorites(poi));
   const isDirectionActive = nconf.get().direction.enabled;
 
   const openDirection = () => {
@@ -32,13 +33,14 @@ const PoiPopup = ({ poi }) => {
   };
 
   const toggleStorePoi = () => {
-    const inFavorites = isInFavorites(poi);
-    Telemetry.sendPoiEvent(poi, 'favorite', { stored: !inFavorites });
-    if (inFavorites) {
+    const isFavorite = isInFavorites(poi);
+    Telemetry.sendPoiEvent(poi, 'favorite', { stored: !isFavorite });
+    if (isFavorite) {
       removeFromFavorites(poi);
     } else {
       addToFavorites(poi);
     }
+    setInFavorites(!isFavorite);
   };
 
   return (
@@ -59,7 +61,7 @@ const PoiPopup = ({ poi }) => {
         isDirectionActive={isDirectionActive}
         openDirection={openDirection}
         onClickPhoneNumber={onClickPhoneNumber}
-        isPoiInFavorite={isInFavorites(poi)}
+        isPoiInFavorite={inFavorites}
         toggleStorePoi={toggleStorePoi}
       />
     </div>

--- a/src/scss/includes/popup.scss
+++ b/src/scss/includes/popup.scss
@@ -36,4 +36,23 @@
     font-size: 14px;
     line-height: 1.29;
   }
+
+  // Directions button
+  .button--primary {
+    font-size: 12px;
+    font-weight: normal;
+    height: 24px;
+  }
+
+  // Call / Book / Like / Share buttons
+  .button--secondary {
+    padding: 4px;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+
+    .button-icon {
+      font-size: 13px;
+    }
+  }
 }


### PR DESCRIPTION
## Description
Add buttons at the bottom of OSM/PJ Popups (directions / phone / booking / like / share)

## Screenshots
![image](https://user-images.githubusercontent.com/1225909/123670661-bc60d780-d83d-11eb-8f67-ac36dd29d312.png)

