### PR TITLE
QMAPS-2191 remove Beta from logo and title

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -22,9 +22,6 @@ server:
   unsupportedBrowsers:
     redirect: false
 
-app:
-  versionFlag: Beta
-
 # Services
 services:
   geocoder:

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "Qwant Maps",
-  "name": "Qwant Maps - Beta",
+  "name": "Qwant Maps",
   "icons": [
     {
       "src": "./images/logo_128.png",

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -102,7 +102,6 @@ const TopBar = ({ value, setUserInputValue, inputRef, onSuggestToggle, backButto
           }}
           className="search_form__logo__button"
           title={_('Qwant Maps Home', 'search bar')}
-          data-flag-text={config.app.versionFlag}
         />
         <div className="search_form__wrapper">
           <div className="search_form__return icon-arrow-left" onMouseDown={backButtonAction} />

--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -69,21 +69,6 @@ input[type="search"] {
   background: url(../images/qwant-logo.svg) no-repeat;
   background-size: cover;
   margin: 0 $spacing-m 0 $spacing-s;
-
-  &[data-flag-text]:before {
-    font-weight: bold;
-    content: attr(data-flag-text);
-    background: $secondary_text;
-    color: $grey-light;
-    position: absolute;
-    left: 28px;
-    top: 10px;
-    font-size: 10px;
-    line-height: 14px;
-    padding: 1px 3px;
-    border-radius: 6px;
-    border: 2px solid white;
-  }
 }
 
 // Return arrows

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -3,7 +3,6 @@
   <head>
     <meta charset='utf-8'>
     <title><%= _('Qwant Maps') %>
-      <% if(config.app.versionFlag) { %> - <%= config.app.versionFlag %><% } %>
       <% if(config.envName) { %> - <%= config.envName %><% } %>
     </title>
     <meta name="description" content="<%= _('The map that respects your privacy') %>">


### PR DESCRIPTION
## Description
Remove "Beta" from logo and title
NB: I didn't touch BetaInfoBox (which appears when a language is not supported and tells that we're still in beta).
@Charlotte-Ziegler please tell me if it needs to be removed or rephrased. If yes I can do that in a separate issue.


## Screenshots
![image](https://user-images.githubusercontent.com/1225909/123824166-15904000-d8fe-11eb-82d7-dde724136311.png)

