### PR TITLE
Qmaps 2187 Increase feedback message duration

### DIFF
--- a/src/components/ui/Alert.jsx
+++ b/src/components/ui/Alert.jsx
@@ -1,27 +1,29 @@
 import React, { useEffect, useState, useRef } from 'react';
 import cs from 'classnames';
-import { string, node } from 'prop-types';
+import { string, node, number } from 'prop-types';
 import { CloseButton } from './index';
 import { IconCheckboxCircle } from './icons';
 import { GREEN_DARK } from 'src/libs/colors';
 
-const Alert = ({ className = '', children, type }) => {
+const Alert = ({ className = '', autoHideDelay, children, type }) => {
   const [hidden, setHidden] = useState(false);
   const alertRef = useRef();
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      // Animate is not supported on old iOS
-      if (alertRef.current && alertRef.current.animate) {
-        alertRef.current.animate([{ opacity: 1 }, { opacity: 0 }], 300).onfinish = () => {
+    if (autoHideDelay) {
+      const timer = setTimeout(() => {
+        // Animate is not supported on old iOS
+        if (alertRef.current && alertRef.current.animate) {
+          alertRef.current.animate([{ opacity: 1 }, { opacity: 0 }], 300).onfinish = () => {
+            setHidden(true);
+          };
+        } else {
           setHidden(true);
-        };
-      } else {
-        setHidden(true);
-      }
-    }, 3000);
-    return () => clearTimeout(timer);
-  }, [alertRef]);
+        }
+      }, autoHideDelay);
+      return () => clearTimeout(timer);
+    }
+  }, [alertRef, autoHideDelay]);
 
   if (hidden) {
     return null;
@@ -44,6 +46,7 @@ Alert.propTypes = {
   className: string,
   children: node.isRequired,
   type: string,
+  autoHideDelay: number,
 };
 
 export default Alert;

--- a/src/components/ui/UserFeedbackYesNo.jsx
+++ b/src/components/ui/UserFeedbackYesNo.jsx
@@ -28,7 +28,9 @@ const UserFeedbackYesNo = ({ questionId, context, question }) => {
   if (isAnswered) {
     return (
       <div className="feedback-success">
-        <Alert type="success">{_('Thank you for helping us to improve your experience.')}</Alert>
+        <Alert type="success" autoHideDelay={5000}>
+          {_('Thank you for helping us to improve your experience.')}
+        </Alert>
       </div>
     );
   }


### PR DESCRIPTION
## Description
Add a new prop to the `Alert` component to control for how long it remains displayed before disappearing.
Use this prop to set the duration of user feedback "thank you" messages to 5 seconds instead of 3 seconds.