### PR TITLE
React: Convert PoiPanel to a functional component

### DIFF
--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -115,14 +115,29 @@ const PanelManager = ({ router }) => {
       const [poi, params] = urlPart.split('?');
       const { q: query } = parseQueryString(params);
       const poiId = poi.split('@')[0];
+      const { pois, poiFilters = {}, isFromFavorite } = options;
+
+      if (pois) {
+        window.execOnMapLoaded(() => {
+          fire('add_category_markers', options.pois, poiFilters);
+        });
+      }
+
+      let backAction = null;
+      if (poiFilters.category || poiFilters.query) {
+        backAction = e => backToList(e, poiFilters);
+      } else if (isFromFavorite) {
+        backAction = backToFavorite;
+      }
+
       setPanelOptions({
         ActivePanel: PoiPanel,
         options: {
           ...options,
           query,
           poiId,
-          backToList,
-          backToFavorite,
+          backAction,
+          inList: !!pois,
         },
         panelSize: 'default',
       });

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -10,27 +10,38 @@ import { Panel, PanelNav, Button } from 'src/components/ui';
 import { BackToQwantButton } from 'src/components/BackToQwantButton';
 import { useDevice, useI18n } from 'src/hooks';
 
-const PoiPanel = ({ poi, poiId, backAction, inList }) => {
+const PoiPanel = ({ poi, poiId, backAction, inList, centerMap }) => {
   const { isMobile } = useDevice();
   const [fullPoi, setFullPoi] = useState(poi);
   const { _ } = useI18n();
 
   useEffect(() => {
-    if (fullPoi) {
+    // direction shortcut will be visible in minimized state
+    fire('mobile_direction_button_visibility', false);
+
+    return () => {
+      fire('move_mobile_bottom_ui', 0);
+      fire('mobile_direction_button_visibility', true);
+    };
+  }, []);
+
+  useEffect(() => {
+    const mapPoi = poi || fullPoi;
+    if (mapPoi) {
       window.execOnMapLoaded(() => {
         if (inList) {
-          fire('click_category_marker', fullPoi);
+          fire('click_category_marker', mapPoi);
         } else {
-          fire('create_poi_marker', fullPoi);
+          fire('create_poi_marker', mapPoi);
         }
-        fire('ensure_poi_visible', fullPoi, {});
+        fire('ensure_poi_visible', mapPoi, { centerMap });
       });
     }
 
     return () => {
       fire('clean_marker');
     };
-  }, [fullPoi, inList]);
+  }, [poi, fullPoi, inList, centerMap]);
 
   useEffect(() => {
     const loadPoi = async () => {
@@ -113,6 +124,7 @@ PoiPanel.propTypes = {
   poi: PropTypes.object,
   backAction: PropTypes.func,
   inList: PropTypes.bool,
+  centerMap: PropTypes.bool,
 };
 
 export default PoiPanel;

--- a/src/panel/poi/PoiPanelContent.jsx
+++ b/src/panel/poi/PoiPanelContent.jsx
@@ -18,6 +18,10 @@ const PoiPanelContent = ({ poi }) => {
   const { enabled: isDirectionActive } = useConfig('direction');
 
   useEffect(() => {
+    setPoiInFavorite(isInFavorites(poi));
+  }, [poi]);
+
+  useEffect(() => {
     // direction shortcut will be visible in minimized state
     fire('mobile_direction_button_visibility', false);
     fire('set_direction_shortcut_callback', openDirection);

--- a/src/panel/poi/PoiPanelContent.jsx
+++ b/src/panel/poi/PoiPanelContent.jsx
@@ -22,8 +22,6 @@ const PoiPanelContent = ({ poi }) => {
   }, [poi]);
 
   useEffect(() => {
-    // direction shortcut will be visible in minimized state
-    fire('mobile_direction_button_visibility', false);
     fire('set_direction_shortcut_callback', openDirection);
 
     // @TODO: use a global favorite context
@@ -38,8 +36,6 @@ const PoiPanelContent = ({ poi }) => {
 
     return () => {
       unListen(storePoiChangeHandler);
-      fire('move_mobile_bottom_ui', 0);
-      fire('mobile_direction_button_visibility', true);
       // Clear direction shortcut cb to reset default action
       fire('set_direction_shortcut_callback', null);
     };

--- a/src/panel/poi/PoiPanelContent.jsx
+++ b/src/panel/poi/PoiPanelContent.jsx
@@ -1,0 +1,126 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import Telemetry from 'src/libs/telemetry';
+import ActionButtons from './ActionButtons';
+import PoiBlockContainer from './PoiBlockContainer';
+import OsmContribution from 'src/components/OsmContribution';
+import CategoryList from 'src/components/CategoryList';
+import { isFromPagesJaunes, isFromOSM } from 'src/libs/pois';
+import { fire, listen, unListen } from 'src/libs/customEvents';
+import { addToFavorites, removeFromFavorites, isInFavorites } from 'src/adapters/store';
+import PoiItem from 'src/components/PoiItem';
+import { Flex, Divider } from 'src/components/ui';
+import { useConfig, useI18n } from 'src/hooks';
+
+const PoiPanelContent = ({ poi }) => {
+  const { _ } = useI18n();
+  const [isPoiInFavorite, setPoiInFavorite] = useState(isInFavorites(poi));
+  const { enabled: isDirectionActive } = useConfig('direction');
+
+  useEffect(() => {
+    // direction shortcut will be visible in minimized state
+    fire('mobile_direction_button_visibility', false);
+    fire('set_direction_shortcut_callback', openDirection);
+
+    // @TODO: use a global favorite context
+    const storePoiChangeHandler = listen(
+      'poi_favorite_state_changed',
+      (changedFavPoi, isPoiInFavorite) => {
+        if (changedFavPoi === poi) {
+          setPoiInFavorite(isPoiInFavorite);
+        }
+      }
+    );
+
+    return () => {
+      unListen(storePoiChangeHandler);
+      fire('move_mobile_bottom_ui', 0);
+      fire('mobile_direction_button_visibility', true);
+      // Clear direction shortcut cb to reset default action
+      fire('set_direction_shortcut_callback', null);
+    };
+  }, [poi, openDirection]);
+
+  const center = () => {
+    Telemetry.sendPoiEvent(poi, 'go');
+    fire('fit_map', poi);
+  };
+
+  const openDirection = useCallback(() => {
+    Telemetry.sendPoiEvent(poi, 'itinerary');
+    window.app.navigateTo('/routes/', { poi });
+  }, [poi]);
+
+  const onClickPhoneNumber = () => {
+    const source = poi.meta && poi.meta.source;
+    if (source) {
+      Telemetry.sendPoiEvent(
+        poi,
+        'phone',
+        Telemetry.buildInteractionData({
+          id: poi.id,
+          source,
+          template: 'single',
+          zone: 'detail',
+          element: 'phone',
+        })
+      );
+    }
+  };
+
+  const toggleStorePoi = () => {
+    Telemetry.sendPoiEvent(poi, 'favorite', { stored: !isPoiInFavorite });
+    if (isPoiInFavorite) {
+      removeFromFavorites(poi);
+    } else {
+      addToFavorites(poi);
+    }
+  };
+
+  if (!poi) {
+    return null;
+  }
+
+  return (
+    <div className="poi_panel__content">
+      <Flex alignItems="flex-start" justifyContent="space-between">
+        <PoiItem
+          poi={poi}
+          className="u-mb-l poi-panel-poiItem"
+          withAlternativeName
+          withOpeningHours
+          onClick={center}
+        />
+      </Flex>
+      <div className="u-mb-l">
+        <ActionButtons
+          poi={poi}
+          isDirectionActive={isDirectionActive}
+          openDirection={openDirection}
+          onClickPhoneNumber={onClickPhoneNumber}
+          isPoiInFavorite={isPoiInFavorite}
+          toggleStorePoi={toggleStorePoi}
+        />
+      </div>
+      <div className="poi_panel__fullContent">
+        <PoiBlockContainer poi={poi} />
+        {isFromPagesJaunes(poi) && (
+          <div className="poi_panel__info-partnership u-text--caption u-mb-s">
+            {_('In partnership with')}
+            <img src="./statics/images/pj.svg" alt="PagesJaunes" width="80" height="16" />
+          </div>
+        )}
+        {isFromOSM(poi) && <OsmContribution poi={poi} />}
+        <Divider paddingTop={0} className="poi_panel__fullWidth" />
+        <h3 className="u-text--smallTitle u-mb-s">{_('Search around this place', 'poi')}</h3>
+        <CategoryList className="poi_panel__categories u-mb-s" limit={4} />
+      </div>
+    </div>
+  );
+};
+
+PoiPanelContent.propTypes = {
+  poi: PropTypes.object,
+};
+
+export default PoiPanelContent;


### PR DESCRIPTION
## Description
Convert the POI Panel to a functional component, as it's one of the few left that is still a class.

I used the occasion to split the component in two parts:
 - `<PoiPanelContent>` is now responsible for the inner rendering of the panel. It takes only a `poi` prop and doesn't have to care about where it comes from, what's happening on the map, etc.
 - wrapping it, `<PoiPanel>` is now responsible for the data loading and side effects of opening/closing the panel. It's still rather complex, because of the asynchronicity and all the things about POI in the context of a list, but this is simpler to follow.

The next step would be to clean this further by having a top state managing all POIs, multiple and single, to share between POIPanel and CategoryPanel foremost. This would help avoid most of the hacks to know if we come from a list or not.
This PR is a stepping stone to that.

## Why
Simplification, consistency, allow re-use of hooks.