### PR TITLE
Define a new hook to abstract favorite state

### DIFF
--- a/src/components/PoiPopup.jsx
+++ b/src/components/PoiPopup.jsx
@@ -1,13 +1,12 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PoiItem from './PoiItem';
 import { fire } from 'src/libs/customEvents';
 import ActionButtons from '../panel/poi/ActionButtons';
 import Telemetry from '../libs/telemetry';
-import { addToFavorites, isInFavorites, removeFromFavorites } from '../adapters/store';
-import { useConfig } from '../hooks';
+import { useConfig, useFavorites } from '../hooks';
 
 const PoiPopup = ({ poi }) => {
-  const [inFavorites, setInFavorites] = useState(isInFavorites(poi));
+  const { isInFavorites, removeFromFavorites, addToFavorites } = useFavorites();
   const isDirectionActive = useConfig('direction').enabled;
 
   const openDirection = () => {
@@ -40,7 +39,6 @@ const PoiPopup = ({ poi }) => {
     } else {
       addToFavorites(poi);
     }
-    setInFavorites(!isFavorite);
   };
 
   return (
@@ -61,7 +59,7 @@ const PoiPopup = ({ poi }) => {
         isDirectionActive={isDirectionActive}
         openDirection={openDirection}
         onClickPhoneNumber={onClickPhoneNumber}
-        isPoiInFavorite={inFavorites}
+        isPoiInFavorite={isInFavorites(poi)}
         toggleStorePoi={toggleStorePoi}
       />
     </div>

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,3 +1,4 @@
 export { useConfig } from './useConfig';
 export { useDevice } from './useDevice';
 export { useI18n } from './useI18n';
+export { useFavorites } from './useFavorites';

--- a/src/hooks/useFavorites.jsx
+++ b/src/hooks/useFavorites.jsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { listen, unListen } from 'src/libs/customEvents';
+
+import { addToFavorites, removeFromFavorites, isInFavorites } from 'src/adapters/store';
+import PoiStore from 'src/adapters/poi/poi_store';
+
+export const useFavorites = () => {
+  const [favorites, setFavorites] = useState(PoiStore.getAll());
+
+  useEffect(() => {
+    const updateFavState = listen('poi_favorite_state_changed', () => {
+      setFavorites(PoiStore.getAll());
+    });
+
+    return () => {
+      unListen(updateFavState);
+    };
+  });
+
+  return { favorites, addToFavorites, removeFromFavorites, isInFavorites };
+};

--- a/src/panel/favorites/FavoritesPanel.jsx
+++ b/src/panel/favorites/FavoritesPanel.jsx
@@ -1,13 +1,12 @@
 /* globals _ */
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import Telemetry from 'src/libs/telemetry';
 import Panel from 'src/components/ui/Panel';
 import FavoriteItems from './FavoriteItems';
-import { removeFromFavorites } from 'src/adapters/store';
-import PoiStore from 'src/adapters/poi/poi_store';
+import { useFavorites } from 'src/hooks';
 
 const FavoritesPanel = () => {
-  const [favs, setFavs] = useState(PoiStore.getAll());
+  const { favorites, removeFromFavorites } = useFavorites();
 
   useEffect(() => {
     Telemetry.add(Telemetry.FAVORITE_OPEN);
@@ -16,9 +15,6 @@ const FavoritesPanel = () => {
   const removeFav = poi => {
     Telemetry.add(Telemetry.FAVORITE_DELETE);
     removeFromFavorites(poi);
-    // @TODO: manage favorites as an upstream state to avoid this duplication
-    // It could be a context or a dedicated hook.
-    setFavs(favs.filter(favorite => favorite !== poi));
   };
 
   const close = () => {
@@ -31,7 +27,7 @@ const FavoritesPanel = () => {
       resizable
       renderHeader={
         <div className="favorite-header u-text--smallTitle u-center">
-          {favs.length === 0
+          {favorites.length === 0
             ? _('Favorite places', 'favorite panel')
             : _('My favorites', 'favorite panel')}
         </div>
@@ -40,7 +36,7 @@ const FavoritesPanel = () => {
       onClose={close}
       className="favorite_panel"
     >
-      <FavoriteItems favorites={favs} removeFavorite={removeFav} />
+      <FavoriteItems favorites={favorites} removeFavorite={removeFav} />
     </Panel>
   );
 };


### PR DESCRIPTION
## Description
Add a new `useFavorites` hook, to factorize how the favorite list is handled as a React state.
By encapsulating the state management in the hook, we don't have to do it in POI components (panel and popup) to ensure re-rendering.

Another close solution would be to use a React context, but as the popups are in their own render tree, this wouldn't be shared and would require non-trivial refactoring before. Here we still relie on the event system, but we hide this complexity to React component.

## Why
- No more redundant state and event listeners in low-level components
- Update the favorite panel content in real time when favorite are added/removed from the new POI popups