### PR TITLE
QMAPS-2203 prevent multiple geolocation popups per session

### DIFF
--- a/src/adapters/poi/specials/navigator_geolocalisation_poi.js
+++ b/src/adapters/poi/specials/navigator_geolocalisation_poi.js
@@ -25,7 +25,7 @@ export default class NavigatorGeolocalisationPoi extends Poi {
   async geolocate(options = { displayErrorModal: true }) {
     return new Promise((resolve, reject) => {
       this.status = navigatorGeolocationStatus.PENDING;
-      navigator.geolocation.getCurrentPosition(
+      window.getPosition(
         position => {
           this.setPosition({ lat: position.coords.latitude, lng: position.coords.longitude });
           resolve();

--- a/src/libs/geolocation.js
+++ b/src/libs/geolocation.js
@@ -26,3 +26,42 @@ export function handleError(error) {
     fire('open_geolocate_not_activated_modal');
   }
 }
+
+window.position = null;
+window.positionWatchID = null;
+
+// Centralize all the position requests in a single function,
+// to avoid multiple calls to getCurrentPosition or watchPosition
+// (these would cause multiple permission popups on Firefox).
+// The native getCurrentPosition and watchPosition will be replaced by this one.
+window.getPosition = (success, error) => {
+  // The first time where the position is requested in the current session, launch watchPosition()
+  // and save the position in a global variable
+  if (!window.position) {
+    window.positionWatchID = navigator.geolocation._watchPosition(position => {
+      success(position);
+      window.position = position;
+    }, error);
+    window.positionAsked = true;
+  }
+
+  // If the position is asked again in the same session, use the global variable
+  else {
+    if (window.position) {
+      success(window.position);
+    } else {
+      error();
+      return;
+    }
+  }
+  return window.positionWatchID;
+};
+
+// This hack replaces the native functions from navigator.geolocation with the one above
+// to prevent Mapbox from calling getPosition or watchPosition many times per session.
+// clearWatch is replaced by a function that does nothing to keep the watchPosition active.
+window.navigator.geolocation._getCurrentPosition = navigator.geolocation.getCurrentPosition;
+window.navigator.geolocation._watchPosition = window.navigator.geolocation.watchPosition;
+window.navigator.geolocation.getCurrentPosition = window.getPosition;
+window.navigator.geolocation.watchPosition = window.getPosition;
+window.navigator.geolocation.clearWatch = () => {};

--- a/src/mapbox/mobile_compass_control.js
+++ b/src/mapbox/mobile_compass_control.js
@@ -32,7 +32,7 @@ export default class MobileCompassControl {
   }
 
   _geolocate() {
-    navigator.geolocation.getCurrentPosition(
+    window.getPosition(
       position => {
         this._map.flyTo({ center: [position.coords.longitude, position.coords.latitude] });
       },


### PR DESCRIPTION
## Description
Once the position is requested (with "my position" suggest item or Mapbox's Geolocation button), and the permission has been granted, watch the user's position for all the session.
This is done by polyfilling getCurrentPosition and watchPosition with a custom function that mimics them without requesting the browser many times

## Why
calling many times getCurrentPosition or watchPosition duting the same session trigger Firefox Desktop's permission popup many times which is annoying

## TO DO
test to be sure that everything still works on other OS / devices / browsers than Windows 10 / PC / Fx & Chrome

## TO DEBATE
Is it OK to "watch" the user's position even when the Mapbox geolocation button is disabled? (I'd say yes).
No information about the user's position is sent to our servers, and the user is aware that his position is known with this icon:
![image](https://user-images.githubusercontent.com/1225909/124618161-d6bb3680-de77-11eb-885a-1f57b1f983af.png)

## Screenshots
![gps](https://user-images.githubusercontent.com/1225909/124618175-dc188100-de77-11eb-99eb-f6bcb253a5b3.gif)