### PR TITLE
Fix: Don't cancel long touch on touchcancel…

### DIFF
--- a/src/adapters/scene.js
+++ b/src/adapters/scene.js
@@ -226,7 +226,9 @@ Scene.prototype.initMapBox = function ({ locationHash, bbox }) {
 
     const longTouchCancellingEvents = [
       'touchend',
-      'touchcancel',
+      // 'touchcancel', // ignore this event as it's always thrown by Firefox Android
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1481923
+      // Doesn't seem to change the behavior for other browsers
       'touchmove',
       'pointerdrag',
       'pointermove',


### PR DESCRIPTION
## Description
Don't use `touchcancel` as a long-touch breaking event, as it is always thrown by Firefox Mobile so clicking anywhere on the map doesn't work with this browser.
https://bugzilla.mozilla.org/show_bug.cgi?id=1481923

As far as I saw on other browsers (Safari iOS, Chrome Android), this doesn't change the behavior on other platforms.
This is expected, as ost of the time it's `touchend` that is thrown. `touchcancel` is used for more specific cases https://developer.mozilla.org/en-US/docs/Web/API/Element/touchcancel_event