### PR TITLE
QMAPS-2178 Fix popup content

### DIFF
--- a/src/adapters/poi/idunn_poi.js
+++ b/src/adapters/poi/idunn_poi.js
@@ -69,7 +69,7 @@ export default class IdunnPoi extends Poi {
     const url = `${serviceConfig.idunn.url}/v1/places/${obj.id}`;
     let requestParams = {};
     if (options.simple) {
-      requestParams = { verbosity: 'short' };
+      requestParams = { verbosity: 'list' };
     }
     try {
       const headers = QueryContext.toHeaders(obj.queryContext);

--- a/src/scss/includes/popup.scss
+++ b/src/scss/includes/popup.scss
@@ -1,5 +1,4 @@
 .poi_popup__container {
-
   position: absolute;
 
   .mapboxgl-popup-content {
@@ -42,6 +41,7 @@
     font-size: 12px;
     font-weight: normal;
     height: 24px;
+    max-width: 132px;
   }
 
   // Call / Book / Like / Share buttons


### PR DESCRIPTION
## Description
2 simple commits for 2 fixes on the content of newly revamped POI popups:
 - give a max width to the "directions" button, so it doesn't get ridiculously big and matches the design
 - fetch more data by using `verbosity=list` for the Idunn call, as responses with `verbosity=short` lacked the phone and image blocks. Thanks @remi-dupre for the tip!

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran de 2021-07-09 10-59-17](https://user-images.githubusercontent.com/243653/125053621-a22cc200-e0a5-11eb-92d3-2134d24dbaff.png)|![Capture d’écran de 2021-07-09 10-58-27](https://user-images.githubusercontent.com/243653/125053624-a3f68580-e0a5-11eb-8e01-f32241fb1528.png)|