### PR TITLE
QMAPS-2223 Fix share menu used from the POI popups

### DIFF
--- a/src/adapters/poi_popup.js
+++ b/src/adapters/poi_popup.js
@@ -128,6 +128,10 @@ PoiPopup.prototype.getPopupAnchor = function (event) {
 PoiPopup.prototype.close = function () {
   if (this.popupHandle) {
     fire('stop_close_popup_timeout');
+    const popupWrapper = document.querySelector('.poi_popup__wrapper');
+    if (popupWrapper) {
+      ReactDOM.unmountComponentAtNode(popupWrapper);
+    }
     this.popupHandle.remove();
     this.popupHandle = null;
   }

--- a/src/scss/includes/components/shareMenu.scss
+++ b/src/scss/includes/components/shareMenu.scss
@@ -1,7 +1,6 @@
 .shareMenu {
   &-menu {
     position: fixed;
-    z-index: 4;
     margin-left: -120px;
     margin-top: 10px;
     background: $background;

--- a/src/scss/includes/z_index.scss
+++ b/src/scss/includes/z_index.scss
@@ -52,3 +52,7 @@
 .poi_popup__container {
   z-index: 6;
 }
+
+.shareMenu-menu {
+  z-index: 6;
+}


### PR DESCRIPTION
## Description
Fix 2 bugs on the "share" action available now directly from the popups:
 - the menu appeared below the popup => simple z-index problem
 - the menu didn't disappear when it was opened and the mouse left it => more serious cause: now that the popup content is a real React component mounted in its own tree when the popup is displayed, it needs to be properly unmounted then the popup is closed, otherwise the component keeps mounted in memory even if its DOM container is removed, which is a big memleak.

This is the component inspector after multiple popup opening/closing:
![Capture d’écran de 2021-07-15 17-27-56](https://user-images.githubusercontent.com/243653/125816689-9e884caa-9734-4059-9c3a-f35dc1ae494e.png)

If you add Portals to the equation, like used by `ShareMenu`, you get persistent DOM nodes because they are not even in the same DOM tree as the one that was removed.

So we need to explicitely unmount the React component each time a popup closes.