### PR TITLE
QMAPS-2190 Fix empty search on POI opened as new tab 

### DIFF
--- a/src/libs/poiContext.js
+++ b/src/libs/poiContext.js
@@ -1,0 +1,12 @@
+import React, { useState, createContext } from 'react';
+
+export const PoiContext = createContext({
+  activePoi: null,
+  setActivePoi: () => {},
+});
+
+export const PoiProvider = ({ children }) => {
+  const [activePoi, setActivePoi] = useState(null);
+
+  return <PoiContext.Provider value={{ activePoi, setActivePoi }}>{children}</PoiContext.Provider>;
+};

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useCallback } from 'react';
+import React, { useEffect, useRef, useState, useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import FavoritesPanel from './favorites/FavoritesPanel';
 import PoiPanel from './poi/PoiPanel';
@@ -14,10 +14,14 @@ import { PanelContext } from 'src/libs/panelContext.js';
 import NoResultPanel from 'src/panel/NoResultPanel';
 import TopBar from 'src/components/TopBar';
 import { useConfig, useDevice } from 'src/hooks';
+import { PoiContext } from 'src/libs/poiContext';
 
-function getTopBarAppValue({ poiFilters = {}, poi = {}, query } = {}) {
+function getTopBarAppValue(activePoi, { poiFilters = {}, poi = {}, query } = {}) {
   if (poi.name) {
     return poi.name;
+  }
+  if (activePoi?.name) {
+    return activePoi.name;
   }
   if (poiFilters.category) {
     return CategoryService.getCategoryByName(poiFilters.category)?.getInputValue() || '';
@@ -28,6 +32,7 @@ function getTopBarAppValue({ poiFilters = {}, poi = {}, query } = {}) {
 const PanelManager = ({ router }) => {
   const directionConf = useConfig('direction');
   const { isMobile } = useDevice();
+  const { activePoi } = useContext(PoiContext);
 
   const [panelOptions, setPanelOptions] = useState({
     ActivePanel: ServicePanel,
@@ -186,14 +191,14 @@ const PanelManager = ({ router }) => {
 
   // Effects on panel change
   useEffect(() => {
-    setTopBarValue(getTopBarAppValue(panelOptions.options));
+    setTopBarValue(getTopBarAppValue(activePoi, panelOptions.options));
 
     // Not in a "list of PoI" context (options.poiFilters is null)
     if (isNullOrEmpty(panelOptions.options?.poiFilters)) {
       // Markers are not persistent
       fire('remove_category_markers');
     }
-  }, [panelOptions.ActivePanel, panelOptions.options]);
+  }, [panelOptions.ActivePanel, panelOptions.options, activePoi]);
 
   const backToList = (e, poiFilters) => {
     e.stopPropagation();

--- a/src/panel/RootComponent.jsx
+++ b/src/panel/RootComponent.jsx
@@ -5,6 +5,7 @@ import { isMobileDevice, mobileDeviceMediaQuery, DeviceContext } from 'src/libs/
 import { fire } from 'src/libs/customEvents';
 import BetaInfoBox from 'src/components/BetaInfoBox';
 import { useConfig } from 'src/hooks';
+import { PoiProvider } from 'src/libs/poiContext';
 
 const RootComponent = ({ router }) => {
   const [isMobile, setIsMobile] = useState(isMobileDevice());
@@ -30,7 +31,9 @@ const RootComponent = ({ router }) => {
 
   return (
     <DeviceContext.Provider value={{ isMobile }}>
-      <PanelManager router={router} />
+      <PoiProvider>
+        <PanelManager router={router} />
+      </PoiProvider>
       {!isMobile && isBurgerMenuEnabled && <Menu />}
       <BetaInfoBox />
     </DeviceContext.Provider>

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import Telemetry from 'src/libs/telemetry';
 import { shouldShowBackToQwant } from 'src/libs/url_utils';
@@ -9,11 +9,13 @@ import { fire } from 'src/libs/customEvents';
 import { Panel, PanelNav, Button } from 'src/components/ui';
 import { BackToQwantButton } from 'src/components/BackToQwantButton';
 import { useDevice, useI18n } from 'src/hooks';
+import { PoiContext } from 'src/libs/poiContext';
 
 const PoiPanel = ({ poi, poiId, backAction, inList, centerMap }) => {
   const { isMobile } = useDevice();
   const [fullPoi, setFullPoi] = useState(poi);
   const { _ } = useI18n();
+  const { _activePoi, setActivePoi } = useContext(PoiContext);
 
   useEffect(() => {
     // direction shortcut will be visible in minimized state
@@ -70,6 +72,14 @@ const PoiPanel = ({ poi, poiId, backAction, inList, centerMap }) => {
 
     loadPoi();
   }, [poi, poiId, inList]);
+
+  useEffect(() => {
+    setActivePoi(fullPoi);
+
+    return () => {
+      setActivePoi(null);
+    };
+  }, [setActivePoi, fullPoi]);
 
   const closeAction = () => {
     window.app.navigateTo('/');

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useContext } from 'react';
 import PropTypes from 'prop-types';
 import Telemetry from 'src/libs/telemetry';
 import { shouldShowBackToQwant } from 'src/libs/url_utils';
@@ -12,10 +12,15 @@ import { useDevice, useI18n } from 'src/hooks';
 import { PoiContext } from 'src/libs/poiContext';
 
 const PoiPanel = ({ poi, poiId, backAction, inList, centerMap }) => {
+  const { activePoi, setActivePoi } = useContext(PoiContext);
   const { isMobile } = useDevice();
-  const [fullPoi, setFullPoi] = useState(poi);
   const { _ } = useI18n();
-  const { _activePoi, setActivePoi } = useContext(PoiContext);
+
+  useEffect(() => {
+    return () => {
+      setActivePoi(null);
+    };
+  }, [setActivePoi]);
 
   useEffect(() => {
     // direction shortcut will be visible in minimized state
@@ -28,7 +33,7 @@ const PoiPanel = ({ poi, poiId, backAction, inList, centerMap }) => {
   }, []);
 
   useEffect(() => {
-    const mapPoi = poi || fullPoi;
+    const mapPoi = poi || activePoi;
     if (mapPoi) {
       window.execOnMapLoaded(() => {
         if (inList) {
@@ -43,7 +48,7 @@ const PoiPanel = ({ poi, poiId, backAction, inList, centerMap }) => {
     return () => {
       fire('clean_marker');
     };
-  }, [poi, fullPoi, inList, centerMap]);
+  }, [poi, activePoi, inList, centerMap]);
 
   useEffect(() => {
     const loadPoi = async () => {
@@ -66,20 +71,12 @@ const PoiPanel = ({ poi, poiId, backAction, inList, centerMap }) => {
         // @TODO: error message instead of close in case of unrecognized POI
         closeAction();
       } else {
-        setFullPoi(bestPoi);
+        setActivePoi(bestPoi);
       }
     };
 
     loadPoi();
-  }, [poi, poiId, inList]);
-
-  useEffect(() => {
-    setActivePoi(fullPoi);
-
-    return () => {
-      setActivePoi(null);
-    };
-  }, [setActivePoi, fullPoi]);
+  }, [poi, poiId, setActivePoi]);
 
   const closeAction = () => {
     window.app.navigateTo('/');
@@ -124,7 +121,7 @@ const PoiPanel = ({ poi, poiId, backAction, inList, centerMap }) => {
         isMobile && shouldShowBackToQwant() && [<BackToQwantButton key="back-to-qwant" isMobile />]
       }
     >
-      <PoiPanelContent poi={fullPoi} />
+      <PoiPanelContent poi={activePoi || poi} />
     </Panel>
   );
 };


### PR DESCRIPTION
## Description
Declare a new React context for POIs, `POIContext`, and use it to store the currently active POI in a global manner.
Use this info in `PanelManager` to update the search bar content, fixing a bug where it didn't work if the app was initialized with a POI Panel as its first view.

## Why
Currently the search bar value, as computed in `getTopBarAppValue` in `PanelManager.jsx`, depends on "panel options" which are actually browser history state values. On a new tab, this history state is empty, so the POI info is nowhere to be found as everything is managed in the state of `PoiPanel`.
