### PR TITLE
Fix prepare scripts for npm 7.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
     gettext git python3 build-essential ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm i npm@7 -g
+RUN npm i npm@">=7.20" -g
 RUN mkdir -p $PROJECT_DIR
 RUN chown node $PROJECT_DIR
 

--- a/local_modules/qwant-maps-common/package.json
+++ b/local_modules/qwant-maps-common/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "build": "rm -rf dist && rollup -c",
-    "prepare": "npm run build",
+    "prepare": "if [ \"$IGNORE_PREPARE\" != true ]; then npm run build; fi",
     "i18n-scan": "i18next-scanner 'src/*.js'"
   },
   "author": "Qwant",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "i18n-pull": "tx pull --all --force",
     "watch": "webpack --config build/webpack.config.js -w --mode=development",
     "msgmerge": "node local_modules/merge-po/index",
-    "prepare": "if [ \"$IGNORE_PREPARE\" != true ]; then node build/before_build.js && npm rebuild @qwant/qwant-maps-common; fi",
+    "prepare": "if [ \"$IGNORE_PREPARE\" != true ]; then node build/before_build.js; fi",
     "lint": "eslint src bin build tests --ext '.js,.jsx'",
     "lint-fix": "eslint --fix src bin build tests --ext '.js,.jsx'",
     "prettier:check": "prettier --check '{src,bin,build,tests}/**/*.{js,jsx}'",


### PR DESCRIPTION
## Description
[npm v7.20.0](https://github.com/npm/cli/releases/tag/v7.20.0) "fixes" a behavior of `prepare` script on `npm install` and `npm ci`. The prepare script is now executed for all workspaces by default.  

This is a breaking change for our Docker image, as dev dependencies are not present to build "qwant-maps-common" at this stage:
```dockerfile
RUN IGNORE_PREPARE=true npm ci --production
```
So it's no longer required to run `npm rebuild` explicitly, but `IGNORE_PREPARE` needs to be used in the workspace script too.
