### PR TITLE
QMAPS-2220 change page title depending on the app state

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -2,3 +2,4 @@ export { useConfig } from './useConfig';
 export { useDevice } from './useDevice';
 export { useI18n } from './useI18n';
 export { useFavorites } from './useFavorites';
+export { usePageTitle } from './usePageTitle';

--- a/src/hooks/usePageTitle.js
+++ b/src/hooks/usePageTitle.js
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useConfig } from './useConfig';
 
 export const usePageTitle = (title, suffix = 'Qwant Maps') => {
-  const envName = useConfig('envName');
+  const { envName } = useConfig();
 
   useEffect(() => {
     const previousTitle = document.title;

--- a/src/hooks/usePageTitle.js
+++ b/src/hooks/usePageTitle.js
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+export const usePageTitle = (title, suffix = 'Qwant Maps') => {
+  useEffect(() => {
+    const previousTitle = document.title;
+    document.title = [title, suffix].filter(i => i).join(' - ');
+
+    return () => {
+      document.title = previousTitle;
+    };
+  }, [title, suffix]);
+};

--- a/src/hooks/usePageTitle.js
+++ b/src/hooks/usePageTitle.js
@@ -1,12 +1,15 @@
 import { useEffect } from 'react';
+import { useConfig } from './useConfig';
 
 export const usePageTitle = (title, suffix = 'Qwant Maps') => {
+  const envName = useConfig('envName');
+
   useEffect(() => {
     const previousTitle = document.title;
-    document.title = [title, suffix].filter(i => i).join(' - ');
+    document.title = [title, suffix, envName].filter(i => i).join(' - ');
 
     return () => {
       document.title = previousTitle;
     };
-  }, [title, suffix]);
+  }, [title, suffix, envName]);
 };

--- a/src/libs/poiList.js
+++ b/src/libs/poiList.js
@@ -1,0 +1,5 @@
+import CategoryService from 'src/adapters/category_service';
+
+export function getListDescription(category, query) {
+  return CategoryService.getCategoryByName(category)?.getInputValue() || query || null;
+}

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -6,7 +6,6 @@ import ServicePanel from './service/ServicePanel';
 import CategoryPanel from 'src/panel/category/CategoryPanel';
 import DirectionPanel from 'src/panel/direction/DirectionPanel';
 import Telemetry from 'src/libs/telemetry';
-import CategoryService from 'src/adapters/category_service';
 import { parseQueryString, getCurrentUrl, buildQueryString } from 'src/libs/url_utils';
 import { fire, listen, unListen } from 'src/libs/customEvents';
 import { isNullOrEmpty } from 'src/libs/object';
@@ -15,18 +14,15 @@ import NoResultPanel from 'src/panel/NoResultPanel';
 import TopBar from 'src/components/TopBar';
 import { useConfig, useDevice } from 'src/hooks';
 import { PoiContext } from 'src/libs/poiContext';
+import { getListDescription } from 'src/libs/poiList';
 
 function getTopBarAppValue(activePoi, { poiFilters = {}, poi = {}, query } = {}) {
-  if (poi.name) {
-    return poi.name;
-  }
-  if (activePoi?.name) {
-    return activePoi.name;
-  }
-  if (poiFilters.category) {
-    return CategoryService.getCategoryByName(poiFilters.category)?.getInputValue() || '';
-  }
-  return poiFilters.query || query || '';
+  return (
+    poi?.name ||
+    activePoi?.name ||
+    getListDescription(poiFilters.category, poiFilters.query || query) ||
+    ''
+  );
 }
 
 const PanelManager = ({ router }) => {

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -7,7 +7,7 @@ import PoiItemList from './PoiItemList';
 import PoiItemListPlaceholder from './PoiItemListPlaceholder';
 import CategoryPanelError from './CategoryPanelError';
 import Telemetry from 'src/libs/telemetry';
-import { useConfig, useDevice } from 'src/hooks';
+import { useConfig, useDevice, usePageTitle } from 'src/hooks';
 import IdunnPoi from 'src/adapters/poi/idunn_poi';
 import { getVisibleBbox } from 'src/panel/layouts';
 import { fire, listen, unListen } from 'src/libs/customEvents';
@@ -17,6 +17,7 @@ import { sources } from 'config/constants.yml';
 import { BackToQwantButton } from 'src/components/BackToQwantButton';
 import { shouldShowBackToQwant } from 'src/libs/url_utils';
 import { Panel, PanelNav, SourceFooter, UserFeedbackYesNo } from 'src/components/ui';
+import { capitalizeFirst } from 'src/libs/string';
 
 const DEBOUNCE_WAIT = 100;
 
@@ -63,6 +64,8 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
   const [initialLoading, setInitialLoading] = useState(true);
   const { isMobile } = useDevice();
   const { maxPlaces } = useConfig('category');
+
+  usePageTitle(capitalizeFirst(poiFilters.category || poiFilters.query));
 
   useEffect(() => {
     const fetchData = debounce(

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -17,7 +17,7 @@ import { sources } from 'config/constants.yml';
 import { BackToQwantButton } from 'src/components/BackToQwantButton';
 import { shouldShowBackToQwant } from 'src/libs/url_utils';
 import { Panel, PanelNav, SourceFooter, UserFeedbackYesNo } from 'src/components/ui';
-import { capitalizeFirst } from 'src/libs/string';
+import { getListDescription } from 'src/libs/poiList';
 
 const DEBOUNCE_WAIT = 100;
 
@@ -65,7 +65,7 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
   const { isMobile } = useDevice();
   const { maxPlaces } = useConfig('category');
 
-  usePageTitle(capitalizeFirst(poiFilters.category || poiFilters.query));
+  usePageTitle(getListDescription(poiFilters.category, poiFilters.query));
 
   useEffect(() => {
     const fetchData = debounce(

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -25,10 +25,11 @@ import ShareMenu from 'src/components/ui/ShareMenu';
 import { updateQueryString } from 'src/libs/url_utils';
 import MobileRouteDetails from './MobileRouteDetails';
 import { isNullOrEmpty } from 'src/libs/object';
+import { usePageTitle } from 'src/hooks';
 
 const MARGIN_TOP_OFFSET = 64; // reserve space to display map
 
-export default class DirectionPanel extends React.Component {
+class DirectionPanel extends React.Component {
   static propTypes = {
     origin: PropTypes.string,
     destination: PropTypes.string,
@@ -520,3 +521,10 @@ export default class DirectionPanel extends React.Component {
 }
 
 DirectionPanel.contextType = PanelContext;
+
+const DirectionPanelFunc = ({ props }) => {
+  usePageTitle(_('Directions'));
+  return <DirectionPanel {...props} />;
+};
+
+export default DirectionPanelFunc;

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -522,7 +522,7 @@ class DirectionPanel extends React.Component {
 
 DirectionPanel.contextType = PanelContext;
 
-const DirectionPanelFunc = ({ props }) => {
+const DirectionPanelFunc = props => {
   usePageTitle(_('Directions'));
   return <DirectionPanel {...props} />;
 };

--- a/src/panel/favorites/FavoritesPanel.jsx
+++ b/src/panel/favorites/FavoritesPanel.jsx
@@ -3,10 +3,12 @@ import React, { useEffect } from 'react';
 import Telemetry from 'src/libs/telemetry';
 import Panel from 'src/components/ui/Panel';
 import FavoriteItems from './FavoriteItems';
-import { useFavorites } from 'src/hooks';
+import { useFavorites, usePageTitle } from 'src/hooks';
 
 const FavoritesPanel = () => {
   const { favorites, removeFromFavorites } = useFavorites();
+
+  usePageTitle(_('Favorite places', 'favorite panel'));
 
   useEffect(() => {
     Telemetry.add(Telemetry.FAVORITE_OPEN);

--- a/src/panel/poi/PoiPanel.jsx
+++ b/src/panel/poi/PoiPanel.jsx
@@ -8,13 +8,15 @@ import PoiPanelContent from './PoiPanelContent';
 import { fire } from 'src/libs/customEvents';
 import { Panel, PanelNav, Button } from 'src/components/ui';
 import { BackToQwantButton } from 'src/components/BackToQwantButton';
-import { useDevice, useI18n } from 'src/hooks';
+import { useDevice, useI18n, usePageTitle } from 'src/hooks';
 import { PoiContext } from 'src/libs/poiContext';
 
 const PoiPanel = ({ poi, poiId, backAction, inList, centerMap }) => {
   const { activePoi, setActivePoi } = useContext(PoiContext);
   const { isMobile } = useDevice();
   const { _ } = useI18n();
+
+  usePageTitle((activePoi || poi)?.name);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Description
Introduce a new React hook to easily change the page title as a side effect, and use it in the app panels.

|Panel|Page title|
|---|---|
|Service|Qwant Maps|
|POI|\<poi name\> - Qwant Maps|
|Category|\<query or category\> - Qwant Maps|
|Favorites|Favorite places - Qwant Maps|
|Direction|Directions - Qwant Map|

These rules can be improved later, for example by including the origin and destination points in the direction panels, but let's start simple.

## Why
Facilitate navigation in browser history + accessibility

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran de 2021-07-20 15-29-33](https://user-images.githubusercontent.com/243653/126332589-adf4cf6d-ff1f-4f95-b53b-07b057e5c95d.png)|![Capture d’écran de 2021-07-20 11-33-49](https://user-images.githubusercontent.com/243653/126332604-c13392e8-bcbc-4c90-9260-e858f38b21c4.png)|
