### PR TITLE
Fix layout of feedback component with a short message

### DIFF
--- a/src/components/ui/UserFeedbackQuestion.jsx
+++ b/src/components/ui/UserFeedbackQuestion.jsx
@@ -5,7 +5,7 @@ import { Flex, CloseButton, Button } from './index';
 const UserFeedbackQuestion = ({ question, options, onClose }) => {
   return (
     <Flex className="feedback">
-      <div className="u-mr-s">{question}</div>
+      <div className="feedback-question u-mr-s">{question}</div>
       <Flex>
         {options.map(({ label, icon, callback }) => (
           <Button

--- a/src/scss/includes/components/feedback.scss
+++ b/src/scss/includes/components/feedback.scss
@@ -7,6 +7,10 @@
     align-self: flex-start;
   }
 
+  &-question {
+    flex-grow: 1;
+  }
+
   &-button {
     svg {
       margin-right: $spacing-xxs;


### PR DESCRIPTION
## Description
Fix the horizontal alignment of the feedback question component when it's used with a short message (for example in English).

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran de 2021-07-26 12-15-15](https://user-images.githubusercontent.com/243653/126973144-76e7d9c7-d65f-4f41-8353-9b2ded215058.png)|![Capture d’écran de 2021-07-26 12-13-58](https://user-images.githubusercontent.com/243653/126973153-f885b906-5e02-4fe4-b98d-895e1c8c5c60.png)|