### PR TITLE
Fix favorite icon alignment in Safari 13

### DIFF
--- a/src/panel/poi/ActionButtons.jsx
+++ b/src/panel/poi/ActionButtons.jsx
@@ -111,7 +111,14 @@ const ActionButtons = ({
         title={_('Favorites', 'poi panel')}
         onClick={toggleStorePoi}
         style={{ borderColor: favoriteColor }}
-        icon={<Heart width={16} color={favoriteColor} fill={favoriteColor || 'transparent'} />}
+        icon={
+          <Heart
+            width={16}
+            height={16}
+            color={favoriteColor}
+            fill={favoriteColor || 'transparent'}
+          />
+        }
       />
 
       <ShareMenu


### PR DESCRIPTION
## Description
Fix the display of the favorite icon in the popup button on Safari 13. The alignment isn't right in the reduced button on this browser if the SVG keeps its default height (24).

## Screenshots (from Browserstack)
|Before|After|
|---|---|
|![Capture d’écran de 2021-08-02 15-51-56](https://user-images.githubusercontent.com/243653/127872995-007349f0-5dbf-4014-9b30-79abfa8f8154.png)|![Capture d’écran de 2021-08-02 15-51-29](https://user-images.githubusercontent.com/243653/127873006-74adf0f5-3384-4a33-b88f-2780ac7b8e8c.png)|

