### PR TITLE
QMAPS-2068 navigate in app menus through history

### DIFF
--- a/src/libs/url_utils.js
+++ b/src/libs/url_utils.js
@@ -45,9 +45,14 @@ export function joinPath(parts) {
     .join('/');
 }
 
-export function getCurrentUrl() {
-  const { pathname, search, hash } = window.location;
-  return `${pathname}${search}${hash}`;
+export function getAppRelativeUrl() {
+  const { search, hash } = window.location;
+  return `${getAppRelativePathname()}${search}${hash}`;
+}
+
+export function getAppRelativePathname() {
+  const appBase = (window.baseURL || '/').replace(/\/$/, '');
+  return window.location.pathname.replace(new RegExp(`^${appBase}`), '');
 }
 
 export function toCssUrl(url) {

--- a/src/libs/url_utils.js
+++ b/src/libs/url_utils.js
@@ -18,6 +18,10 @@ export function getMapHash(zoom, lat, lng) {
   return `map=${zoom.toFixed(2)}/${lat.toFixed(7)}/${lng.toFixed(7)}`;
 }
 
+export function getQueryString(url) {
+  return url?.split('?')[1]?.split('#')[0];
+}
+
 export function parseQueryString(queryString) {
   const params = {};
   new URLSearchParams(queryString).forEach((value, key) => {

--- a/src/panel/Menu.jsx
+++ b/src/panel/Menu.jsx
@@ -9,7 +9,12 @@ import { Flex, CloseButton } from 'src/components/ui';
 import { IconMenu, IconApps, IconArrowLeft } from 'src/components/ui/icons';
 import { useConfig, useDevice } from 'src/hooks';
 import { listen, unListen } from 'src/libs/customEvents';
-import { parseQueryString, updateQueryString, getAppRelativePathname } from 'src/libs/url_utils';
+import {
+  getQueryString,
+  parseQueryString,
+  updateQueryString,
+  getAppRelativePathname,
+} from 'src/libs/url_utils';
 
 const Menu = () => {
   const [openedMenu, setOpenedMenu] = useState(null);
@@ -17,11 +22,14 @@ const Menu = () => {
   const { isMobile } = useDevice();
   const displayProducts = useConfig('burgerMenu').products;
 
+  const openMenuFromUrl = url => {
+    const activeMenuDrawer = parseQueryString(getQueryString(url))['drawer'];
+    setOpenedMenu(activeMenuDrawer);
+  };
+
   useEffect(() => {
-    const routeChangeHandler = listen('routeChange', url => {
-      const activeMenuDrawer = parseQueryString(url.split('?')[1])['drawer'];
-      setOpenedMenu(activeMenuDrawer);
-    });
+    openMenuFromUrl(window.location.href);
+    const routeChangeHandler = listen('routeChange', openMenuFromUrl);
     return () => {
       unListen(routeChangeHandler);
     };

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -6,7 +6,7 @@ import ServicePanel from './service/ServicePanel';
 import CategoryPanel from 'src/panel/category/CategoryPanel';
 import DirectionPanel from 'src/panel/direction/DirectionPanel';
 import Telemetry from 'src/libs/telemetry';
-import { parseQueryString, getCurrentUrl, buildQueryString } from 'src/libs/url_utils';
+import { parseQueryString, getAppRelativeUrl, buildQueryString } from 'src/libs/url_utils';
 import { fire, listen, unListen } from 'src/libs/customEvents';
 import { isNullOrEmpty } from 'src/libs/object';
 import { PanelContext } from 'src/libs/panelContext.js';
@@ -182,7 +182,7 @@ const PanelManager = ({ router }) => {
     });
 
     // Route the initial URL
-    router.routeUrl(getCurrentUrl(), window.history.state || {});
+    router.routeUrl(getAppRelativeUrl(), window.history.state || {});
   }, [router, directionConf]);
 
   // Effects on panel change

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Router from 'src/proxies/app_router';
-import { parseMapHash, joinPath, getCurrentUrl, parseQueryString } from 'src/libs/url_utils';
+import { parseMapHash, joinPath, getAppRelativeUrl, parseQueryString } from 'src/libs/url_utils';
 import { listen } from 'src/libs/customEvents';
 import RootComponent from './RootComponent';
 import Telemetry from 'src/libs/telemetry';
@@ -22,7 +22,7 @@ export default class App {
     this.router = new Router(window.baseUrl);
 
     window.onpopstate = ({ state }) => {
-      this.router.routeUrl(getCurrentUrl(), state || {});
+      this.router.routeUrl(getAppRelativeUrl(), state || {});
     };
 
     ReactDOM.render(<RootComponent router={this.router} />, document.querySelector('#react_root'));

--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -67,6 +67,8 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
 
   usePageTitle(getListDescription(poiFilters.category, poiFilters.query));
 
+  const comparableFilters = JSON.stringify(poiFilters);
+
   useEffect(() => {
     const fetchData = debounce(
       async () => {
@@ -103,17 +105,18 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
     return () => {
       unListen(mapMoveHandler);
     };
-  }, [poiFilters, initialLoading, maxPlaces]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [comparableFilters, initialLoading, maxPlaces]);
 
   useEffect(() => {
     window.execOnMapLoaded(() => {
       fitMap(bbox);
     });
-  }, [bbox, poiFilters]);
+  }, [bbox, comparableFilters]);
 
   useEffect(() => {
     setInitialLoading(true);
-  }, [poiFilters]);
+  }, [comparableFilters]);
 
   useEffect(() => {
     if (poiFilters.category) {

--- a/src/proxies/app_router.js
+++ b/src/proxies/app_router.js
@@ -4,6 +4,7 @@ Sufficient to replace the horrible "URL shard" system
 and ensure the app state is consistent.
 */
 import { joinPath } from 'src/libs/url_utils';
+import { fire } from 'src/libs/customEvents';
 
 function getMatchingRouteDefinition(routeDefs, url) {
   return routeDefs.find(route => new RegExp(route.match).test(url));
@@ -30,6 +31,7 @@ export default class Router {
 
   routeUrl(url, state) {
     const urlWithoutHash = url.split('#')[0];
+    fire('routeChange', urlWithoutHash);
     const routeDef = getMatchingRouteDefinition(this.routeDefs, urlWithoutHash);
     if (!routeDef) {
       return;


### PR DESCRIPTION
## Description
Allow the app menu to be closed by navigating back (and also to be remembered on page reload).  
For that, store the menu state in the url using the same mechanism as Search: a `drawer` query string param indicating the currently opened menu panel (aka. drawer)
In Maps, can be `app` or `products`.

Required a new event sent by the router on page loads so `<Menu>` can be notified.
It's still a bit hackish, not declarative enough for React, but I think it's the minimum change for the current app structure.

It gave me clearer ideas to clean up our router/history implementation (for now there are still too many URL manipulations in deep components), ideally migrating to React Router, but let's do that separately.