### PR TITLE
Fix relative URL routing used by Menu

### DIFF
--- a/src/libs/url_utils.js
+++ b/src/libs/url_utils.js
@@ -49,13 +49,8 @@ export function joinPath(parts) {
     .join('/');
 }
 
-export function getAppRelativeUrl() {
-  const { search, hash } = window.location;
-  return `${getAppRelativePathname()}${search}${hash}`;
-}
-
 export function getAppRelativePathname() {
-  const appBase = (window.baseURL || '/').replace(/\/$/, '');
+  const appBase = (window.baseUrl || '/').replace(/\/$/, '');
   return window.location.pathname.replace(new RegExp(`^${appBase}`), '');
 }
 

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -6,7 +6,7 @@ import ServicePanel from './service/ServicePanel';
 import CategoryPanel from 'src/panel/category/CategoryPanel';
 import DirectionPanel from 'src/panel/direction/DirectionPanel';
 import Telemetry from 'src/libs/telemetry';
-import { parseQueryString, getAppRelativeUrl, buildQueryString } from 'src/libs/url_utils';
+import { parseQueryString, buildQueryString } from 'src/libs/url_utils';
 import { fire, listen, unListen } from 'src/libs/customEvents';
 import { isNullOrEmpty } from 'src/libs/object';
 import { PanelContext } from 'src/libs/panelContext.js';
@@ -182,7 +182,10 @@ const PanelManager = ({ router }) => {
     });
 
     // Route the initial URL
-    router.routeUrl(getAppRelativeUrl(), window.history.state || {});
+    router.routeUrl(
+      document.location.href.replace(document.location.origin, ''),
+      window.history.state || {}
+    );
   }, [router, directionConf]);
 
   // Effects on panel change

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Router from 'src/proxies/app_router';
-import { parseMapHash, joinPath, getAppRelativeUrl, parseQueryString } from 'src/libs/url_utils';
+import { parseMapHash, joinPath, parseQueryString } from 'src/libs/url_utils';
 import { listen } from 'src/libs/customEvents';
 import RootComponent from './RootComponent';
 import Telemetry from 'src/libs/telemetry';
@@ -22,7 +22,10 @@ export default class App {
     this.router = new Router(window.baseUrl);
 
     window.onpopstate = ({ state }) => {
-      this.router.routeUrl(getAppRelativeUrl(), state || {});
+      this.router.routeUrl(
+        document.location.href.replace(document.location.origin, ''),
+        state || {}
+      );
     };
 
     ReactDOM.render(<RootComponent router={this.router} />, document.querySelector('#react_root'));


### PR DESCRIPTION
## Description
Follow-up to https://github.com/Qwant/erdapfel/pull/1173 
Fix a letter case issue (`baseURL` instead of `baseUrl`), which caused the retrieval of app-relative urls to return wrong values on domains which use a prefix part (ex: prod or dev, which use `/maps`).
The prefix wasn't removed, so opening/closing the menu created urls with repeated prefix.
![Capture d’écran de 2021-08-16 15-55-51](https://user-images.githubusercontent.com/243653/129580532-bc2591b9-0dfa-4ab9-a1c1-860ce9d3e132.png)

This function is hackish anyway, switching to React Router should make it simpler to work with relative urls.