### PR TITLE
QMAPS-434 add poi stars for lodging and restaurants

### DIFF
--- a/src/hooks/useI18n.js
+++ b/src/hooks/useI18n.js
@@ -9,6 +9,7 @@ export const useI18n = () => {
 
   return {
     _: window._,
+    _n: window._n,
     locale,
     lang,
     getLocalizedUrl: getLocalizedUrl(lang),

--- a/src/panel/poi/blocks/Details.jsx
+++ b/src/panel/poi/blocks/Details.jsx
@@ -14,18 +14,7 @@ const DetailsBlock = ({ poi }) => {
   const accessibility = findBlock(poi.blocks, 'accessibility');
   const internetAccess = findBlock(poi.blocks, 'internet_access');
   const delivery = findBlock(poi.blocks, 'delivery');
-  // const stars = findBlock(poi.blocks, 'stars');
-  // Example:
-  const stars = {
-    type: 'stars',
-    ratings: [
-      {
-        has_stars: 'yes',
-        nb_stars: 0,
-        // kind: 'restaurant',
-      },
-    ],
-  };
+  const stars = findBlock(poi.blocks, 'stars');
 
   if (!accessibility && !internetAccess && !hasStars(stars) && !hasActiveDeliveryModes(delivery)) {
     return null;

--- a/src/panel/poi/blocks/Details.jsx
+++ b/src/panel/poi/blocks/Details.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import StarsBlock from './Stars';
+import StarsBlock, { hasStars } from './Stars';
 import AccessibilityBlock from './Accessibility';
 import InternetAccessBlock from './InternetAccess';
 import DeliveryBlock, { hasActiveDeliveryModes } from './Delivery';
@@ -17,11 +17,17 @@ const DetailsBlock = ({ poi }) => {
   // const stars = findBlock(poi.blocks, 'stars');
   // Example:
   const stars = {
-    has_stars: 'yes', // yes or unknown
-    nb_stars: 4, // float
+    type: 'stars',
+    ratings: [
+      {
+        has_stars: 'yes',
+        nb_stars: 0,
+        // kind: 'restaurant',
+      },
+    ],
   };
 
-  if (!accessibility && !internetAccess && !hasActiveDeliveryModes(delivery)) {
+  if (!accessibility && !internetAccess && !hasStars(stars) && !hasActiveDeliveryModes(delivery)) {
     return null;
   }
 

--- a/src/panel/poi/blocks/Details.jsx
+++ b/src/panel/poi/blocks/Details.jsx
@@ -1,20 +1,25 @@
 import React from 'react';
+import StarsBlock from './Stars';
 import AccessibilityBlock from './Accessibility';
-// import BreweryBlock from './Brewery';
 import InternetAccessBlock from './InternetAccess';
 import DeliveryBlock, { hasActiveDeliveryModes } from './Delivery';
 import { Divider } from 'src/components/ui';
 import { findBlock } from 'src/libs/pois';
 import { useI18n } from 'src/hooks';
+import poiSubClass from 'src/mapbox/poi_subclass';
 
 const DetailsBlock = ({ poi }) => {
   const { _ } = useI18n();
-
+  const subclass = poiSubClass(poi.subClassName);
   const accessibility = findBlock(poi.blocks, 'accessibility');
   const internetAccess = findBlock(poi.blocks, 'internet_access');
   const delivery = findBlock(poi.blocks, 'delivery');
-  // const brewery = findBlock(poi.blocks, 'brewery');
-  // {brewery && <BreweryBlock block={brewery} />}
+  // const stars = findBlock(poi.blocks, 'stars');
+  // Example:
+  const stars = {
+    has_stars: 'yes', // yes or unknown
+    nb_stars: 4, // float
+  };
 
   if (!accessibility && !internetAccess && !hasActiveDeliveryModes(delivery)) {
     return null;
@@ -25,6 +30,7 @@ const DetailsBlock = ({ poi }) => {
       <Divider paddingTop={0} />
       <h3 className="u-text--smallTitle u-mb-xs">{_('Details')}</h3>
       <div className="poi_panel__fullWidth u-mb-s">
+        {stars && <StarsBlock block={stars} subclass={subclass} />}
         {accessibility && <AccessibilityBlock block={accessibility} />}
         {internetAccess && <InternetAccessBlock block={internetAccess} />}
         {hasActiveDeliveryModes(delivery) && <DeliveryBlock block={delivery} />}

--- a/src/panel/poi/blocks/Stars.jsx
+++ b/src/panel/poi/blocks/Stars.jsx
@@ -37,5 +37,4 @@ const StarsBlock = ({ block, subclass }) => {
 
 export default StarsBlock;
 
-export const hasStars = stars =>
-  stars && stars.ratings && stars.ratings[0] && stars.ratings[0].has_stars === 'yes';
+export const hasStars = stars => stars?.ratings?.[0]?.has_stars === 'yes' || false;

--- a/src/panel/poi/blocks/Stars.jsx
+++ b/src/panel/poi/blocks/Stars.jsx
@@ -1,0 +1,35 @@
+/* global _n */
+import React from 'react';
+import Block from './Block';
+import { IconStar } from 'src/components/ui/icons';
+import { ACTION_BLUE_BASE } from 'src/libs/colors';
+import { capitalizeFirst } from 'src/libs/string';
+import { useI18n } from '../../../hooks';
+
+const StarsBlock = ({ block, subclass }) => {
+  const { _ } = useI18n();
+
+  if (block.has_stars === 'unknown') {
+    return null;
+  }
+
+  if (block.nb_stars && block.nb_stars > 0) {
+    return (
+      <Block simple icon={<IconStar fill={ACTION_BLUE_BASE} width={20} />}>
+        {capitalizeFirst(
+          _n('{subclass} with %d star', '{subclass} with %d stars', block.nb_stars, 'poi', {
+            subclass,
+          })
+        )}
+      </Block>
+    );
+  }
+
+  return (
+    <Block simple icon={<IconStar fill={ACTION_BLUE_BASE} width={20} />}>
+      {_('Starred {subclass}', 'poi', { subclass })}
+    </Block>
+  );
+};
+
+export default StarsBlock;

--- a/src/panel/poi/blocks/Stars.jsx
+++ b/src/panel/poi/blocks/Stars.jsx
@@ -1,25 +1,28 @@
-/* global _n */
 import React from 'react';
 import Block from './Block';
 import { IconStar } from 'src/components/ui/icons';
 import { ACTION_BLUE_BASE } from 'src/libs/colors';
 import { capitalizeFirst } from 'src/libs/string';
-import { useI18n } from '../../../hooks';
+import { useI18n } from 'src/hooks';
 
 const StarsBlock = ({ block, subclass }) => {
-  const { _ } = useI18n();
+  const { _, _n } = useI18n();
 
-  if (block.has_stars === 'unknown') {
+  if (!hasStars(block)) {
     return null;
   }
 
-  if (block.nb_stars && block.nb_stars > 0) {
+  if (block.ratings[0].nb_stars && block.ratings[0].nb_stars > 0) {
     return (
       <Block simple icon={<IconStar fill={ACTION_BLUE_BASE} width={20} />}>
         {capitalizeFirst(
-          _n('{subclass} with %d star', '{subclass} with %d stars', block.nb_stars, 'poi', {
-            subclass,
-          })
+          _n(
+            '{subclass} with %d star',
+            '{subclass} with %d stars',
+            block.ratings[0].nb_stars,
+            'poi',
+            { subclass }
+          )
         )}
       </Block>
     );
@@ -33,3 +36,6 @@ const StarsBlock = ({ block, subclass }) => {
 };
 
 export default StarsBlock;
+
+export const hasStars = stars =>
+  stars && stars.ratings && stars.ratings[0] && stars.ratings[0].has_stars === 'yes';


### PR DESCRIPTION
## Description
- cleanup commented code
- add "stars" block with two fields: has_stars (unknown/yes) / nb_stars (float > 0 if it is known, 0 or undefined if not known)
- Fake data (to remove when the API is ready, hence the draft status)
- display the block ("Starred {type}"   or   "{Type} with {n} stars")
- Ensure proper capitalization in the languages where the string starts (or does not start) with "{Type}"

## Screenshots
![image](https://user-images.githubusercontent.com/1225909/129583558-650e9fa2-086f-4e88-9327-1fd61b4d5023.png)
![image](https://user-images.githubusercontent.com/1225909/129584098-bbecc80f-3ec4-4f52-b112-3ffe1b344c21.png)

