### PR TITLE
Qmaps 1796 fix direction form pins

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -58,7 +58,7 @@ statics:
 
 burgerMenu:
   enabled: true
-  products: true
+  products: false
 
 performance:
   enabled: false

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -58,7 +58,7 @@ statics:
 
 burgerMenu:
   enabled: true
-  products: false
+  products: true
 
 performance:
   enabled: false

--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -107,7 +107,7 @@ class DirectionInput extends React.Component {
               <input
                 ref={inputRef}
                 id={`direction-input_${pointType}`}
-                className={classnames({ valid: point !== null })}
+                className={classnames({ valid: !!point })}
                 type="search"
                 required
                 autoComplete="off"

--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -12,6 +12,7 @@ import Telemetry from 'src/libs/telemetry';
 import { handleFocus } from 'src/libs/input';
 import { isMobileDevice } from 'src/libs/device';
 import { IconArrowLeft, IconClose } from 'src/components/ui/icons';
+import classnames from 'classnames';
 
 class DirectionInput extends React.Component {
   static propTypes = {
@@ -106,6 +107,7 @@ class DirectionInput extends React.Component {
               <input
                 ref={inputRef}
                 id={`direction-input_${pointType}`}
+                className={classnames({ valid: point !== null })}
                 type="search"
                 required
                 autoComplete="off"

--- a/src/scss/includes/direction-field.scss
+++ b/src/scss/includes/direction-field.scss
@@ -96,17 +96,6 @@
     }
 
     input {
-      &:valid {
-        ~ .direction-icon-block {
-          .direction-icon-origin {
-            background-image: url('../images/direction_icons/origin-active.svg');
-          }
-
-          .direction-icon-destination {
-            background-image: url('../images/direction_icons/pin-active.svg');
-          }
-        }
-      }
       &:focus {
         ~ .direction-icon-block {
           .direction-icon-origin {
@@ -115,6 +104,17 @@
 
           .direction-icon-destination {
             background-image: url('../images/direction_icons/pin-focus.svg');
+          }
+        }
+      }
+      &.valid {
+        ~ .direction-icon-block {
+          .direction-icon-origin {
+            background-image: url('../images/direction_icons/origin-active.svg');
+          }
+
+          .direction-icon-destination {
+            background-image: url('../images/direction_icons/pin-active.svg');
           }
         }
       }


### PR DESCRIPTION
## Description

- make the form pins become blue/red only when the field content is a valid poi or location
- else, keep the icons light grey on blur, and dark grey on focus and when typing in the fields
- when editing a valid field, remove the blue/red color and return to dark grey

Nice side effects:
- no more icons blinking when the route is being computed
- everything is ok when clicking the "x" button and the "invert fields" button
- everything is ok when filling the fields by clicking on the map / moving a pin on the map to edit a field

## Screenshots
![1796](https://user-images.githubusercontent.com/1225909/129747775-bcf87740-47f8-425b-984c-92669bdfeb1d.gif)

