### PR TITLE
Fix contrib block being displayed on latlon POIs

### DIFF
--- a/src/components/Contribution.jsx
+++ b/src/components/Contribution.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import Telemetry from 'src/libs/telemetry';
 import { Flex } from 'src/components/ui';
-import { isFromOSM } from 'src/libs/pois';
+import { isFromOSM, isFromPagesJaunes } from 'src/libs/pois';
 import classnames from 'classnames';
 import { useI18n } from 'src/hooks';
 
 const Contribution = ({ poi }) => {
   const { _ } = useI18n();
 
-  if (!poi.meta) {
+  if ((!isFromOSM(poi) && !isFromPagesJaunes(poi)) || !poi.meta) {
     return null;
   }
 


### PR DESCRIPTION
## Description
Prevent the new unified Contribution block from being displayed on POIs which are neither OSM nor PagesJaunes… for examples, "latlon POIs" which appear when clicking anywhere on the map

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran 2021-09-06 à 16 46 48](https://user-images.githubusercontent.com/243653/132234632-f51cbbf1-097d-4822-a141-b043e89ddccf.png)|![Capture d’écran 2021-09-06 à 16 47 17](https://user-images.githubusercontent.com/243653/132234725-b237d5de-b7a5-49d0-8e83-0f42eb739a63.png)|

