### PR TITLE
QMAPS-2285 show old browser modal for iOS < 10 and adapt babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -6,7 +6,7 @@ module.exports = function (api) {
       '@babel/preset-env',
       {
         targets: {
-          browsers: ['Chrome >= 60', 'Firefox >= 44', 'Safari >= 8', 'Edge >= 17'],
+          browsers: ['Chrome >= 60', 'Firefox >= 44', 'Safari >= 10', 'Edge >= 17'],
         },
         useBuiltIns: 'entry',
         corejs: 2,

--- a/bin/middlewares/unsupported_browser.js
+++ b/bin/middlewares/unsupported_browser.js
@@ -1,5 +1,20 @@
+function iOSversion(userAgent) {
+  if (/iP(hone|od|ad)/.test(userAgent)) {
+    const v = userAgent.match(/OS (\d+)_(\d+)_?(\d+)?/);
+    return [parseInt(v[1], 10), parseInt(v[2], 10), parseInt(v[3] || 0, 10)];
+  }
+}
+
 function isUnsupported(userAgent = '') {
-  return userAgent.match('Trident'); // old IE detection
+  // iOS < 10 detection
+  if (iOSversion(userAgent)[0] < 10) {
+    return true;
+  }
+
+  // old IE detection
+  if (userAgent.match('Trident')) {
+    return true;
+  }
 }
 
 module.exports = function (config) {

--- a/bin/middlewares/unsupported_browser.js
+++ b/bin/middlewares/unsupported_browser.js
@@ -1,5 +1,5 @@
 function isOldIE(userAgent) {
-  return userAgent.match('Trident'); // Test for IE <= 11
+  return userAgent.match('Trident') || false; // Test for IE <= 11
 }
 
 function isOldiOS(userAgent) {
@@ -9,12 +9,11 @@ function isOldiOS(userAgent) {
       return parseInt(v[1], 10) < 10; // test if major iOS version is < 10
     }
   }
+  return false;
 }
 
 function isUnsupported(userAgent = '') {
-  if (isOldIE(userAgent) || isOldiOS(userAgent)) {
-    return true;
-  }
+  return isOldIE(userAgent) || isOldiOS(userAgent);
 }
 
 module.exports = function (config) {

--- a/bin/middlewares/unsupported_browser.js
+++ b/bin/middlewares/unsupported_browser.js
@@ -1,25 +1,24 @@
-function iOSversion(userAgent) {
+function isOldIE(userAgent) {
+  return userAgent.match('Trident'); // Test for IE <= 11
+}
+
+function isOldiOS(userAgent) {
   if (/iP(hone|od|ad)/.test(userAgent)) {
     const v = userAgent.match(/OS (\d+)_(\d+)_?(\d+)?/);
-    return [parseInt(v[1], 10), parseInt(v[2], 10), parseInt(v[3] || 0, 10)];
+    if (v && v[1]) {
+      return parseInt(v[1], 10) < 10; // test if major iOS version is < 10
+    }
   }
 }
 
 function isUnsupported(userAgent = '') {
-  // iOS < 10 detection
-  if (iOSversion(userAgent)[0] < 10) {
-    return true;
-  }
-
-  // old IE detection
-  if (userAgent.match('Trident')) {
+  if (isOldIE(userAgent) || isOldiOS(userAgent)) {
     return true;
   }
 }
 
 module.exports = function (config) {
   const redirect = config.server.unsupportedBrowsers.redirect;
-
   return function (req, res, next) {
     if (redirect && isUnsupported(req.headers['user-agent'])) {
       res.redirect(302, config.system.baseUrl + 'unsupported');

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -20,7 +20,7 @@ server:
   routerBaseUrl: / # path prefix expected by the express server
   useGeoipForInitialPosition: true
   unsupportedBrowsers:
-    redirect: true
+    redirect: false
 
 # Services
 services:

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -20,7 +20,7 @@ server:
   routerBaseUrl: / # path prefix expected by the express server
   useGeoipForInitialPosition: true
   unsupportedBrowsers:
-    redirect: false
+    redirect: true
 
 # Services
 services:


### PR DESCRIPTION
## Description
- show old browser modal on iOS < 10 (these OS have a Safari < 10 which doesn't support some of our JS/CSS)
- adapt babel config to safari >= 10 to save space

## Why
Avoid JS errors / non-working website on old devices without explanation

## Screenshots

![image](https://user-images.githubusercontent.com/1225909/132237446-79feb2a3-5464-4167-bc5c-fc8bc836c511.png)

