### PR TITLE
Fix layout issues in menu

### DIFF
--- a/src/panel/menu/ProductCard.jsx
+++ b/src/panel/menu/ProductCard.jsx
@@ -10,7 +10,7 @@ const ProductCard = ({ logo, title, desc, link, href, mobileApps }) => {
   return (
     <div className="card-wrapper">
       <a className="card productCard" href={href} target="_self">
-        <img className="u-mb-xxs" src={logo} width="48" height="48" alt="" />
+        <img className="u-mb-xs" src={logo} width="48" height="48" alt="" />
         <div className="u-color--primary u-text--heading5 u-mb-s">{title}</div>
         <div className="card-desc u-color--secondary u-text--body1 u-mb-l">{desc}</div>
         <div className="card-link">{link}</div>

--- a/src/scss/includes/menu.scss
+++ b/src/scss/includes/menu.scss
@@ -138,6 +138,9 @@ $productDrawerWidth: 744px;
   }
 
   .productCard {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     text-align: center;
     margin-bottom: $spacing-s;
     padding: $spacing-xxl-3 $spacing-l;

--- a/src/scss/includes/menu.scss
+++ b/src/scss/includes/menu.scss
@@ -84,6 +84,7 @@ $productDrawerWidth: 744px;
   width: 100%;
   height: 100%;
   color: $grey-semi-darkness;
+  line-height: normal;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Description
Fix two layout issues in the menu, caused by the inclusion of the CSS base from the qwant-ponents having some generic side-effects:
 - in the "Products" drawer, the logos weren't centered in the cards anymore (due to all images now having `display: block`)
 - the "Products" button was too big, not the same size as the app menu button anymore (due to button line-height inheriting line-height from parents)

These two components may soon be refactored with better use of qwant-ponents, reducing the need for specific CSS, but for now just fix the display bugs.

## Screenshots
|Before|After|
|---|---|
|![localhost_3000__drawer=products](https://user-images.githubusercontent.com/243653/133410117-f54d34ed-38a5-416f-ba08-88d6c38cf679.png)|![localhost_3000_](https://user-images.githubusercontent.com/243653/133410113-c0a17735-3a99-41a5-a464-cbf702111615.png)|
|![Capture d’écran de 2021-09-15 11-34-57](https://user-images.githubusercontent.com/243653/133410068-d5d90051-0d93-4fda-add7-86557aa29ed7.png)|![Capture d’écran de 2021-09-15 11-35-18](https://user-images.githubusercontent.com/243653/133410069-8feebe37-5992-46f0-98f9-dacd1e14a6aa.png)|
