### PR TITLE
Update map style

### DIFF
--- a/config/constants.yml
+++ b/config/constants.yml
@@ -49,7 +49,7 @@ map:
   center:
     lng: 2.52
     lat: 52.41
-  pois_layers: ['poi-level-3', 'poi-level-2', 'poi-level-1', 'poi-level-no-name', 'poi-level-street-furniture']
+  pois_layers: ['poi-level-3', 'poi-level-2', 'poi-level-1', 'poi-level-street-furniture']
   routes_layer: "poi-level-street-furniture"
 
 sources:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       "dependencies": {
         "@babel/polyfill": "^7.8.0",
         "@qwant/map-style-builder": "github:Qwant/map-style-builder#81eebb0",
-        "@qwant/qwant-basic-gl-style": "^1.3.1",
+        "@qwant/qwant-basic-gl-style": "^1.4.0",
         "@qwant/qwant-ponents": "^0.1.1",
         "@turf/along": "^6.0.1",
         "@turf/bbox": "^6.0.1",
@@ -2985,8 +2985,9 @@
       "link": true
     },
     "node_modules/@qwant/qwant-basic-gl-style": {
-      "version": "1.3.1",
-      "integrity": "sha512-zIjW9WgOwFOSQmKaCTvDKaGmB8PCwtyU+2PFLBmLdVR4zGWypP6evqtv8jzT0g5MgYFx1sLLKWzP+qhHIccQRA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@qwant/qwant-basic-gl-style/-/qwant-basic-gl-style-1.4.0.tgz",
+      "integrity": "sha512-PcABX01ru9bqj6wy+2/A61N0OJq5yTRb9a4MWidycipn2dFFScovK4F146oI6a72n2gMzjKgVm4qaFVAB+ua3g=="
     },
     "node_modules/@qwant/qwant-maps-common": {
       "resolved": "local_modules/qwant-maps-common",
@@ -23390,8 +23391,9 @@
       "version": "file:local_modules/po-js-loader"
     },
     "@qwant/qwant-basic-gl-style": {
-      "version": "1.3.1",
-      "integrity": "sha512-zIjW9WgOwFOSQmKaCTvDKaGmB8PCwtyU+2PFLBmLdVR4zGWypP6evqtv8jzT0g5MgYFx1sLLKWzP+qhHIccQRA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@qwant/qwant-basic-gl-style/-/qwant-basic-gl-style-1.4.0.tgz",
+      "integrity": "sha512-PcABX01ru9bqj6wy+2/A61N0OJq5yTRb9a4MWidycipn2dFFScovK4F146oI6a72n2gMzjKgVm4qaFVAB+ua3g=="
     },
     "@qwant/qwant-maps-common": {
       "version": "file:local_modules/qwant-maps-common",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.8.0",
     "@qwant/map-style-builder": "github:Qwant/map-style-builder#81eebb0",
-    "@qwant/qwant-basic-gl-style": "^1.3.1",
+    "@qwant/qwant-basic-gl-style": "^1.4.0",
     "@qwant/qwant-ponents": "^0.1.1",
     "@turf/along": "^6.0.1",
     "@turf/bbox": "^6.0.1",


### PR DESCRIPTION
Increase qwant-basic-gl-style version to include latest changes about city hierarchy (https://github.com/Qwant/qwant-basic-gl-style/pull/118) and clickable POIs (https://github.com/Qwant/qwant-basic-gl-style/pull/117)

Also remove ref to the `poi-level-no-name` layer as it doesn't exist anymore.
