### PR TITLE
Add labels for common nameless POIs

### DIFF
--- a/local_modules/qwant-maps-common/i18n/br/resource.json
+++ b/local_modules/qwant-maps-common/i18n/br/resource.json
@@ -239,5 +239,10 @@
   "city": "kêr",
   "country": "bro",
   "address": "chomlec'h",
-  "street": "straed"
+  "street": "straed",
+  "bicycle parking": "",
+  "recycling container": "",
+  "left luggage": "",
+  "motorcycle parking": "",
+  "parcel pickup": ""
 }

--- a/local_modules/qwant-maps-common/i18n/ca/resource.json
+++ b/local_modules/qwant-maps-common/i18n/ca/resource.json
@@ -239,5 +239,10 @@
   "city": "ciutat",
   "country": "país",
   "address": "adreça",
-  "street": "carrer"
+  "street": "carrer",
+  "bicycle parking": "",
+  "recycling container": "",
+  "left luggage": "",
+  "motorcycle parking": "",
+  "parcel pickup": ""
 }

--- a/local_modules/qwant-maps-common/i18n/de/resource.json
+++ b/local_modules/qwant-maps-common/i18n/de/resource.json
@@ -239,5 +239,10 @@
   "city": "Stadt",
   "country": "Land",
   "address": "Adresse",
-  "street": "Straße"
+  "street": "Straße",
+  "bicycle parking": "",
+  "recycling container": "",
+  "left luggage": "",
+  "motorcycle parking": "",
+  "parcel pickup": ""
 }

--- a/local_modules/qwant-maps-common/i18n/en/resource.json
+++ b/local_modules/qwant-maps-common/i18n/en/resource.json
@@ -239,5 +239,10 @@
   "city": "city",
   "country": "country",
   "address": "address",
-  "street": "street"
+  "street": "street",
+  "bicycle parking": "bicycle parking",
+  "recycling container": "recycling container",
+  "left luggage": "left luggage",
+  "motorcycle parking": "motorcycle parking",
+  "parcel pickup": "parcel pickup"
 }

--- a/local_modules/qwant-maps-common/i18n/es/resource.json
+++ b/local_modules/qwant-maps-common/i18n/es/resource.json
@@ -239,5 +239,10 @@
   "city": "ciudad",
   "country": "país",
   "address": "dirección",
-  "street": "calle"
+  "street": "calle",
+  "bicycle parking": "",
+  "recycling container": "",
+  "left luggage": "",
+  "motorcycle parking": "",
+  "parcel pickup": ""
 }

--- a/local_modules/qwant-maps-common/i18n/fr/resource.json
+++ b/local_modules/qwant-maps-common/i18n/fr/resource.json
@@ -239,5 +239,10 @@
   "city": "ville",
   "country": "pays",
   "address": "adresse",
-  "street": "rue"
+  "street": "rue",
+  "bicycle parking": "parking à vélo",
+  "recycling container": "conteneur de tri",
+  "left luggage": "consigne",
+  "motorcycle parking": "parking deux-roues motorisés",
+  "parcel pickup": "point de retrait"
 }

--- a/local_modules/qwant-maps-common/i18n/it/resource.json
+++ b/local_modules/qwant-maps-common/i18n/it/resource.json
@@ -239,5 +239,10 @@
   "city": "città",
   "country": "nazione",
   "address": "indirizzo",
-  "street": "strada"
+  "street": "strada",
+  "bicycle parking": "",
+  "recycling container": "",
+  "left luggage": "",
+  "motorcycle parking": "",
+  "parcel pickup": ""
 }

--- a/local_modules/qwant-maps-common/src/place_category_name.js
+++ b/local_modules/qwant-maps-common/src/place_category_name.js
@@ -25,6 +25,7 @@ const subClasses = {
   bed_and_breakfast: () => _('bed and breakfast'),
   beverages: () => _('beverages shop'),
   bicycle: () => _('bicycle shop'),
+  bicycle_parking: () => _('bicycle parking'),
   biergarten: () => _('biergarten'),
   billiards: () => _('billiards'),
   bmx: () => _('bmx'),
@@ -70,6 +71,7 @@ const subClasses = {
   community_centre: () => _('community centre'),
   computer: () => _('computer shop'),
   confectionery: () => _('confectionery shop'),
+  container: () => _('recycling container'),
   convenience: () => _('convenience store'),
   copyshop: () => _('copyshop'),
   cosmetics: () => _('cosmetics shop'),
@@ -137,6 +139,7 @@ const subClasses = {
   kitchen: () => _('kitchen manufacturer'),
   lamps: () => _('lamps shop'),
   laundry: () => _('laundry'),
+  left_luggage: () => _('left luggage'),
   library: () => _('library'),
   lodging: () => _('hotel'),
   long_jump: () => _('long jump'),
@@ -152,6 +155,7 @@ const subClasses = {
   motocross: () => _('motocross'),
   motor: () => _('motor'),
   motorcycle: () => _('motorcycle shop'),
+  motorcycle_parking: () => _('motorcycle parking'),
   multi: () => _('multi'),
   museum: () => _('museum'),
   music: () => _('music shop'),
@@ -177,6 +181,7 @@ const subClasses = {
   police: () => _('police'),
   polling_station: () => _('polling station'),
   post_office: () => _('post office'),
+  post_pickup: () => _('parcel pickup'),
   prison: () => _('prison'),
   pub: () => _('pub'),
   public_building: () => _('public building'),
@@ -252,6 +257,6 @@ function getPlaceCategoryName({ subclass }, lang) {
     return subClasses[subclass]();
   }
   return '';
-};
+}
 
 export { getPlaceCategoryName };


### PR DESCRIPTION
## Description
Add labels to some of the subclasses of POIs that are frequently not named.

## Why
Now that nameless POIs can be clickable (if they are not in the `poi-level-street-furniture` layer), some of them display an empty panel title.

## Screenshots
|Before|After|
|---|---|
|![maps dev qwant ninja_maps_place_osm_node_8027554663 (1)](https://user-images.githubusercontent.com/243653/134010098-6b27912e-8432-4587-a46b-63bf495830db.png)|![localhost_3000_place_osm_node_8027554663](https://user-images.githubusercontent.com/243653/134009631-51dd8ac2-3353-42b3-956b-3de9ef8153a3.png)|