### PR TITLE
Fix vertical alignment of topbar clear button

### DIFF
--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -94,6 +94,7 @@ input[type="search"] {
   width: 30px;
   color: $secondary_text;
   cursor: pointer;
+  line-height: initial;
   display: none;
 }
 


### PR DESCRIPTION
## Description
Fix the vertical alignement of the topbar clear cross, which got changed by generic CSS applied by the qwant-ponents module.
As for https://github.com/Qwant/erdapfel/pull/1189, just fix it simply now, until we reimplement this part with the proper layout components from the qwant-ponents.

## Screenshots
|Before|After|
|---|---|
|![Capture d’écran 2021-09-21 à 14 34 06](https://user-images.githubusercontent.com/243653/134171185-5fd1cab4-4a6d-4edf-aab7-aa28c40a674b.png)|![Capture d’écran 2021-09-21 à 14 34 25](https://user-images.githubusercontent.com/243653/134171187-0f0b0d1f-75f5-4682-abca-1b5050788b95.png)|