### PR TITLE
Add a feature flag for local history

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -91,3 +91,6 @@ covid19:
 userFeedback:
   enabled: false
   dismissDurationDays: 30
+
+searchHistory:
+  enabled: false


### PR DESCRIPTION
Simply declare a feature flag for the local search history functionality, defaulting to `false` so we can develop the feature incrementaly.

Can be set to `true` locally through an env var: `TILEVIEW_searchHistory_enabled=true`