### PR TITLE
Qmaps 2290 save search history

### DIFF
--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -27,9 +27,10 @@ export function saveQuery(q) {
 export function deleteQuery(q) {
   const searchHistory = get(SEARCH_HISTORY_KEY) || [];
   const index = searchHistory.indexOf(q);
-  if (index > -1) {
-    searchHistory.splice(index, 1);
+  if (index === -1) {
+    return;
   }
+  searchHistory.splice(index, 1);
   // Serialize the list and save it in localStorage
   set(SEARCH_HISTORY_KEY, searchHistory);
 }

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -1,0 +1,40 @@
+import { get, set, del } from './store';
+
+const search_history = get('search_history') || [];
+
+// Add a query to the list
+export function save_query(q) {
+  // Delete query if it's already in the list
+  if (search_history.includes(q)) {
+    delete_query(q);
+  }
+
+  // Put the query at the end of the array
+  search_history.push(q);
+
+  // Limit the list to the 100 last items
+  if (search_history.length > 100) {
+    search_history.unshift();
+  }
+
+  // Serialize the list and save it in localStorage
+  set('search_history', search_history);
+  console.log(search_history);
+}
+
+// Delete a query from the list
+export function delete_query(q) {
+  const index = search_history.indexOf(q);
+  if (index > -1) {
+    search_history.splice(index, 1);
+  }
+  // Serialize the list and save it in localStorage
+  set('search_history', search_history);
+  console.log(search_history);
+}
+
+// Delete the whole search history
+export function delete_search_history() {
+  del('queries_list');
+  search_history = [];
+}

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -14,7 +14,7 @@ export function save_query(q) {
 
   // Limit the list to the 100 last items
   if (search_history.length > 100) {
-    search_history.unshift();
+    search_history.shift();
   }
 
   // Serialize the list and save it in localStorage

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -1,38 +1,41 @@
 import { get, set, del } from './store';
 
-let search_history = get('search_history') || [];
+const SEARCH_HISTORY_KEY = 'search_history';
+const HISTORY_SIZE = 100;
 
 // Add a query to the list
 export function save_query(q) {
+  const searchHistory = get(SEARCH_HISTORY_KEY) || [];
+
   // Delete query if it's already in the list
-  if (search_history.includes(q)) {
+  if (searchHistory.includes(q)) {
     delete_query(q);
   }
 
   // Put the query at the end of the array
-  search_history.push(q);
+  searchHistory.push(q);
 
   // Limit the list to the 100 last items
-  if (search_history.length > 100) {
-    search_history.shift();
+  if (searchHistory.length > HISTORY_SIZE) {
+    searchHistory.shift();
   }
 
   // Serialize the list and save it in localStorage
-  set('search_history', search_history);
+  set(SEARCH_HISTORY_KEY, searchHistory);
 }
 
 // Delete a query from the list
 export function delete_query(q) {
-  const index = search_history.indexOf(q);
+  const searchHistory = get(SEARCH_HISTORY_KEY) || [];
+  const index = searchHistory.indexOf(q);
   if (index > -1) {
-    search_history.splice(index, 1);
+    searchHistory.splice(index, 1);
   }
   // Serialize the list and save it in localStorage
-  set('search_history', search_history);
+  set(SEARCH_HISTORY_KEY, searchHistory);
 }
 
 // Delete the whole search history
 export function delete_search_history() {
-  del('queries_list');
-  search_history = [];
+  del(SEARCH_HISTORY_KEY);
 }

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -1,6 +1,6 @@
 import { get, set, del } from './store';
 
-const search_history = get('search_history') || [];
+let search_history = get('search_history') || [];
 
 // Add a query to the list
 export function save_query(q) {
@@ -19,7 +19,6 @@ export function save_query(q) {
 
   // Serialize the list and save it in localStorage
   set('search_history', search_history);
-  console.log(search_history);
 }
 
 // Delete a query from the list
@@ -30,7 +29,6 @@ export function delete_query(q) {
   }
   // Serialize the list and save it in localStorage
   set('search_history', search_history);
-  console.log(search_history);
 }
 
 // Delete the whole search history

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -14,14 +14,14 @@ export function saveQuery(item) {
   deleteQuery(item);
 
   // Retrieve the search history
-  const searchHistory = get(SEARCH_HISTORY_KEY) || [];
+  let searchHistory = get(SEARCH_HISTORY_KEY) || [];
 
   // Put the query at the end of the array
   searchHistory.push(item);
 
-  // Limit the list to the 100 last items
+  // Limit the list to the last items
   if (searchHistory.length > HISTORY_SIZE) {
-    searchHistory.shift();
+    searchHistory = searchHistory.slice(-HISTORY_SIZE);
   }
 
   // Serialize the list and save it in localStorage

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -3,7 +3,6 @@ import { get, set, del } from './store';
 const SEARCH_HISTORY_KEY = 'search_history';
 const HISTORY_SIZE = 100;
 
-// Add a query to the list
 export function saveQuery(item) {
   // ignore intention objects for now
   if (!item.id) {
@@ -28,7 +27,6 @@ export function saveQuery(item) {
   set(SEARCH_HISTORY_KEY, searchHistory);
 }
 
-// Delete a query from the list
 export function deleteQuery(item) {
   const searchHistory = get(SEARCH_HISTORY_KEY) || [];
   const index = searchHistory.findIndex(storedItem => item.id === storedItem.id);
@@ -40,7 +38,6 @@ export function deleteQuery(item) {
   set(SEARCH_HISTORY_KEY, searchHistory);
 }
 
-// Delete the whole search history
 export function deleteSearchHistory() {
   del(SEARCH_HISTORY_KEY);
 }

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -4,9 +4,9 @@ const SEARCH_HISTORY_KEY = 'search_history';
 const HISTORY_SIZE = 100;
 
 // Add a query to the list
-export function save_query(q) {
+export function saveQuery(q) {
   // Delete query if it's already in the list
-  delete_query(q);
+  deleteQuery(q);
 
   // Retrieve the search history
   const searchHistory = get(SEARCH_HISTORY_KEY) || [];
@@ -24,7 +24,7 @@ export function save_query(q) {
 }
 
 // Delete a query from the list
-export function delete_query(q) {
+export function deleteQuery(q) {
   const searchHistory = get(SEARCH_HISTORY_KEY) || [];
   const index = searchHistory.indexOf(q);
   if (index > -1) {
@@ -35,6 +35,6 @@ export function delete_query(q) {
 }
 
 // Delete the whole search history
-export function delete_search_history() {
+export function deleteSearchHistory() {
   del(SEARCH_HISTORY_KEY);
 }

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -4,15 +4,20 @@ const SEARCH_HISTORY_KEY = 'search_history';
 const HISTORY_SIZE = 100;
 
 // Add a query to the list
-export function saveQuery(q) {
+export function saveQuery(item) {
+  // ignore intention objects for now
+  if (!item.id) {
+    return;
+  }
+
   // Delete query if it's already in the list
-  deleteQuery(q);
+  deleteQuery(item);
 
   // Retrieve the search history
   const searchHistory = get(SEARCH_HISTORY_KEY) || [];
 
   // Put the query at the end of the array
-  searchHistory.push(q);
+  searchHistory.push(item);
 
   // Limit the list to the 100 last items
   if (searchHistory.length > HISTORY_SIZE) {
@@ -24,9 +29,9 @@ export function saveQuery(q) {
 }
 
 // Delete a query from the list
-export function deleteQuery(q) {
+export function deleteQuery(item) {
   const searchHistory = get(SEARCH_HISTORY_KEY) || [];
-  const index = searchHistory.indexOf(q);
+  const index = searchHistory.findIndex(storedItem => item.id === storedItem.id);
   if (index === -1) {
     return;
   }

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -5,12 +5,11 @@ const HISTORY_SIZE = 100;
 
 // Add a query to the list
 export function save_query(q) {
-  const searchHistory = get(SEARCH_HISTORY_KEY) || [];
-
   // Delete query if it's already in the list
-  if (searchHistory.includes(q)) {
-    delete_query(q);
-  }
+  delete_query(q);
+
+  // Retrieve the search history
+  const searchHistory = get(SEARCH_HISTORY_KEY) || [];
 
   // Put the query at the end of the array
   searchHistory.push(q);

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -19,9 +19,7 @@ const TopBar = ({ value, setUserInputValue, inputRef, onSuggestToggle, backButto
   const [focused, setFocused] = useState(false);
   const { isMobile } = useDevice();
   const config = useConfig();
-  console.log(config);
   const searchHistoryConfig = config.searchHistory;
-  console.log(searchHistoryConfig);
 
   // give keyboard focus to the field when typing anywhere
   useEffect(() => {

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -9,6 +9,7 @@ import Menu from 'src/panel/Menu';
 import { useConfig, useDevice } from 'src/hooks';
 import { handleFocus } from 'src/libs/input';
 import { selectItem, fetchSuggests } from 'src/libs/suggest';
+import { save_query } from 'src/adapters/search_history';
 
 const MAPBOX_RESERVED_KEYS = ['ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown', '-', '+', '='];
 
@@ -18,6 +19,9 @@ const TopBar = ({ value, setUserInputValue, inputRef, onSuggestToggle, backButto
   const [focused, setFocused] = useState(false);
   const { isMobile } = useDevice();
   const config = useConfig();
+  console.log(config);
+  const searchHistoryConfig = config.searchHistory;
+  console.log(searchHistoryConfig);
 
   // give keyboard focus to the field when typing anywhere
   useEffect(() => {
@@ -52,6 +56,9 @@ const TopBar = ({ value, setUserInputValue, inputRef, onSuggestToggle, backButto
 
   const onSelectSuggestion = (item, options) => {
     selectItem(item, options);
+    if (item?.name && searchHistoryConfig?.enabled) {
+      save_query(item.name);
+    }
     inputRef.current.blur();
   };
 

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -9,7 +9,7 @@ import Menu from 'src/panel/Menu';
 import { useConfig, useDevice } from 'src/hooks';
 import { handleFocus } from 'src/libs/input';
 import { selectItem, fetchSuggests } from 'src/libs/suggest';
-import { save_query } from 'src/adapters/search_history';
+import { saveQuery } from 'src/adapters/search_history';
 
 const MAPBOX_RESERVED_KEYS = ['ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown', '-', '+', '='];
 
@@ -55,7 +55,7 @@ const TopBar = ({ value, setUserInputValue, inputRef, onSuggestToggle, backButto
   const onSelectSuggestion = (item, options) => {
     selectItem(item, options);
     if (item?.name && searchHistoryConfig?.enabled) {
-      save_query(item.name);
+      saveQuery(item.name);
     }
     inputRef.current.blur();
   };

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -54,8 +54,8 @@ const TopBar = ({ value, setUserInputValue, inputRef, onSuggestToggle, backButto
 
   const onSelectSuggestion = (item, options) => {
     selectItem(item, options);
-    if (item?.name && searchHistoryConfig?.enabled) {
-      saveQuery(item.name);
+    if (item && searchHistoryConfig?.enabled) {
+      saveQuery(item);
     }
     inputRef.current.blur();
   };

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -7,6 +7,8 @@ import SuggestsDropdown from 'src/components/ui/SuggestsDropdown';
 import { fetchSuggests, getInputValue, modifyList } from 'src/libs/suggest';
 import { UserFeedbackYesNo } from './index';
 
+
+
 const SUGGEST_DEBOUNCE_WAIT = 100;
 
 let currentQuery = null;

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -7,8 +7,6 @@ import SuggestsDropdown from 'src/components/ui/SuggestsDropdown';
 import { fetchSuggests, getInputValue, modifyList } from 'src/libs/suggest';
 import { UserFeedbackYesNo } from './index';
 
-
-
 const SUGGEST_DEBOUNCE_WAIT = 100;
 
 let currentQuery = null;


### PR DESCRIPTION
## Description
- Use the feature flag searchHistoryConfig.enabled
- save last 100 queries in local storage, ordered by date (last item of the list is the most recent)
- if an existing query is searched again, it's put at the end of the list
- queries are saved by name if we type a valid query and press enter, or select a suggest.
- queries are not saved if no results were found


## Screenshots

Example: LocalStorage after searching Nice, Lyon, Lyon 3eme, Negresco and Lyon again. Only one occurrence of "Lyon" is visible at the end.

![image](https://user-images.githubusercontent.com/1225909/134201362-b819a64d-af04-434f-9de0-810a09fdbba9.png)

