### PR TITLE
Fix top bar content on fresh load

### DIFF
--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -17,9 +17,9 @@ import { PoiContext } from 'src/libs/poiContext';
 import { getListDescription } from 'src/libs/poiList';
 import poiSubClass from 'src/mapbox/poi_subclass';
 
-function getTopBarAppValue(activePoi, { poiFilters = {}, poi = {}, query } = {}) {
+function getTopBarAppValue(activePoi, { poiFilters = {}, poi, query } = {}) {
   const currentPoi = poi || activePoi;
-  if (!isNullOrEmpty(currentPoi)) {
+  if (currentPoi) {
     return currentPoi.name || poiSubClass(currentPoi.subClassName);
   }
   return getListDescription(poiFilters.category, poiFilters.query || query) || '';


### PR DESCRIPTION
## Description
My fix in https://github.com/Qwant/erdapfel/pull/1196 was shit and introduced a new bug.
Due to the default value `{}` of the `poi` field in the second argument, `poi || activePoi` returned `{}` even if `activePoi` was a full object.