### PR TITLE
Qmaps 2289 directions history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "erdapfel",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "workspaces": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "erdapfel",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "workspaces": [

--- a/src/panel/direction/DirectionInput.jsx
+++ b/src/panel/direction/DirectionInput.jsx
@@ -13,6 +13,10 @@ import { handleFocus } from 'src/libs/input';
 import { isMobileDevice } from 'src/libs/device';
 import { IconArrowLeft, IconClose } from 'src/components/ui/icons';
 import classnames from 'classnames';
+import nconf from '@qwant/nconf-getter';
+import { saveQuery } from 'src/adapters/search_history';
+
+const searchHistoryConfig = nconf.get().searchHistory;
 
 class DirectionInput extends React.Component {
   static propTypes = {
@@ -82,6 +86,9 @@ class DirectionInput extends React.Component {
     } else {
       const name = selectedPoi.type === 'latlon' ? selectedPoi.address.street : selectedPoi.name;
       this.props.onChangePoint(name, selectedPoi);
+      if (searchHistoryConfig?.enabled) {
+        saveQuery(selectedPoi);
+      }
     }
   };
 
@@ -102,6 +109,7 @@ class DirectionInput extends React.Component {
             outputNode={document.getElementById('direction-autocomplete_suggestions')}
             withGeoloc={withGeoloc}
             onSelect={this.selectItem}
+            withHistory={searchHistoryConfig?.enabled}
           >
             {({ onKeyDown, onFocus, onBlur, highlightedValue }) => (
               <input


### PR DESCRIPTION
## Description
- save queries typed in Directions in the history (if they're valid PoIs)
- display history items in Direction fields' suggest

## Screenshots
![image](https://user-images.githubusercontent.com/1225909/135861613-8bedc30b-9481-48df-b7f7-c8ad59657d45.png)

