### PR TITLE
QMAPS-2312 survey CSS fixes

### DIFF
--- a/src/scss/includes/survey.scss
+++ b/src/scss/includes/survey.scss
@@ -12,5 +12,18 @@
     left: 10px;
     right: 10px;
     bottom: auto !important;
+
+    div + div {
+      div:first-child {
+        width: 100%;
+        min-height: $spacing-xl;
+      }
+
+      div:last-child {
+        a {
+          padding: $spacing-xxs $spacing-m;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description

Enhance CSS of survey widget 

NB: I did this fix in Erdapfel's CSS code *for now* .

I decided not to change that inside the Notification Qwant-ponent yet because we first need to see with the Phoenix team / Design team if these kind of change wouldn't mess with their (other) notifications.
I [contacted them](https://team.qwant.rocks/qwant/pl/najck4bio7fsfyspzb6wryaqxe) about that, and if these edits don't bother them I'll move them inside the Qwant-ponent's css.


- Smaller button

- Better alignment on mobile for one-line descriptions
![image](https://user-images.githubusercontent.com/1225909/137955362-ca970be5-e103-4a77-b2dc-bb4931592cbb.png)

-and for multiline descriptions
![image](https://user-images.githubusercontent.com/1225909/137955510-0be5b764-4838-4585-a0a9-a068911c9cc1.png)
![image](https://user-images.githubusercontent.com/1225909/137955546-b43daaf8-3931-4b42-8f8c-67b1930ac335.png)

