### PR TITLE
QMAPS-2354 save dismissed surveys in localStorage

### DIFF
--- a/src/adapters/survey.js
+++ b/src/adapters/survey.js
@@ -1,0 +1,12 @@
+import { get, set } from './store';
+
+const SURVEY_KEY = 'closed_survey_';
+
+export function closeSurvey(id) {
+  // Serialize the list and save it in localStorage
+  set(SURVEY_KEY + id, true);
+}
+
+export function isSurveyClosed(id) {
+  return get(SURVEY_KEY + id) || 0;
+}

--- a/src/components/Survey.jsx
+++ b/src/components/Survey.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import { Notification, Text } from '@qwant/qwant-ponents';
 import React, { useState } from 'react';
 import { useDevice, useSurvey } from 'src/hooks';
+import { closeSurvey } from 'src/adapters/survey';
 
 const Survey = () => {
   const [enabled, setEnabled] = useState(true);
@@ -10,6 +11,7 @@ const Survey = () => {
 
   const onClose = () => {
     setEnabled(false);
+    closeSurvey(survey.id);
   };
 
   return (

--- a/src/hooks/useSurvey.js
+++ b/src/hooks/useSurvey.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useDevice, useConfig, useI18n } from 'src/hooks';
+import { isSurveyClosed } from 'src/adapters/survey';
 
 export const useSurvey = () => {
   const testGroupPer = useConfig('testGroupPer');
@@ -19,7 +20,9 @@ export const useSurvey = () => {
     fetch(surveyUrl)
       .then(response => response.json())
       .then(response => {
-        setSurvey(response.data[0]);
+        if (response?.data?.[0] && !isSurveyClosed(response.data[0].id)) {
+          setSurvey(response.data[0]);
+        }
       });
   }, [isMobile, locale, surveyApiUrl, testGroupPer]);
 


### PR DESCRIPTION
## Description
- save dismissed surveys in localStorage
- don't show a survey on load if if has already been dismissed

## Screenshots

![image](https://user-images.githubusercontent.com/1225909/137958833-7e9d8dd0-b290-4c3c-be6c-e5bde2f7a431.png)

