### PR TITLE
Maintain device context in dedicated provider

### DIFF
--- a/src/libs/device.js
+++ b/src/libs/device.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 export const mobileDeviceMediaQuery = window.matchMedia('(max-width: 640px)');
 
@@ -7,3 +7,21 @@ export function isMobileDevice() {
 }
 
 export const DeviceContext = React.createContext({ isMobile: isMobileDevice() });
+
+export const DeviceProvider = ({ children }) => {
+  const [isMobile, setIsMobile] = useState(isMobileDevice());
+
+  useEffect(() => {
+    const deviceChanged = ({ matches: isMobile }) => {
+      setIsMobile(isMobile);
+    };
+
+    mobileDeviceMediaQuery.addEventListener('change', deviceChanged);
+
+    return () => {
+      mobileDeviceMediaQuery.removeEventListener('change', deviceChanged);
+    };
+  }, []);
+
+  return <DeviceContext.Provider value={{ isMobile }}>{children}</DeviceContext.Provider>;
+};

--- a/src/panel/RootComponent.jsx
+++ b/src/panel/RootComponent.jsx
@@ -1,40 +1,30 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import Menu from 'src/panel/Menu';
 import PanelManager from 'src/panel/PanelManager';
-import { isMobileDevice, mobileDeviceMediaQuery, DeviceContext } from 'src/libs/device';
-import { fire } from 'src/libs/customEvents';
-import { useConfig } from 'src/hooks';
 import { PoiProvider } from 'src/libs/poiContext';
+import { fire } from 'src/libs/customEvents';
+import { useConfig, useDevice } from 'src/hooks';
 
 const RootComponent = ({ router }) => {
-  const [isMobile, setIsMobile] = useState(isMobileDevice());
   const { enabled: isBurgerMenuEnabled } = useConfig('burgerMenu');
+  const { isMobile } = useDevice();
 
   useEffect(() => {
-    const deviceChanged = ({ matches: isMobile }) => {
-      setIsMobile(isMobile);
-      if (!isMobile) {
-        window.execOnMapLoaded(() => {
-          fire('move_mobile_bottom_ui', 0);
-        });
-      }
-      fire('update_map_paddings');
-    };
-
-    mobileDeviceMediaQuery.addListener(deviceChanged);
-
-    return () => {
-      mobileDeviceMediaQuery.removeListener(deviceChanged);
-    };
-  });
+    if (!isMobile) {
+      window.execOnMapLoaded(() => {
+        fire('move_mobile_bottom_ui', 0);
+      });
+    }
+    fire('update_map_paddings');
+  }, [isMobile]);
 
   return (
-    <DeviceContext.Provider value={{ isMobile }}>
+    <>
       <PoiProvider>
         <PanelManager router={router} />
       </PoiProvider>
       {!isMobile && isBurgerMenuEnabled && <Menu />}
-    </DeviceContext.Provider>
+    </>
   );
 };
 

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import Router from 'src/proxies/app_router';
 import { parseMapHash, joinPath, parseQueryString } from 'src/libs/url_utils';
 import { listen } from 'src/libs/customEvents';
+import { DeviceProvider } from 'src/libs/device';
 import RootComponent from './RootComponent';
 import Telemetry from 'src/libs/telemetry';
 
@@ -28,7 +29,12 @@ export default class App {
       );
     };
 
-    ReactDOM.render(<RootComponent router={this.router} />, document.querySelector('#react_root'));
+    ReactDOM.render(
+      <DeviceProvider>
+        <RootComponent router={this.router} />
+      </DeviceProvider>,
+      document.querySelector('#react_root')
+    );
   }
 
   initMap() {


### PR DESCRIPTION
## Description
Put the device context provider in the same module as the device context, instead of managing its state in RootComponent.

## Why
 - Separation of concerns and increasing re-usability
 - Try to use the same pattern for all contexts (context + provider in the same file), for clarity
