### PR TITLE
QMAPS-2352 add 3 logs for surveys

### DIFF
--- a/local_modules/telemetry/index.js
+++ b/local_modules/telemetry/index.js
@@ -76,5 +76,9 @@ module.exports = {
     'home_category',
     /* User feedback */
     'user_feedback_answer',
+    /* Surveys */
+    'survey_display',
+    'survey_close',
+    'survey_answer',
   ],
 };

--- a/src/components/Survey.jsx
+++ b/src/components/Survey.jsx
@@ -3,6 +3,7 @@ import { Notification, Text } from '@qwant/qwant-ponents';
 import React, { useState } from 'react';
 import { useDevice, useSurvey } from 'src/hooks';
 import { closeSurvey } from 'src/adapters/survey';
+import Telemetry from 'src/libs/telemetry';
 
 const Survey = () => {
   const [enabled, setEnabled] = useState(true);
@@ -12,6 +13,11 @@ const Survey = () => {
   const onClose = () => {
     setEnabled(false);
     closeSurvey(survey.id);
+    Telemetry.add(Telemetry.SURVEY_CLOSE, { id: survey.id });
+  };
+
+  const onClick = () => {
+    Telemetry.add(Telemetry.SURVEY_ANSWER, { id: survey.id });
   };
 
   return (
@@ -24,6 +30,7 @@ const Survey = () => {
           url={survey.url}
           buttonLabel={survey.cta}
           onClose={onClose}
+          onClick={onClick}
           mobile={isMobile}
         >
           <Text typo="body-2" color="primary">

--- a/src/hooks/useSurvey.js
+++ b/src/hooks/useSurvey.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useDevice, useConfig, useI18n } from 'src/hooks';
 import { isSurveyClosed } from 'src/adapters/survey';
+import Telemetry from 'src/libs/telemetry';
 
 export const useSurvey = () => {
   const testGroupPer = useConfig('testGroupPer');
@@ -21,6 +22,7 @@ export const useSurvey = () => {
       .then(response => response.json())
       .then(response => {
         if (response?.data?.[0] && !isSurveyClosed(response.data[0].id)) {
+          Telemetry.add(Telemetry.SURVEY_DISPLAY, { id: response.data[0].id });
           setSurvey(response.data[0]);
         }
       });


### PR DESCRIPTION
## Description
Add 3 logs:
Telemetry.SURVEY_DISPLAY
Telemetry.SURVEY_CLOSE
Telemetry.SURVEY_ANSWER
they all send an additional data "id" equal to the current survey's id.
if a survey isn't displayed (ineligible test group, current date not between the survey's start and end, or survey already closed in a previous session), no logs are done.
