### PR TITLE
QMAPS-2316 dedup favorites and history

### DIFF
--- a/src/adapters/suggest_sources.js
+++ b/src/adapters/suggest_sources.js
@@ -72,17 +72,13 @@ export function suggestResults(
           }
         }
 
-        const keptGeocoderSuggestions = pois.slice(
-          0,
-          maxItems - favoriteItems.length - intentionsOrCategories.length - historyItems.length
-        );
-
         const suggestList = [
           ...historyItems,
           ...favoriteItems,
           ...intentionsOrCategories,
-          ...keptGeocoderSuggestions,
-        ];
+          ...pois,
+        ].slice(0, maxItems);
+
         resolve(suggestList);
       } catch (e) {
         reject(e);

--- a/src/adapters/suggest_sources.js
+++ b/src/adapters/suggest_sources.js
@@ -19,18 +19,33 @@ export function suggestResults(
 ) {
   let geocoderPromise;
   let promise;
+
+  // If favorites are enabled:
+  // - get favourites that match the query
+  const favoriteItems = maxFavorites > 0 ? PoiStore.get(term).slice(0, maxFavorites) : [];
+
+  // If history is enabled:
+  // - get all the history items
+  // - ignore the items that are already present in the favourites list
+  // - keep the N first items (where N = maxHistoryItems)
   const historyItems =
     maxHistoryItems > 0
       ? getHistoryItems(term, { withIntentions: withCategories })
+          .filter(item => item.id !== favoriteItems.find(favorite => favorite.id === item.id)?.id)
           .slice(0, maxHistoryItems)
           .map(item => {
             item._suggestSource = 'history';
             return item;
           })
       : [];
+
+  // Field focused and empty: get history + favourite items
   if (term === '') {
     promise = Promise.resolve([...historyItems, ...PoiStore.getAll().slice(0, maxFavorites)]);
-  } else {
+  }
+
+  // Field focused and not empty: get history + favourite + geocoder items
+  else {
     // eslint-disable-next-line no-async-promise-executor
     promise = new Promise(async (resolve, reject) => {
       geocoderPromise = getGeocoderSuggestions(term, {
@@ -56,17 +71,15 @@ export function suggestResults(
             intentionsOrCategories = intentions;
           }
         }
-        const favorites = PoiStore.get(term);
-        const keptFavorites = favorites.slice(0, maxFavorites);
 
         const keptGeocoderSuggestions = pois.slice(
           0,
-          maxItems - keptFavorites.length - intentionsOrCategories.length - historyItems.length
+          maxItems - favoriteItems.length - intentionsOrCategories.length - historyItems.length
         );
 
         const suggestList = [
           ...historyItems,
-          ...keptFavorites,
+          ...favoriteItems,
           ...intentionsOrCategories,
           ...keptGeocoderSuggestions,
         ];


### PR DESCRIPTION
## Description
- Refactor suggest a little (add comments, retrieve favorites first, slice it at maxFavorites, simplify the final split)
- Get the histotry items, remove the items that are already present in favorites list, then slice it at maxHistoryItems
- as a result, when we type in a field, items that are present in both lists are only visible once, in the favourites list. And items that are only present in history are shown in the history list.
- Geocoder items are not removed if they are already present in history and favorites, but that's doable too if we want to!

## Screenshots

Ex: Nice is in favorites, Nimes is not, both are in the history, when I type "Ni", this happens now:

![image](https://user-images.githubusercontent.com/1225909/139078193-f3cbf3ca-5d92-4f5a-837b-229471775c7d.png)


