### PR TITLE
QMAPS-2368 favorites when focusing empty field with no history

### DIFF
--- a/src/adapters/suggest_sources.js
+++ b/src/adapters/suggest_sources.js
@@ -39,9 +39,12 @@ export function suggestResults(
           })
       : [];
 
-  // Field focused and empty: get history + favourite items
+  // Field focused and empty: get history + favourite items, but no favourites if history items are present
   if (term === '') {
-    promise = Promise.resolve([...historyItems, ...PoiStore.getAll().slice(0, maxFavorites)]);
+    promise = Promise.resolve([
+      ...historyItems,
+      ...PoiStore.getAll().slice(0, historyItems.length > 0 ? 0 : maxFavorites),
+    ]);
   }
 
   // Field focused and not empty: get history + favourite + geocoder items

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -21,7 +21,7 @@ const getSuggestItemLimits = ({ inputValue, withHistory, isMobile }) => {
 
   if (!inputValue) {
     return {
-      maxFavorites: 0,
+      maxFavorites: 2, // only if no history items
       maxHistoryItems: isMobile ? 7 : 3,
     };
   }


### PR DESCRIPTION
## Description
- display up to 2 favorites when focusing an empty field if no history items are available
- if history is enabled and not empty, then only the history items are displayed

## Screenshots

![image](https://user-images.githubusercontent.com/1225909/139865246-589873cd-21df-4f75-a0af-63caedc05067.png)

