### PR TITLE
Redirect to the base url when searching empty query or equivalent

### DIFF
--- a/bin/middlewares/fullText_query.js
+++ b/bin/middlewares/fullText_query.js
@@ -37,9 +37,14 @@ module.exports = function (config) {
       },
       timeout: idunnTimeout,
     });
-    if (response.status === 204)
-      // if search an empty query or an equivalent
+    // Return to home if query is empty or equivalent
+    if (response.data.geocoding.query === '') {
       return `${config.system.baseUrl}`;
+    }
+    // Return noresult url if no results were found for an acceptable query
+    if (response.status === 204) {
+      return `${config.system.baseUrl}noresult?${params.toString()}`;
+    }
     const intention = (response.data.intentions || [])[0];
     if (isIntentionValid(intention)) {
       const { q, bbox, category } = intention.filter;

--- a/bin/middlewares/fullText_query.js
+++ b/bin/middlewares/fullText_query.js
@@ -37,6 +37,8 @@ module.exports = function (config) {
       },
       timeout: idunnTimeout,
     });
+    if(response.status === 204) // if search an empty query or an equivalent
+      return `${config.system.baseUrl}`
     const intention = (response.data.intentions || [])[0];
     if (isIntentionValid(intention)) {
       const { q, bbox, category } = intention.filter;

--- a/bin/middlewares/fullText_query.js
+++ b/bin/middlewares/fullText_query.js
@@ -37,8 +37,9 @@ module.exports = function (config) {
       },
       timeout: idunnTimeout,
     });
-    if(response.status === 204) // if search an empty query or an equivalent
-      return `${config.system.baseUrl}`
+    if (response.status === 204)
+      // if search an empty query or an equivalent
+      return `${config.system.baseUrl}`;
     const intention = (response.data.intentions || [])[0];
     if (isIntentionValid(intention)) {
       const { q, bbox, category } = intention.filter;

--- a/tests/__data__/autocomplete_empty.json
+++ b/tests/__data__/autocomplete_empty.json
@@ -1,1 +1,1 @@
-{"type":"FeatureCollection","geocoding":{"version":"0.1.0","query":""},"intentions":[],"features":[]}
+{"type":"FeatureCollection","geocoding":{"version":"0.1.0","query":"gibberish"},"intentions":[],"features":[]}

--- a/tests/__data__/autocomplete_nlu.json
+++ b/tests/__data__/autocomplete_nlu.json
@@ -1,6 +1,6 @@
 {
   "type": "FeatureCollection",
-  "geocoding": {"version": "0.1.0", "query": ""},
+  "geocoding": {"version": "0.1.0", "query": "restonice"},
   "intentions": [
     {
       "filter": {

--- a/tests/__data__/search_type.json
+++ b/tests/__data__/search_type.json
@@ -1,6 +1,6 @@
 {
   "type": "FeatureCollection",
-  "geocoding": {"version": "0.1.0", "query": ""},
+  "geocoding": {"version": "0.1.0", "query": "single"},
   "features": [
     {
       "type": "Feature",


### PR DESCRIPTION
State : Draft (need to discuss)

## Description
New behabior from Idunn fulltext endpoint : 
- Return http response  204 when the query is acceptable, but no results are return from elasticsearch
- Return  http response 200 when the query is acceptable and results are return from elasticsearch OR the query is empty (or equivalent) and no result are returned from ES

## Goal
We would like to redirect to the base url in order to avoid : `Sorry, we could not find this place` when the query is empty or equivalent

The goal of the PR is to have a base to discuss with @xem.

## Why
https://jira.qwant.ninja/browse/QMAPS-2199
