### PR TITLE
Qmaps 2372 history panel filled

### DIFF
--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -95,7 +95,7 @@ export function getHistoryItems(term = '', { withIntentions = false } = {}) {
     });
 }
 
-export function listHistoryItemsByDate(from = 0, to = Date.now()) {
+export function listHistoryItemsByDate(from, to) {
   const searchHistory = get(SEARCH_HISTORY_KEY) || [];
   return searchHistory
     .reverse() // so it's ordered with most recent items first

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -94,3 +94,15 @@ export function getHistoryItems(term = '', { withIntentions = false } = {}) {
       }
     });
 }
+
+export function listHistoryItemsByDate(from = 0, to = Date.now()) {
+  const searchHistory = get(SEARCH_HISTORY_KEY) || [];
+  return searchHistory
+    .reverse() // so it's ordered with most recent items first
+    .filter(item => item.date >= from && item.date < to);
+}
+
+export function historyLength() {
+  const searchHistory = get(SEARCH_HISTORY_KEY) || [];
+  return searchHistory.length;
+}

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -61,14 +61,14 @@ export function deleteSearchHistory() {
 }
 
 const itemEquals = ({ type, item }, other) => {
-  if (type === 'intention' && other.type === 'intention') {
+  if (type === 'intention') {
     return (
-      item.fullTextQuery === other.item.fullTextQuery &&
-      item.category?.name === other.item.category?.name &&
-      item.place?.properties?.geocoding?.name === other.item.place?.properties?.geocoding?.name
+      item.fullTextQuery === other.fullTextQuery &&
+      item.category?.name === other.category?.name &&
+      item.place?.properties?.geocoding?.name === other.place?.properties?.geocoding?.name
     );
-  } else if (type === 'poi' && other.type === 'poi') {
-    return item.id === other.item.id;
+  } else if (type === 'poi') {
+    return item.id === other.id;
   }
   return false;
 };

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -14,12 +14,20 @@ export function getHistoryEnabled() {
   return get(SEARCH_HISTORY_KEY + '_enabled');
 }
 
+export function getHistory() {
+  return get(SEARCH_HISTORY_KEY) || [];
+}
+
+export function setHistory(searchHistory) {
+  set(SEARCH_HISTORY_KEY, searchHistory);
+}
+
 export function saveQuery(item) {
   // Delete query if it's already in the list
   deleteQuery(item);
 
   // Retrieve the search history
-  let searchHistory = get(SEARCH_HISTORY_KEY) || [];
+  let searchHistory = getHistory();
 
   // Put the query at the end of the array
   searchHistory.push({
@@ -34,18 +42,18 @@ export function saveQuery(item) {
   }
 
   // Serialize the list and save it in localStorage
-  set(SEARCH_HISTORY_KEY, searchHistory);
+  setHistory(searchHistory);
 }
 
 export function deleteQuery(item) {
-  const searchHistory = get(SEARCH_HISTORY_KEY) || [];
+  const searchHistory = getHistory();
   const index = searchHistory.findIndex(stored => itemEquals(stored, item));
   if (index === -1) {
     return;
   }
   searchHistory.splice(index, 1);
   // Serialize the list and save it in localStorage
-  set(SEARCH_HISTORY_KEY, searchHistory);
+  setHistory(searchHistory);
 }
 
 export function deleteSearchHistory() {
@@ -53,16 +61,16 @@ export function deleteSearchHistory() {
 }
 
 const itemEquals = ({ type, item }, other) => {
-  if (type === 'intention') {
+  if (type === 'intention' && other.type === 'intention') {
     return (
-      other instanceof Intention &&
-      item.fullTextQuery === other.fullTextQuery &&
-      item.category?.name === other.category?.name &&
-      item.place?.properties?.geocoding?.name === other.place?.properties?.geocoding?.name
+      item.fullTextQuery === other.item.fullTextQuery &&
+      item.category?.name === other.item.category?.name &&
+      item.place?.properties?.geocoding?.name === other.item.place?.properties?.geocoding?.name
     );
-  } else {
-    return other instanceof Poi && item.id === other.id;
+  } else if (type === 'poi' && other.type === 'poi') {
+    return item.id === other.item.id;
   }
+  return false;
 };
 
 const itemMatches = ({ type, item }, term) => {
@@ -78,7 +86,7 @@ const itemMatches = ({ type, item }, term) => {
 };
 
 export function getHistoryItems(term = '', { withIntentions = false } = {}) {
-  const searchHistory = get(SEARCH_HISTORY_KEY) || [];
+  const searchHistory = getHistory();
   return searchHistory
     .reverse() // so it's ordered with most recent items first
     .filter(stored => withIntentions || stored.type !== 'intention')
@@ -96,13 +104,12 @@ export function getHistoryItems(term = '', { withIntentions = false } = {}) {
 }
 
 export function listHistoryItemsByDate(from, to) {
-  const searchHistory = get(SEARCH_HISTORY_KEY) || [];
-  return searchHistory
+  return getHistory()
     .reverse() // so it's ordered with most recent items first
-    .filter(item => item.date >= from && item.date < to);
+    .filter(item => item.date >= from && item.date < to); // filter by date range
 }
 
 export function historyLength() {
-  const searchHistory = get(SEARCH_HISTORY_KEY) || [];
+  const searchHistory = getHistory();
   return searchHistory.length;
 }

--- a/src/panel/history/HistoryPanel.jsx
+++ b/src/panel/history/HistoryPanel.jsx
@@ -2,10 +2,25 @@
 import React, { useState } from 'react';
 import Panel from 'src/components/ui/Panel';
 import { Box, Flex, Switch, Text } from '@qwant/qwant-ponents';
-import { setHistoryEnabled, getHistoryEnabled } from 'src/adapters/search_history';
+import {
+  setHistoryEnabled,
+  getHistoryEnabled,
+  listHistoryItemsByDate,
+  historyLength,
+} from 'src/adapters/search_history';
 
 const HistoryPanel = () => {
   const [isChecked, setIsChecked] = useState(getHistoryEnabled());
+  const now = new Date();
+  const lastMidnight = new Date().setUTCHours(0, 0, 0, 0);
+  const lastWeek = new Date().setUTCDate(now.getUTCDate() - 7);
+  const last2Weeks = new Date().setUTCDate(now.getUTCDate() - 14);
+  const last3Weeks = new Date().setUTCDate(now.getUTCDate() - 21);
+  const todayHistoryItems = listHistoryItemsByDate(lastMidnight, now);
+  const lastWeekHistoryItems = listHistoryItemsByDate(lastWeek, lastMidnight);
+  const last2WeeksHistoryItems = listHistoryItemsByDate(last2Weeks, lastWeek);
+  const last3WeeksHistoryItems = listHistoryItemsByDate(last3Weeks, last2Weeks);
+  const olderHistoryItems = listHistoryItemsByDate(0, last3Weeks);
   const close = () => {
     window.app.navigateTo('/');
   };
@@ -39,7 +54,6 @@ const HistoryPanel = () => {
                 'history panel'
               )}
           &nbsp;
-          <a href="#">{_('Learn more')}</a>
         </Text>
         <Switch
           name="history_enabled"
@@ -48,11 +62,23 @@ const HistoryPanel = () => {
           onChange={onChange}
         />
       </Flex>
-      <Box mt="xl">
-        {isChecked && (
-          <Text>{_('As soon as you do a search, you can find it here 👇', 'history panel')}</Text>
-        )}
-      </Box>
+      <Flex className="history_panel_links">
+        <a href="#">{_('Learn more')}</a>
+        {isChecked && historyLength() > 0 && <a href="#">{_('Delete my history')}</a>}
+      </Flex>
+      {isChecked && (
+        <Box mt="xl">
+          {todayHistoryItems.length ? (
+            todayHistoryItems.map(item => (
+              <Flex key={item.item.id}>
+                {item.date} - {item.type} - {item.item.name}
+              </Flex>
+            ))
+          ) : (
+            <Text>{_('As soon as you do a search, you can find it here 👇', 'history panel')}</Text>
+          )}
+        </Box>
+      )}
     </Panel>
   );
 };

--- a/src/panel/history/HistoryPanel.jsx
+++ b/src/panel/history/HistoryPanel.jsx
@@ -1,41 +1,40 @@
 /* globals _ */
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import Panel from 'src/components/ui/Panel';
-import { Heading, Box, Flex, Switch, Text, Button, IconEmpty } from '@qwant/qwant-ponents';
+import { Heading, Stack, Box, Flex, Switch, Text, Button, IconEmpty } from '@qwant/qwant-ponents';
 import {
   setHistoryEnabled,
   getHistoryEnabled,
   listHistoryItemsByDate,
   historyLength,
   deleteQuery,
-  getHistory,
   deleteSearchHistory,
 } from 'src/adapters/search_history';
 import PlaceIcon from 'src/components/PlaceIcon';
+import { capitalizeFirst } from 'src/libs/string';
 
 const HistoryPanel = () => {
   const [isChecked, setIsChecked] = useState(getHistoryEnabled());
-  const [history, setHistory] = useState(getHistory()); // Local copy of localStorage history
   const now = new Date();
   const lastMidnight = new Date().setUTCHours(0, 0, 0, 0);
   const lastWeek = new Date().setUTCDate(-7);
-  const last2Weeks = new Date().setUTCDate(-14);
-  const last3Weeks = new Date().setUTCDate(-21);
-  const [todayHistory, setTodayHistory] = useState([]);
-  const [lastWeekHistory, setLastWeekHistory] = useState([]);
-  const [last2WeeksHistory, setLast2WeeksHistory] = useState([]);
-  const [last3WeeksHistory, setLast3WeeksHistory] = useState([]);
-  const [olderHistory, setOlderHistory] = useState([]);
-
-  // Observe changes in local history
-  useEffect(() => {
-    // Update the 5 lists
-    setTodayHistory(listHistoryItemsByDate(lastMidnight, now));
-    setLastWeekHistory(listHistoryItemsByDate(lastWeek, lastMidnight));
-    setLast2WeeksHistory(listHistoryItemsByDate(last2Weeks, lastWeek));
-    setLast3WeeksHistory(listHistoryItemsByDate(last3Weeks, last2Weeks));
-    setOlderHistory(listHistoryItemsByDate(0, last3Weeks));
-  }, [history]);
+  const lastMonth = new Date().setUTCDate(-30);
+  const last6Months = new Date().setUTCDate(-180);
+  const lastYear = new Date().setUTCDate(-365);
+  const [todayHistory, setTodayHistory] = useState(listHistoryItemsByDate(lastMidnight, now));
+  const [lastWeekHistory, setLastWeekHistory] = useState(
+    listHistoryItemsByDate(lastWeek, lastMidnight)
+  );
+  const [lastMonthHistory, setLastMonthHistory] = useState(
+    listHistoryItemsByDate(lastMonth, lastWeek)
+  );
+  const [last6MonthsHistory, setLast6MonthsHistory] = useState(
+    listHistoryItemsByDate(last6Months, lastMonth)
+  );
+  const [lastYearHistory, setLastYearHistory] = useState(
+    listHistoryItemsByDate(lastYear, last6Months)
+  );
+  const [olderHistory, setOlderHistory] = useState(listHistoryItemsByDate(0, lastYear));
 
   const close = () => {
     window.app.navigateTo('/');
@@ -44,6 +43,15 @@ const HistoryPanel = () => {
   const onChange = e => {
     setIsChecked(e.target.checked);
     setHistoryEnabled(e.target.checked);
+  };
+
+  const computeHistory = () => {
+    setTodayHistory(listHistoryItemsByDate(lastMidnight, now));
+    setLastWeekHistory(listHistoryItemsByDate(lastWeek, lastMidnight));
+    setLastMonthHistory(listHistoryItemsByDate(lastMonth, lastWeek));
+    setLast6MonthsHistory(listHistoryItemsByDate(last6Months, lastMonth));
+    setLastYearHistory(listHistoryItemsByDate(lastYear, last6Months));
+    setOlderHistory(listHistoryItemsByDate(0, lastYear));
   };
 
   const visit = item => {
@@ -73,8 +81,8 @@ const HistoryPanel = () => {
     // Remove the item in localStorage
     deleteQuery(item);
 
-    // Refresh local copy of localStorage to re-render the page
-    setHistory(getHistory());
+    // Refresh lists and re-render the page
+    computeHistory();
   };
 
   // Clear all the history
@@ -83,8 +91,9 @@ const HistoryPanel = () => {
     if (confirm('Are you sure?')) {
       // Clear history in localStorage
       deleteSearchHistory();
-      // Refresh local copy of localStorage to re-render the page
-      setHistory(getHistory());
+
+      // Refresh lists and re-render the page
+      computeHistory();
     }
   };
 
@@ -96,18 +105,18 @@ const HistoryPanel = () => {
     },"item":{"id":"admin:osm:relation:170100","name":"Nice (06000-06300)","type":"zone","latLon":{"lat":43.7009358,"lng":7.2683912},"className":"","subClassName":"","bbox":[7.1819535,43.6454189,7.323912,43.7607635],"value":"Nice (06000-06300), Alpes-Maritimes, France","queryContext":{"term":"nice","ranking":1,"lang":"fr","position":{"lat":"43.700","lon":"7.300","zoom":"10.000"}},"address":{"stateDistrict":"Alpes-Maritimes","country":"France"}}},{"type":"poi","date":${
       new Date().setUTCDate(-4)
     },"item":{"id":"admin:osm:relation:120965","name":"Lyon","type":"zone","latLon":{"lat":45.7578137,"lng":4.8320114},"className":"","subClassName":"","bbox":[4.7718134,45.7073666,4.8983774,45.8082628],"value":"Lyon, Métropole de Lyon, Auvergne-Rhône-Alpes, France","queryContext":{"term":"lyon","ranking":1,"lang":"fr","position":{"lat":"43.700","lon":"7.300","zoom":"10.000"}},"address":{"stateDistrict":"Métropole de Lyon","state":"Auvergne-Rhône-Alpes","country":"France"}}},{"type":"poi","date":${
-      new Date().setUTCDate(-9)
+      new Date().setUTCDate(-20)
     },"item":{"id":"admin:osm:relation:7444","name":"Paris (75000-75116)","type":"zone","latLon":{"lat":48.8566969,"lng":2.3514616},"className":"","subClassName":"","bbox":[2.224122,48.8155755,2.4697602,48.902156],"value":"Paris (75000-75116), Île-de-France, France","queryContext":{"term":"paris","ranking":1,"lang":"fr","position":{"lat":"45.800","lon":"4.800","zoom":"10.000"}},"address":{"stateDistrict":"Paris","state":"Île-de-France","country":"France"}}},{"type":"poi","date":${
-      new Date().setUTCDate(-14)
+      new Date().setUTCDate(-160)
     },"item":{"id":"admin:osm:relation:54517","name":"Rennes (35000-35700)","type":"zone","latLon":{"lat":48.1113387,"lng":-1.6800198},"className":"","subClassName":"","bbox":[-1.7525876,48.0769155,-1.6244045,48.1549705],"value":"Rennes (35000-35700), Ille-et-Vilaine, Bretagne, France","queryContext":{"term":"Rennes","ranking":1,"lang":"fr","position":{"lat":"48.900","lon":"2.300","zoom":"11.000"}},"address":{"stateDistrict":"Ille-et-Vilaine","state":"Bretagne","country":"France"}}},{"type":"poi","date":${
-      new Date().setUTCDate(-18)
+      new Date().setUTCDate(-300)
     },"item":{"id":"addr:6.989375;43.700095:300","name":"300 Avenue Amiral de Grasse","type":"house","latLon":{"lat":43.700095,"lng":6.989375},"className":"","subClassName":"","value":"300 Avenue Amiral de Grasse (Le Bar-sur-Loup)","queryContext":{"term":"300 av amira","ranking":1,"lang":"fr","position":{"lat":"48.100","lon":"-1.700","zoom":"12.000"}},"address":{"street":"300 Avenue Amiral de Grasse","city":"Le Bar-sur-Loup","stateDistrict":"Alpes-Maritimes","state":"Provence-Alpes-Côte d'Azur","country":"France"}}},{"type":"poi","date":${
-      new Date().setUTCDate(-30)
+      new Date().setUTCDate(-400)
     },"item":{"id":"osm:way:5013364","name":"Tour Eiffel","type":"poi","latLon":{"lat":48.858260156496016,"lng":2.2944990157640612},"className":"attraction","subClassName":"attraction","value":"Tour Eiffel (Paris)","queryContext":{"term":"tour eiffel","ranking":1,"lang":"fr","position":{"lat":"43.700","lon":"7.000","zoom":"17.000"}},"address":{"street":"5 Avenue Anatole France","suburb":"Quartier du Gros-Caillou","cityDistrict":"Paris 7e Arrondissement","city":"Paris","stateDistrict":"Paris","state":"Île-de-France","country":"France","label":"5 Avenue Anatole France (Paris)"}}},
     {"type":"intention","date":1636550261818,"item":{"filter":{"bbox":[7.1819535,43.6454189,7.323912,43.7607635],"category":"restaurant"},"category":{"name":"restaurant","label":"restaurant","iconName":"restaurant","color":"#d76600","matcher":{"regex":"restos?|restaus?|ma?cs?do(?:nald(?:'s)?)?|burgers+king|quick|subway|flunch|hards+rocks+cafe|kfc|pizza|brioches+doree|fives+guys|mezzos+dis+pasta|pommes+des+pain|prets+as+manger|vapiano|starbucks|bigs+fernand|sushi|memphiss+coffee|buffalos+grill|las+boucherie|hippopotamus|leon|pataterie|pizzeria|brasserie|fasts+food|restaurations+rapide|snack|creperie|kebab|sandwicherie|ils+ristorante|le kiosque a pizzas|buffalo grill|campanile|courtepaille|burger king|la pataterie|pizza hut|au bureau|poivre rouge|la croissanterie|tutti pizza|la boite a pizza|la brioche doree|leon de bruxelles|bagelstein|columbus cafe|memphis coffee|del arte|class'croute|o'tacos|sushi shop|mezzo di pasta|pomme de pain|big fernand|pizza sprint|bistro regent|l'epicurien|tablapizza|speed burger|pat a pain|pizza bonici|firmin|l'atelier gourmand|pizza time|a la bonne heure|francesca|planet sushi|speed rabbit pizza|pegast|pizza pai|best western|crep'eat|baila pizza|waffle factory|casino cafeteria|la pizza de nico|crocodile|fresh burritos|231 east street|bagel corner|coeur de ble|dubble|eat sushi|fuxia|il ristorante|les fils a maman|nooi|pitaya|jour|les burgers de papa|bchef|chez papa|cojean|le fournil de pierre|oceane|terre et mer|bistro romain|el rancho|l'alambic|le patacrepe|pizza city|cote sushi|la maison bleue|le club sandwich cafe|les 3 brasseurs|bellota-bellota|bistrot du boucher|la tagliatella|nostrum|pizza pino|point chaud|tacos avenue|exki|garden ice cafe|green is better|le paradis du fruit|les relais d'alsace|ma campagne|mamie bigoude|pasta pizza|pizza cosy|planetalis|salad&co|tommy's diner|yogurt factory|cafe leffe|dominos pizza|indiana cafe|le comptoir du malt|lina's|mythic burger|nikki sushi|alto cafe|ankka|burger bar by quick|carre bleu|esprit sushi|feel juice|five guys"},"alternativeName":"catégorie","type":"category","id":"category:restaurant"},"bbox":[7.1819535,43.6454189,7.323912,43.7607635],"place":{"type":"Feature","geometry":{"coordinates":[7.2683912,43.7009358],"type":"Point"},"properties":{"geocoding":{"type":"zone","label":"Nice (06000-06300), Alpes-Maritimes, France","name":"Nice","postcode":"06000;06100;06200;06300","city":null,"id":"admin:osm:relation:170100","zone_type":"city","citycode":"6088","level":8,"administrative_regions":[{"id":"admin:osm:relation:7385","insee":"6","level":6,"label":"Alpes-Maritimes, France","name":"Alpes-Maritimes","zip_codes":[],"coord":{"lon":7.2683912,"lat":43.7009358},"bbox":[6.6352025999999995,43.4800526,7.7184776,44.3625081],"zone_type":"state_district","parent_id":"admin:osm:relation:2202162","codes":[{"name":"ISO3166-2","value":"FR-06"},{"name":"ref:INSEE","value":"06"},{"name":"ref:nuts","value":"FRL03"},{"name":"ref:nuts:3","value":"FRL03"},{"name":"wikidata","value":"Q3139"}]},{"id":"admin:osm:relation:2202162","insee":"","level":2,"label":"France","name":"France","zip_codes":[],"coord":{"lon":2.3514616,"lat":48.8566969},"bbox":[-5.4517733,41.261115499999995,9.8282225,51.3055721],"zone_type":"country","parent_id":null,"codes":[{"name":"ISO3166-1","value":"FR"},{"name":"ISO3166-1:alpha2","value":"FR"},{"name":"ISO3166-1:alpha3","value":"FRA"},{"name":"ISO3166-1:numeric","value":"250"},{"name":"wikidata","value":"Q142"}]}],"codes":[{"name":"ref:FR:SIREN","value":"210600888"},{"name":"ref:INSEE","value":"06088"},{"name":"wikidata","value":"Q33959"}],"bbox":[7.1819535,43.6454189,7.323912,43.7607635]}}}}}]`;
 
-    // Refresh local copy of history and re-render the page
-    setHistory(getHistory());
+    // Refresh lists and re-render the page
+    computeHistory();
   };
 
   const showItem = item => {
@@ -176,7 +185,8 @@ const HistoryPanel = () => {
           </Box>
           <Box>
             <Text typo="body-2" color="secondary">
-              {item.item.place.properties.geocoding.name}
+              {item.item?.place?.properties?.geocoding?.name ||
+                capitalizeFirst(_('nearby', 'history'))}
             </Text>
           </Box>
         </Flex>
@@ -225,7 +235,7 @@ const HistoryPanel = () => {
         {isChecked && <Button onClick={demo}>DEMO</Button>}
       </Flex>
       {isChecked && (
-        <Box mt="xl">
+        <Stack gap="xl">
           {todayHistory.length > 0 && (
             <Box className="history-list">
               <Heading typo="heading-6">{_('Today', 'history panel')}</Heading>
@@ -238,28 +248,34 @@ const HistoryPanel = () => {
               <Box>{lastWeekHistory.map(showItem)}</Box>
             </Box>
           )}
-          {last2WeeksHistory.length > 0 && (
+          {lastMonthHistory.length > 0 && (
             <Box className="history-list">
-              <Heading typo="heading-6">{_('Last 2 weeks', 'history panel')}</Heading>
-              <Box>{last2WeeksHistory.map(showItem)}</Box>
+              <Heading typo="heading-6">{_('Last month', 'history panel')}</Heading>
+              <Box>{lastMonthHistory.map(showItem)}</Box>
             </Box>
           )}
-          {last3WeeksHistory.length > 0 && (
+          {last6MonthsHistory.length > 0 && (
             <Box className="history-list">
-              <Heading typo="heading-6">{_('Last 3 weeks', 'history panel')}</Heading>
-              <Box>{last3WeeksHistory.map(showItem)}</Box>
+              <Heading typo="heading-6">{_('Last 6 months', 'history panel')}</Heading>
+              <Box>{last6MonthsHistory.map(showItem)}</Box>
+            </Box>
+          )}
+          {lastYearHistory.length > 0 && (
+            <Box className="history-list">
+              <Heading typo="heading-6">{_('Last year', 'history panel')}</Heading>
+              <Box>{lastYearHistory.map(showItem)}</Box>
             </Box>
           )}
           {olderHistory.length > 0 && (
             <Box className="history-list">
-              <Heading typo="heading-6">{_('Older', 'history panel')}</Heading>
+              <Heading typo="heading-6">{_('More than one year ago', 'history panel')}</Heading>
               <Box>{olderHistory.map(showItem)}</Box>
             </Box>
           )}
           {historyLength() === 0 && (
             <Text>{_('As soon as you do a search, you can find it here 👇', 'history panel')}</Text>
           )}
-        </Box>
+        </Stack>
       )}
     </Panel>
   );

--- a/src/panel/history/HistoryPanel.jsx
+++ b/src/panel/history/HistoryPanel.jsx
@@ -7,8 +7,10 @@ import {
   getHistoryEnabled,
   listHistoryItemsByDate,
   historyLength,
+  deleteQuery,
+  deleteSearchHistory,
 } from 'src/adapters/search_history';
-import PlaceIcon from '../../components/PlaceIcon';
+import PlaceIcon from 'src/components/PlaceIcon';
 
 const HistoryPanel = () => {
   const [isChecked, setIsChecked] = useState(getHistoryEnabled());
@@ -29,6 +31,19 @@ const HistoryPanel = () => {
   const onChange = e => {
     setIsChecked(e.target.checked);
     setHistoryEnabled(e.target.checked);
+  };
+
+  const visit = item => {
+    // PoI
+    if (item.type === 'poi') {
+      window.app.navigateTo(`/place/${item.item.id}`);
+    }
+    // Intention
+    else if (item.type === 'intention') {
+      window.app.navigateTo(
+        `/places/?type=${item.item.category.name}&bbox=${item.item.bbox.join(',')}`
+      );
+    }
   };
 
   // TEMPORARY: fill history with items (poi, address, city, intention) from different dates (< 24h, < 1 week, < 2 weeks, < 3 weeks, older)
@@ -57,10 +72,20 @@ const HistoryPanel = () => {
     return item.type === 'poi' ? (
       // poi / city / address
       <Flex key={item.item.id} className="history-list-item">
-        <Box>
+        <Box
+          onClick={() => {
+            visit(item);
+          }}
+        >
           <PlaceIcon className="autocomplete_suggestion_icon" place={item.item} withBackground />
         </Box>
-        <Flex takeAvailableSpace column>
+        <Flex
+          takeAvailableSpace
+          column
+          onClick={() => {
+            visit(item);
+          }}
+        >
           <Box>
             <Text typo="body-1" color="primary">
               {item.item.name}
@@ -78,20 +103,30 @@ const HistoryPanel = () => {
           </Box>
         </Flex>
         <Text color="primary">
-          <IconEmpty />
+          <IconEmpty onClick={() => deleteQuery(item)} />
         </Text>
       </Flex>
     ) : (
       // intention
       <Flex key={item.item.category.id} className="history-list-item">
-        <Box>
+        <Box
+          onClick={() => {
+            visit(item);
+          }}
+        >
           <PlaceIcon
             className="autocomplete_suggestion_icon"
             category={item.item.category}
             withBackground
           />
         </Box>
-        <Flex takeAvailableSpace column>
+        <Flex
+          takeAvailableSpace
+          column
+          onClick={() => {
+            visit(item);
+          }}
+        >
           <Box>
             <Text typo="body-1" color="primary">
               {item.item.category.name}
@@ -104,7 +139,7 @@ const HistoryPanel = () => {
           </Box>
         </Flex>
         <Text color="primary">
-          <IconEmpty />
+          <IconEmpty onClick={() => deleteQuery(item)} />
         </Text>
       </Flex>
     );
@@ -144,7 +179,9 @@ const HistoryPanel = () => {
       </Flex>
       <Flex className="history_panel_links">
         <a href="#">{_('Learn more')}</a>
-        {isChecked && historyLength() > 0 && <a href="#">{_('Delete my history')}</a>}
+        {isChecked && historyLength() > 0 && (
+          <a onClick={deleteSearchHistory}>{_('Delete my history')}</a>
+        )}
         {isChecked && <Button onClick={demo}>DEMO</Button>}
       </Flex>
       {isChecked && (

--- a/src/panel/history/HistoryPanel.jsx
+++ b/src/panel/history/HistoryPanel.jsx
@@ -1,7 +1,7 @@
 /* globals _ */
 import React, { useState } from 'react';
 import Panel from 'src/components/ui/Panel';
-import { Box, Flex, Switch, Text } from '@qwant/qwant-ponents';
+import { Heading, Box, Flex, Switch, Text, Button } from '@qwant/qwant-ponents';
 import {
   setHistoryEnabled,
   getHistoryEnabled,
@@ -13,9 +13,9 @@ const HistoryPanel = () => {
   const [isChecked, setIsChecked] = useState(getHistoryEnabled());
   const now = new Date();
   const lastMidnight = new Date().setUTCHours(0, 0, 0, 0);
-  const lastWeek = new Date().setUTCDate(now.getUTCDate() - 7);
-  const last2Weeks = new Date().setUTCDate(now.getUTCDate() - 14);
-  const last3Weeks = new Date().setUTCDate(now.getUTCDate() - 21);
+  const lastWeek = new Date().setUTCDate(-7);
+  const last2Weeks = new Date().setUTCDate(-14);
+  const last3Weeks = new Date().setUTCDate(-21);
   const todayHistoryItems = listHistoryItemsByDate(lastMidnight, now);
   const lastWeekHistoryItems = listHistoryItemsByDate(lastWeek, lastMidnight);
   const last2WeeksHistoryItems = listHistoryItemsByDate(last2Weeks, lastWeek);
@@ -28,6 +28,43 @@ const HistoryPanel = () => {
   const onChange = e => {
     setIsChecked(e.target.checked);
     setHistoryEnabled(e.target.checked);
+  };
+
+  // TEMPORARY: fill history with items (poi, address, city, intention) from different dates (< 24h, < 1 week, < 2 weeks, < 3 weeks, older)
+  // prettier-ignore
+  const demo = () => {
+    localStorage.qmaps_v1_search_history_v1 = `[{"type":"poi","date":${
+      new Date().setUTCHours(9,0,0,0)
+    },"item":{"id":"admin:osm:relation:170100","name":"Nice (06000-06300)","type":"zone","latLon":{"lat":43.7009358,"lng":7.2683912},"className":"","subClassName":"","bbox":[7.1819535,43.6454189,7.323912,43.7607635],"value":"Nice (06000-06300), Alpes-Maritimes, France","queryContext":{"term":"nice","ranking":1,"lang":"fr","position":{"lat":"43.700","lon":"7.300","zoom":"10.000"}},"address":{"stateDistrict":"Alpes-Maritimes","country":"France"}}},{"type":"poi","date":${
+      new Date().setUTCDate(-4)
+    },"item":{"id":"admin:osm:relation:120965","name":"Lyon","type":"zone","latLon":{"lat":45.7578137,"lng":4.8320114},"className":"","subClassName":"","bbox":[4.7718134,45.7073666,4.8983774,45.8082628],"value":"Lyon, Métropole de Lyon, Auvergne-Rhône-Alpes, France","queryContext":{"term":"lyon","ranking":1,"lang":"fr","position":{"lat":"43.700","lon":"7.300","zoom":"10.000"}},"address":{"stateDistrict":"Métropole de Lyon","state":"Auvergne-Rhône-Alpes","country":"France"}}},{"type":"poi","date":${
+      new Date().setUTCDate(-9)
+    },"item":{"id":"admin:osm:relation:7444","name":"Paris (75000-75116)","type":"zone","latLon":{"lat":48.8566969,"lng":2.3514616},"className":"","subClassName":"","bbox":[2.224122,48.8155755,2.4697602,48.902156],"value":"Paris (75000-75116), Île-de-France, France","queryContext":{"term":"paris","ranking":1,"lang":"fr","position":{"lat":"45.800","lon":"4.800","zoom":"10.000"}},"address":{"stateDistrict":"Paris","state":"Île-de-France","country":"France"}}},{"type":"poi","date":${
+      new Date().setUTCDate(-14)
+    },"item":{"id":"admin:osm:relation:54517","name":"Rennes (35000-35700)","type":"zone","latLon":{"lat":48.1113387,"lng":-1.6800198},"className":"","subClassName":"","bbox":[-1.7525876,48.0769155,-1.6244045,48.1549705],"value":"Rennes (35000-35700), Ille-et-Vilaine, Bretagne, France","queryContext":{"term":"Rennes","ranking":1,"lang":"fr","position":{"lat":"48.900","lon":"2.300","zoom":"11.000"}},"address":{"stateDistrict":"Ille-et-Vilaine","state":"Bretagne","country":"France"}}},{"type":"poi","date":${
+      new Date().setUTCDate(-18)
+    },"item":{"id":"addr:6.989375;43.700095:300","name":"300 Avenue Amiral de Grasse","type":"house","latLon":{"lat":43.700095,"lng":6.989375},"className":"","subClassName":"","value":"300 Avenue Amiral de Grasse (Le Bar-sur-Loup)","queryContext":{"term":"300 av amira","ranking":1,"lang":"fr","position":{"lat":"48.100","lon":"-1.700","zoom":"12.000"}},"address":{"street":"300 Avenue Amiral de Grasse","city":"Le Bar-sur-Loup","stateDistrict":"Alpes-Maritimes","state":"Provence-Alpes-Côte d'Azur","country":"France"}}},{"type":"poi","date":${
+      new Date().setUTCDate(-30)
+    },"item":{"id":"osm:way:5013364","name":"Tour Eiffel","type":"poi","latLon":{"lat":48.858260156496016,"lng":2.2944990157640612},"className":"attraction","subClassName":"attraction","value":"Tour Eiffel (Paris)","queryContext":{"term":"tour eiffel","ranking":1,"lang":"fr","position":{"lat":"43.700","lon":"7.000","zoom":"17.000"}},"address":{"street":"5 Avenue Anatole France","suburb":"Quartier du Gros-Caillou","cityDistrict":"Paris 7e Arrondissement","city":"Paris","stateDistrict":"Paris","state":"Île-de-France","country":"France","label":"5 Avenue Anatole France (Paris)"}}},
+    {"type":"intention","date":1636550261818,"item":{"filter":{"bbox":[7.1819535,43.6454189,7.323912,43.7607635],"category":"restaurant"},"category":{"name":"restaurant","label":"restaurant","iconName":"restaurant","color":"#d76600","matcher":{"regex":"restos?|restaus?|ma?cs?do(?:nald(?:'s)?)?|burgers+king|quick|subway|flunch|hards+rocks+cafe|kfc|pizza|brioches+doree|fives+guys|mezzos+dis+pasta|pommes+des+pain|prets+as+manger|vapiano|starbucks|bigs+fernand|sushi|memphiss+coffee|buffalos+grill|las+boucherie|hippopotamus|leon|pataterie|pizzeria|brasserie|fasts+food|restaurations+rapide|snack|creperie|kebab|sandwicherie|ils+ristorante|le kiosque a pizzas|buffalo grill|campanile|courtepaille|burger king|la pataterie|pizza hut|au bureau|poivre rouge|la croissanterie|tutti pizza|la boite a pizza|la brioche doree|leon de bruxelles|bagelstein|columbus cafe|memphis coffee|del arte|class'croute|o'tacos|sushi shop|mezzo di pasta|pomme de pain|big fernand|pizza sprint|bistro regent|l'epicurien|tablapizza|speed burger|pat a pain|pizza bonici|firmin|l'atelier gourmand|pizza time|a la bonne heure|francesca|planet sushi|speed rabbit pizza|pegast|pizza pai|best western|crep'eat|baila pizza|waffle factory|casino cafeteria|la pizza de nico|crocodile|fresh burritos|231 east street|bagel corner|coeur de ble|dubble|eat sushi|fuxia|il ristorante|les fils a maman|nooi|pitaya|jour|les burgers de papa|bchef|chez papa|cojean|le fournil de pierre|oceane|terre et mer|bistro romain|el rancho|l'alambic|le patacrepe|pizza city|cote sushi|la maison bleue|le club sandwich cafe|les 3 brasseurs|bellota-bellota|bistrot du boucher|la tagliatella|nostrum|pizza pino|point chaud|tacos avenue|exki|garden ice cafe|green is better|le paradis du fruit|les relais d'alsace|ma campagne|mamie bigoude|pasta pizza|pizza cosy|planetalis|salad&co|tommy's diner|yogurt factory|cafe leffe|dominos pizza|indiana cafe|le comptoir du malt|lina's|mythic burger|nikki sushi|alto cafe|ankka|burger bar by quick|carre bleu|esprit sushi|feel juice|five guys"},"alternativeName":"catégorie","type":"category","id":"category:restaurant"},"bbox":[7.1819535,43.6454189,7.323912,43.7607635],"place":{"type":"Feature","geometry":{"coordinates":[7.2683912,43.7009358],"type":"Point"},"properties":{"geocoding":{"type":"zone","label":"Nice (06000-06300), Alpes-Maritimes, France","name":"Nice","postcode":"06000;06100;06200;06300","city":null,"id":"admin:osm:relation:170100","zone_type":"city","citycode":"6088","level":8,"administrative_regions":[{"id":"admin:osm:relation:7385","insee":"6","level":6,"label":"Alpes-Maritimes, France","name":"Alpes-Maritimes","zip_codes":[],"coord":{"lon":7.2683912,"lat":43.7009358},"bbox":[6.6352025999999995,43.4800526,7.7184776,44.3625081],"zone_type":"state_district","parent_id":"admin:osm:relation:2202162","codes":[{"name":"ISO3166-2","value":"FR-06"},{"name":"ref:INSEE","value":"06"},{"name":"ref:nuts","value":"FRL03"},{"name":"ref:nuts:3","value":"FRL03"},{"name":"wikidata","value":"Q3139"}]},{"id":"admin:osm:relation:2202162","insee":"","level":2,"label":"France","name":"France","zip_codes":[],"coord":{"lon":2.3514616,"lat":48.8566969},"bbox":[-5.4517733,41.261115499999995,9.8282225,51.3055721],"zone_type":"country","parent_id":null,"codes":[{"name":"ISO3166-1","value":"FR"},{"name":"ISO3166-1:alpha2","value":"FR"},{"name":"ISO3166-1:alpha3","value":"FRA"},{"name":"ISO3166-1:numeric","value":"250"},{"name":"wikidata","value":"Q142"}]}],"codes":[{"name":"ref:FR:SIREN","value":"210600888"},{"name":"ref:INSEE","value":"06088"},{"name":"wikidata","value":"Q33959"}],"bbox":[7.1819535,43.6454189,7.323912,43.7607635]}}}}}]`;
+
+    // eslint-disable-next-line no-self-assign
+    location = location;
+  };
+
+  const showItem = item => {
+    return item.type === 'poi' ? (
+      // poi / city / address
+      <Flex key={item.item.id}>
+        {item.date} - {item.type} - {item.item.name}
+      </Flex>
+    ) : (
+      // intention
+      <Flex key={item.item.category.id}>
+        {item.date} - {item.type} - {item.item.category.name} -
+        {item.item.place.properties.geocoding.name}
+      </Flex>
+    );
   };
 
   return (
@@ -65,16 +102,41 @@ const HistoryPanel = () => {
       <Flex className="history_panel_links">
         <a href="#">{_('Learn more')}</a>
         {isChecked && historyLength() > 0 && <a href="#">{_('Delete my history')}</a>}
+        {isChecked && <Button onClick={demo}>DEMO</Button>}
       </Flex>
       {isChecked && (
         <Box mt="xl">
-          {todayHistoryItems.length ? (
-            todayHistoryItems.map(item => (
-              <Flex key={item.item.id}>
-                {item.date} - {item.type} - {item.item.name}
-              </Flex>
-            ))
-          ) : (
+          {todayHistoryItems.length > 0 && (
+            <>
+              <Heading typo="heading-6">{_('Today', 'history panel')}</Heading>
+              {todayHistoryItems.map(showItem)}
+            </>
+          )}
+          {lastWeekHistoryItems.length > 0 && (
+            <>
+              <Heading typo="heading-6">{_('Last week', 'history panel')}</Heading>
+              {lastWeekHistoryItems.map(showItem)}
+            </>
+          )}
+          {last2WeeksHistoryItems.length > 0 && (
+            <>
+              <Heading typo="heading-6">{_('Last 2 weeks', 'history panel')}</Heading>
+              {last2WeeksHistoryItems.map(showItem)}
+            </>
+          )}
+          {last3WeeksHistoryItems.length > 0 && (
+            <>
+              <Heading typo="heading-6">{_('Last 3 weeks', 'history panel')}</Heading>
+              {last3WeeksHistoryItems.map(showItem)}
+            </>
+          )}
+          {olderHistoryItems.length > 0 && (
+            <>
+              <Heading typo="heading-6">{_('Older', 'history panel')}</Heading>
+              {olderHistoryItems.map(showItem)}
+            </>
+          )}
+          {historyLength() === 0 && (
             <Text>{_('As soon as you do a search, you can find it here 👇', 'history panel')}</Text>
           )}
         </Box>

--- a/src/panel/history/HistoryPanel.jsx
+++ b/src/panel/history/HistoryPanel.jsx
@@ -79,7 +79,7 @@ const HistoryPanel = () => {
   // Remove one item from the list
   const remove = item => {
     // Remove the item in localStorage
-    deleteQuery(item);
+    deleteQuery(item.item);
 
     // Refresh lists and re-render the page
     computeHistory();

--- a/src/panel/history/HistoryPanel.jsx
+++ b/src/panel/history/HistoryPanel.jsx
@@ -1,13 +1,14 @@
 /* globals _ */
 import React, { useState } from 'react';
 import Panel from 'src/components/ui/Panel';
-import { Heading, Box, Flex, Switch, Text, Button } from '@qwant/qwant-ponents';
+import { Heading, Box, Flex, Switch, Text, Button, IconEmpty } from '@qwant/qwant-ponents';
 import {
   setHistoryEnabled,
   getHistoryEnabled,
   listHistoryItemsByDate,
   historyLength,
 } from 'src/adapters/search_history';
+import PlaceIcon from '../../components/PlaceIcon';
 
 const HistoryPanel = () => {
   const [isChecked, setIsChecked] = useState(getHistoryEnabled());
@@ -55,14 +56,56 @@ const HistoryPanel = () => {
   const showItem = item => {
     return item.type === 'poi' ? (
       // poi / city / address
-      <Flex key={item.item.id}>
-        {item.date} - {item.type} - {item.item.name}
+      <Flex key={item.item.id} className="history-list-item">
+        <Box>
+          <PlaceIcon className="autocomplete_suggestion_icon" place={item.item} withBackground />
+        </Box>
+        <Flex takeAvailableSpace column>
+          <Box>
+            <Text typo="body-1" color="primary">
+              {item.item.name}
+            </Text>
+          </Box>
+          <Box>
+            <Text typo="body-2" color="secondary">
+              {item.item?.address?.label ||
+                item.item?.address?.city ||
+                item.item?.address?.stateDistrict ||
+                item.item?.address?.state ||
+                item.item?.address?.country ||
+                ''}
+            </Text>
+          </Box>
+        </Flex>
+        <Text color="primary">
+          <IconEmpty />
+        </Text>
       </Flex>
     ) : (
       // intention
-      <Flex key={item.item.category.id}>
-        {item.date} - {item.type} - {item.item.category.name} -
-        {item.item.place.properties.geocoding.name}
+      <Flex key={item.item.category.id} className="history-list-item">
+        <Box>
+          <PlaceIcon
+            className="autocomplete_suggestion_icon"
+            category={item.item.category}
+            withBackground
+          />
+        </Box>
+        <Flex takeAvailableSpace column>
+          <Box>
+            <Text typo="body-1" color="primary">
+              {item.item.category.name}
+            </Text>
+          </Box>
+          <Box>
+            <Text typo="body-2" color="secondary">
+              {item.item.place.properties.geocoding.name}
+            </Text>
+          </Box>
+        </Flex>
+        <Text color="primary">
+          <IconEmpty />
+        </Text>
       </Flex>
     );
   };
@@ -107,34 +150,34 @@ const HistoryPanel = () => {
       {isChecked && (
         <Box mt="xl">
           {todayHistoryItems.length > 0 && (
-            <>
+            <Box className="history-list">
               <Heading typo="heading-6">{_('Today', 'history panel')}</Heading>
-              {todayHistoryItems.map(showItem)}
-            </>
+              <Box>{todayHistoryItems.map(showItem)}</Box>
+            </Box>
           )}
           {lastWeekHistoryItems.length > 0 && (
-            <>
+            <Box className="history-list">
               <Heading typo="heading-6">{_('Last week', 'history panel')}</Heading>
-              {lastWeekHistoryItems.map(showItem)}
-            </>
+              <Box>{lastWeekHistoryItems.map(showItem)}</Box>
+            </Box>
           )}
           {last2WeeksHistoryItems.length > 0 && (
-            <>
+            <Box className="history-list">
               <Heading typo="heading-6">{_('Last 2 weeks', 'history panel')}</Heading>
-              {last2WeeksHistoryItems.map(showItem)}
-            </>
+              <Box>{last2WeeksHistoryItems.map(showItem)}</Box>
+            </Box>
           )}
           {last3WeeksHistoryItems.length > 0 && (
-            <>
+            <Box className="history-list">
               <Heading typo="heading-6">{_('Last 3 weeks', 'history panel')}</Heading>
-              {last3WeeksHistoryItems.map(showItem)}
-            </>
+              <Box>{last3WeeksHistoryItems.map(showItem)}</Box>
+            </Box>
           )}
           {olderHistoryItems.length > 0 && (
-            <>
+            <Box className="history-list">
               <Heading typo="heading-6">{_('Older', 'history panel')}</Heading>
-              {olderHistoryItems.map(showItem)}
-            </>
+              <Box>{olderHistoryItems.map(showItem)}</Box>
+            </Box>
           )}
           {historyLength() === 0 && (
             <Text>{_('As soon as you do a search, you can find it here 👇', 'history panel')}</Text>

--- a/src/panel/menu/AppMenu.jsx
+++ b/src/panel/menu/AppMenu.jsx
@@ -40,7 +40,7 @@ const AppMenu = ({ close, openProducts }) => {
           }}
           icon={<IconHistory width={16} fill={PURPLE} />}
         >
-          {_('My search history', 'menu')}
+          {_('My history', 'menu')}
         </MenuItem>
       )}
       <MenuItem

--- a/src/scss/includes/panels/history_panel.scss
+++ b/src/scss/includes/panels/history_panel.scss
@@ -17,3 +17,18 @@
   display: block;
   width: 50%;
 }
+
+.history-list {
+  border-bottom: 1px solid;
+  margin: 15px 0;
+
+  &:last-of-type {
+    border-bottom: none;
+  }
+}
+
+.history-list-item {
+  padding: 5px 0;
+  min-height: 40px;
+  margin: 0 0 5px 0;
+}

--- a/src/scss/includes/panels/history_panel.scss
+++ b/src/scss/includes/panels/history_panel.scss
@@ -31,4 +31,5 @@
   padding: 5px 0;
   min-height: 40px;
   margin: 0 0 5px 0;
+  cursor: pointer;
 }

--- a/src/scss/includes/panels/history_panel.scss
+++ b/src/scss/includes/panels/history_panel.scss
@@ -12,3 +12,8 @@
     padding: 12px;
   }
 }
+
+.history_panel_links a {
+  display: block;
+  width: 50%;
+}

--- a/src/scss/includes/panels/history_panel.scss
+++ b/src/scss/includes/panels/history_panel.scss
@@ -20,7 +20,6 @@
 
 .history-list {
   border-bottom: 1px solid;
-  margin: 15px 0;
 
   &:last-of-type {
     border-bottom: none;


### PR DESCRIPTION
## Description

- List last visited PoIs and intentions in 6 different lists
- A link to delete everything
- Each item can be visited by clicking on it, or deleted by clicking a little trash icon on the right
- Items listed in history: PoI, Address, City, Area/Zone (Arrondissement, Département, Région), Country, Intention with or without category, with or without location
- Items not listed in history: GPS coordinates, POIs clicked on the map or in a PoI list, plus any of the above if it has not been typed in a search field.
- fixed history dedup (for both saving individual items in history and deleting them)
- TEMP: a DEMO button fills the history with different types and dates (will be removed)
- TODO in another MR: final design


## Screenshots

![image](https://user-images.githubusercontent.com/1225909/142895512-0aac2905-2d7b-4b33-929a-e3bc56525a95.png)

