### PR TITLE
app.js: prevent mutation of global config

### DIFF
--- a/bin/app.js
+++ b/bin/app.js
@@ -125,11 +125,18 @@ function App(config) {
     const userAgent = req.headers['user-agent'];
     const disableMenuRule = config.server.disableBurgerMenu.userAgentRule;
     const { server: _droppedServerConfig, ...appConfig } = config;
+    let localAppConfig = appConfig;
     if (disableMenuRule && userAgent && userAgent.match(disableMenuRule)) {
-      appConfig.burgerMenu.enabled = false;
+      localAppConfig = {
+        ...appConfig,
+        burgerMenu: {
+          ...appConfig.burgerMenu,
+          enabled: false,
+        },
+      };
     }
-    appConfig.testGroupPer = testGroup(config, req).testGroupPer;
-    res.render('index', { config: appConfig });
+    localAppConfig.testGroupPer = testGroup(config, req).testGroupPer;
+    res.render('index', { config: localAppConfig });
   });
 
   if (config.server.acceptPostedLogs) {


### PR DESCRIPTION
I feel like the best way to fix this indefinitely would be to clone the global config, but it doesn't seem like this is something idiomatic in Javascript: https://attacomsian.com/blog/javascript-clone-objects (describes a solution based on a library, and the other one consists in serializing then de-serializing JSON ... lol nope).

So I guess we will have to be careful never mutating the global configuration.

EDIT: maybe we'd want to use the no-mutation lint from https://github.com/jhusain/eslint-plugin-immutable ? It seems unacceptable to me that eslint accepts this by default:

```javascript
const obj = { a: 3 };
obj.a = 0;
```