### PR TITLE
Qmaps 2373 / 2374 history modals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5240,9 +5240,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001238",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001238.tgz",
-      "integrity": "sha512-bZGam2MxEt7YNsa2VwshqWQMwrYs5tR5WZQRYSuFxsBQunWjBuXhN4cS9nV5FFb1Z9y+DoQcQ0COyQbv6A+CKw==",
+      "version": "1.0.30001283",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
+      "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -25254,9 +25254,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001238",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001238.tgz",
-      "integrity": "sha512-bZGam2MxEt7YNsa2VwshqWQMwrYs5tR5WZQRYSuFxsBQunWjBuXhN4cS9nV5FFb1Z9y+DoQcQ0COyQbv6A+CKw==",
+      "version": "1.0.30001283",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
+      "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==",
       "dev": true
     },
     "capture-exit": {

--- a/src/modals/HistoryModal.jsx
+++ b/src/modals/HistoryModal.jsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Modal from 'src/components/ui/Modal';
+import { fire } from 'src/libs/customEvents';
+import { CloseButton } from 'src/components/ui';
+import classnames from 'classnames';
+import { useDevice, useI18n } from 'src/hooks';
+import { Button, Box, Flex } from '@qwant/qwant-ponents';
+import { deleteSearchHistory } from 'src/adapters/search_history';
+
+const HistoryModal = ({ status, onClose, onAccept }) => {
+  const { _ } = useI18n();
+  const { isMobile } = useDevice();
+
+  const statuses = {
+    DISABLE: {
+      title: _('Disable Qwant Maps history', 'history'),
+      text: _('With this action all your search history will be lost.', 'history'),
+      button1: _('Cancel', 'history'),
+      button2: _('Disable my history', 'history'),
+      className: 'modal__history__disable',
+    },
+    CLEAR: {
+      title: _('Clear all my Qwant Maps history', 'history'),
+      text: _('This action cannot be reversed', 'history'),
+      button1: _('Cancel', 'history'),
+      button2: _('Clear my history', 'history'),
+      className: 'modal__history__delete',
+    },
+  };
+
+  const { title, text, button1, button2, className } = statuses[status];
+  return (
+    <div className="modal__maps__history">
+      <Modal onClose={onClose}>
+        <Box m="s" className={classnames('modal__maps', className)}>
+          <CloseButton onClick={onClose} />
+          <div className="modal__maps__content">
+            <h2
+              className="modal__title u-text--smallTitle"
+              dangerouslySetInnerHTML={{ __html: title }}
+            />
+            <div
+              className="modal__subtitle u-text--subtitle"
+              dangerouslySetInnerHTML={{ __html: text }}
+            />
+            <Flex column={isMobile}>
+              <Button full variant="secondary" onClick={onClose} m="xxs">
+                {button1}
+              </Button>
+              <Button full variant="primary" onClick={onAccept} m="xxs">
+                {button2}
+              </Button>
+            </Flex>
+          </div>
+        </Box>
+      </Modal>
+    </div>
+  );
+};
+
+function close() {
+  ReactDOM.unmountComponentAtNode(document.querySelector('.react_modal__container'));
+}
+
+function disable() {
+  deleteSearchHistory();
+  fire('disable_history');
+  close();
+}
+
+function clear() {
+  deleteSearchHistory();
+  fire('clear_history');
+  close();
+}
+
+function open(status, onClose, onAccept) {
+  ReactDOM.render(
+    <HistoryModal status={status} onClose={onClose} onAccept={onAccept} />,
+    document.querySelector('.react_modal__container')
+  );
+}
+
+export function openDisableHistoryModal() {
+  open('DISABLE', close, disable);
+}
+
+export function openClearHistoryModal() {
+  open('CLEAR', close, clear);
+}
+
+export default HistoryModal;

--- a/src/scss/includes/panels/history_panel.scss
+++ b/src/scss/includes/panels/history_panel.scss
@@ -32,3 +32,7 @@
   margin: 0 0 5px 0;
   cursor: pointer;
 }
+
+.modal__maps__history .modal {
+  width: 400px;
+}


### PR DESCRIPTION
## Description
Show confirmation modals before clearing or disabling local search history.
Both use the same component 
Disabling the history also provokes clearing the history
Desktop / Mobile designs are different (buttons stacked on mobile)
Also in this MR: updated the caniuse dependency

## Screenshots
Modal 1 (seen on desktop):
![image](https://user-images.githubusercontent.com/1225909/143900462-a59fa609-899d-41f2-8bfa-57379b62552a.png)

Modal 2 (seen on mobile):
![image](https://user-images.githubusercontent.com/1225909/143900512-de311b22-decc-406e-8723-845daf06e3bb.png)

