### PR TITLE
QMAPS-2356 show history prompt in suggest if feature flag enabled and prompt not yet answered

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -94,7 +94,7 @@ userFeedback:
   dismissDurationDays: 30
 
 searchHistory:
-  enabled: false
+  enabled: true
 
 survey:
   surveyApiUrl: override_by_environment

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -94,7 +94,7 @@ userFeedback:
   dismissDurationDays: 30
 
 searchHistory:
-  enabled: true
+  enabled: false
 
 survey:
   surveyApiUrl: override_by_environment

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -14,6 +14,14 @@ export function getHistoryEnabled() {
   return get(SEARCH_HISTORY_KEY + '_enabled');
 }
 
+export function setHistoryPrompt(value) {
+  set(SEARCH_HISTORY_KEY + '_prompt', value);
+}
+
+export function getHistoryPrompt() {
+  return get(SEARCH_HISTORY_KEY + '_prompt');
+}
+
 export function getHistory() {
   return get(SEARCH_HISTORY_KEY) || [];
 }

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -143,8 +143,11 @@ const TopBar = ({ value, setUserInputValue, inputRef, onSuggestToggle, backButto
                   onFocus();
                 }}
                 onBlur={() => {
-                  setFocused(false);
-                  onBlur();
+                  // The mouseLeave flag allows to keep the suggest open when clicking outside of the browser
+                  if (!window.mouseLeave) {
+                    setFocused(false);
+                    onBlur();
+                  }
                 }}
                 onKeyDown={onKeyDown}
               />

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useCallback, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import debounce from 'lodash.debounce';
 import { bool, string, func, object } from 'prop-types';
-import { useConfig, useDevice, useI18n } from 'src/hooks';
+import { useDevice, useI18n } from 'src/hooks';
 import SuggestsDropdown from 'src/components/ui/SuggestsDropdown';
 import { fetchSuggests, getInputValue, modifyList } from 'src/libs/suggest';
 import { UserFeedbackYesNo } from './index';

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useCallback, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import debounce from 'lodash.debounce';
 import { bool, string, func, object } from 'prop-types';
-import { useDevice, useI18n } from 'src/hooks';
+import { useConfig, useDevice, useI18n } from 'src/hooks';
 import SuggestsDropdown from 'src/components/ui/SuggestsDropdown';
 import { fetchSuggests, getInputValue, modifyList } from 'src/libs/suggest';
 import { UserFeedbackYesNo } from './index';
@@ -171,7 +171,10 @@ const Suggest = ({
           setHasFocus(true);
         },
         onBlur: () => {
-          setHasFocus(false);
+          // The mouseLeave flag allows to keep the suggest open when clicking outside of the browser
+          if (!window.mouseLeave) {
+            setHasFocus(false);
+          }
         },
         highlightedValue: highlighted ? getInputValue(highlighted) : null,
       })}
@@ -183,6 +186,7 @@ const Suggest = ({
               suggestItems={items}
               highlighted={highlighted}
               onSelect={selectItem}
+              value={value}
             />
             {withFeedback && value && items.length > 0 && !items[0].errorLabel && (
               <UserFeedbackYesNo

--- a/src/components/ui/SuggestsDropdown.jsx
+++ b/src/components/ui/SuggestsDropdown.jsx
@@ -19,7 +19,7 @@ const SuggestsDropdown = ({ className = '', suggestItems, onSelect, highlighted,
           {_(
             'Convenient and completely private, the history will only be visible to you on this device 🙈.',
             'history'
-          )}
+          )}{' '}
           <a href="">{_('Read more', 'history')}</a>
         </Box>
         <Box mt="l">

--- a/src/components/ui/SuggestsDropdown.jsx
+++ b/src/components/ui/SuggestsDropdown.jsx
@@ -1,11 +1,35 @@
 import React from 'react';
 import classnames from 'classnames';
 import { object, func, string, arrayOf } from 'prop-types';
-
 import SuggestItem from './SuggestItem';
+import { useConfig, useI18n } from 'src/hooks';
+import { Stack, Box, Button, Heading } from '@qwant/qwant-ponents';
+import { getHistoryPrompt } from 'src/adapters/search_history';
 
-const SuggestsDropdown = ({ className = '', suggestItems, onSelect, highlighted }) => {
-  return (
+const SuggestsDropdown = ({ className = '', suggestItems, onSelect, highlighted, value }) => {
+  const { _ } = useI18n();
+  const searchHistoryConfig = useConfig('searchHistory');
+
+  // Focused and empty field, unanswered prompt, history feature enabled: show history prompt
+  return searchHistoryConfig?.enabled && value === '' && getHistoryPrompt() === null ? (
+    <Box m="l">
+      <Heading as="h6">{_('History is available on Qwant Maps', 'history')}</Heading>
+      <Stack>
+        <Box>
+          {_(
+            'Convenient and completely private, the history will only be visible to you on this device 🙈.',
+            'history'
+          )}
+          <a href="">{_('Read more', 'history')}</a>
+        </Box>
+        <Box mt="l">
+          <Button variant="secondary">{_('No thanks', 'history')}</Button>
+          <Button ml="l">{_('Enable history', 'history')}</Button>
+        </Box>
+      </Stack>
+    </Box>
+  ) : (
+    // Focused field and (answered prompt or history feature disabled): show suggest
     <ul className={classnames('autocomplete_suggestions', className)}>
       {suggestItems.map((suggestItem, index) => (
         <li
@@ -27,6 +51,7 @@ SuggestsDropdown.propTypes = {
   highlighted: object,
   onSelect: func.isRequired,
   className: string,
+  value: string,
 };
 
 export default SuggestsDropdown;

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -35,6 +35,15 @@ export default class App {
       </DeviceProvider>,
       document.querySelector('#react_root')
     );
+
+    // The mouseLeave flag allows to keep the suggest open when clicking outside of the browser
+    window.mouseLeave = false;
+    window.document.onmouseleave = () => {
+      window.mouseLeave = true;
+    };
+    window.document.onmouseenter = () => {
+      window.mouseLeave = false;
+    };
   }
 
   initMap() {

--- a/src/panel/app_panel.js
+++ b/src/panel/app_panel.js
@@ -38,10 +38,10 @@ export default class App {
 
     // The mouseLeave flag allows to keep the suggest open when clicking outside of the browser
     window.mouseLeave = false;
-    window.document.onmouseleave = () => {
+    window.document.documentElement.onmouseleave = () => {
       window.mouseLeave = true;
     };
-    window.document.onmouseenter = () => {
+    window.document.documentElement.onmouseenter = () => {
       window.mouseLeave = false;
     };
   }


### PR DESCRIPTION
## Description
- ensure suggest doesn't close when the mouse clicks outside of the window (not asked in the ticket but very convenient for debug and UX)
-  when the search field is focused and empty, show history prompt panel instead of the suggest if the history feature flag is enabled and is this prompt is not yet answered
- TODO (in next MRs): make buttons clickable, provide link URL, final design

## Why
*Why this PR is needed. Feature, step to something bigger, bug, etc.*

## Screenshots
![image](https://user-images.githubusercontent.com/1225909/145242721-b5c14dca-56f8-4beb-a8f3-5b55ec9c5534.png)
