### PR TITLE
QMAPS-2357, QMAPS-2358, QMAPS-2295 history in suggest

### DIFF
--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -94,7 +94,7 @@ userFeedback:
   dismissDurationDays: 30
 
 searchHistory:
-  enabled: false
+  enabled: true
 
 survey:
   surveyApiUrl: override_by_environment

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -19,7 +19,7 @@ export function setHistoryPrompt(value) {
 }
 
 export function getHistoryPrompt() {
-  return get(SEARCH_HISTORY_KEY + '_prompt');
+  return get(SEARCH_HISTORY_KEY + '_prompt'); // null by default, true if the prompt has been answered
 }
 
 export function getHistory() {

--- a/src/components/Survey.jsx
+++ b/src/components/Survey.jsx
@@ -13,7 +13,7 @@ const Survey = () => {
   const onClose = () => {
     setEnabled(false);
     closeSurvey(survey.id);
-    Telemetry.add(Telemetry.SURVEY_CLOSE, { id: survey.id });
+    Telemetry.add(Telemetry.SURVEY_CLOSE, { id: survey.id, device: isMobile ? "mobile" : "desktop" });
   };
 
   const onClick = () => {

--- a/src/components/Survey.jsx
+++ b/src/components/Survey.jsx
@@ -13,7 +13,10 @@ const Survey = () => {
   const onClose = () => {
     setEnabled(false);
     closeSurvey(survey.id);
-    Telemetry.add(Telemetry.SURVEY_CLOSE, { id: survey.id, device: isMobile ? "mobile" : "desktop" });
+    Telemetry.add(Telemetry.SURVEY_CLOSE, {
+      id: survey.id,
+      device: isMobile ? 'mobile' : 'desktop',
+    });
   };
 
   const onClick = () => {

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -122,6 +122,7 @@ const TopBar = ({ value, setUserInputValue, inputRef, onSuggestToggle, backButto
             onSelect={onSelectSuggestion}
             withFeedback
             withHistory={searchHistoryEnabled}
+            withHistoryPrompt
           >
             {({ onKeyDown, onFocus, onBlur, highlightedValue }) => (
               <input

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -193,7 +193,7 @@ const Suggest = ({
       setHighlighted(null);
       fetchItems(value);
       setIsOpen(true);
-      if(value && answer !== null) {
+      if (value && answer !== null) {
         setAfterAnswer(true);
       }
     }

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -142,7 +142,7 @@ const Suggest = ({
             <Stack>
               <Box>
                 {_(
-                  'You can change your mind at any time and <a href="/history">manage the activation of the history</a> in the menu.',
+                  'You can change your mind at any time and manage the activation of the history in the menu.',
                   'history'
                 )}
               </Box>

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -90,7 +90,14 @@ const Suggest = ({
                   'Convenient and completely private, the history will only be visible to you on this device 🙈.',
                   'history'
                 )}{' '}
-                <a href="@TODO">{_('Read more', 'history')}</a>
+                <a
+                  href="@TODO"
+                  onMouseDown={e => {
+                    e.preventDefault();
+                  }}
+                >
+                  {_('Read more', 'history')}
+                </a>
               </Box>
               <Box mt="l">
                 <Button
@@ -297,6 +304,23 @@ const Suggest = ({
                 context={encodeURIComponent(value) + document.location.hash}
                 question={_('Satisfied with the results?')}
               />
+            )}
+            {!value && items.length > 0 && !items[0].errorLabel && (
+              <div className="suggestHistoryFooter">
+                {_(
+                  'Your history is activated. It is only visible to you on this device.',
+                  'suggest'
+                )}{' '}
+                <a
+                  href="@TODO"
+                  target="_blank"
+                  onMouseDown={e => {
+                    e.preventDefault();
+                  }}
+                >
+                  {_('Learn more', 'suggest')}
+                </a>
+              </div>
             )}
           </div>,
           outputNode

--- a/src/components/ui/SuggestsDropdown.jsx
+++ b/src/components/ui/SuggestsDropdown.jsx
@@ -4,7 +4,7 @@ import { object, func, string, arrayOf } from 'prop-types';
 import SuggestItem from './SuggestItem';
 import { useI18n } from 'src/hooks';
 
-const SuggestsDropdown = ({ className = '', suggestItems, onSelect, highlighted, value }) => {
+const SuggestsDropdown = ({ className = '', suggestItems, onSelect, highlighted }) => {
   const { _ } = useI18n();
 
   // Focused and empty field, unanswered prompt, history feature enabled: show history prompt

--- a/src/components/ui/SuggestsDropdown.jsx
+++ b/src/components/ui/SuggestsDropdown.jsx
@@ -1,80 +1,14 @@
-import { React, useState } from 'react';
+import React from 'react';
 import classnames from 'classnames';
 import { object, func, string, arrayOf } from 'prop-types';
 import SuggestItem from './SuggestItem';
-import { useConfig, useI18n } from 'src/hooks';
-import { Stack, Box, Button, Heading } from '@qwant/qwant-ponents';
-import { getHistoryPrompt } from 'src/adapters/search_history';
+import { useI18n } from 'src/hooks';
 
 const SuggestsDropdown = ({ className = '', suggestItems, onSelect, highlighted, value }) => {
   const { _ } = useI18n();
-  const searchHistoryConfig = useConfig('searchHistory');
-  const [answer, setAnswer] = useState(null);
-
-  const historyPrompt = () => {
-    if (answer === null) {
-      return (
-        <Box m="l">
-          <Heading as="h6">{_('History is available on Qwant Maps', 'history')}</Heading>
-          <Stack>
-            <Box>
-              {_(
-                'Convenient and completely private, the history will only be visible to you on this device 🙈.',
-                'history'
-              )}{' '}
-              <a href="">{_('Read more', 'history')}</a>
-            </Box>
-            <Box mt="l">
-              <Button variant="secondary" onClick={() => setAnswer(false)}>
-                {_('No thanks', 'history')}
-              </Button>
-              <Button ml="l" onClick={() => setAnswer(true)}>
-                {_('Enable history', 'history')}
-              </Button>
-            </Box>
-          </Stack>
-        </Box>
-      );
-    }
-
-    if (answer === true) {
-      return (
-        <Box m="l">
-          <Heading as="h6">{_('Well done, the history is activated!', 'history')}</Heading>
-          <Stack>
-            <Box>
-              {_(
-                'You can find and manage your complete history at any time in the menu',
-                'history'
-              )}
-            </Box>
-          </Stack>
-        </Box>
-      );
-    }
-
-    if (answer === false) {
-      return (
-        <Box m="l">
-          <Heading as="h6">{_('No worries, history is disabled', 'history')}</Heading>
-          <Stack>
-            <Box>
-              {_(
-                'You can change your mind at any time and manage the activation of the history in the menu.',
-                'history'
-              )}
-            </Box>
-          </Stack>
-        </Box>
-      );
-    }
-  };
 
   // Focused and empty field, unanswered prompt, history feature enabled: show history prompt
-  return searchHistoryConfig?.enabled && value === '' && getHistoryPrompt() === null ? (
-    historyPrompt()
-  ) : (
-    // Focused field and (answered prompt or history feature disabled): show suggest
+  return (
     <ul className={classnames('autocomplete_suggestions', className)}>
       {suggestItems.map((suggestItem, index) => (
         <li

--- a/src/components/ui/SuggestsDropdown.jsx
+++ b/src/components/ui/SuggestsDropdown.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { React, useState } from 'react';
 import classnames from 'classnames';
 import { object, func, string, arrayOf } from 'prop-types';
 import SuggestItem from './SuggestItem';
@@ -9,25 +9,70 @@ import { getHistoryPrompt } from 'src/adapters/search_history';
 const SuggestsDropdown = ({ className = '', suggestItems, onSelect, highlighted, value }) => {
   const { _ } = useI18n();
   const searchHistoryConfig = useConfig('searchHistory');
+  const [answer, setAnswer] = useState(null);
+
+  const historyPrompt = () => {
+    if (answer === null) {
+      return (
+        <Box m="l">
+          <Heading as="h6">{_('History is available on Qwant Maps', 'history')}</Heading>
+          <Stack>
+            <Box>
+              {_(
+                'Convenient and completely private, the history will only be visible to you on this device 🙈.',
+                'history'
+              )}{' '}
+              <a href="">{_('Read more', 'history')}</a>
+            </Box>
+            <Box mt="l">
+              <Button variant="secondary" onClick={() => setAnswer(false)}>
+                {_('No thanks', 'history')}
+              </Button>
+              <Button ml="l" onClick={() => setAnswer(true)}>
+                {_('Enable history', 'history')}
+              </Button>
+            </Box>
+          </Stack>
+        </Box>
+      );
+    }
+
+    if (answer === true) {
+      return (
+        <Box m="l">
+          <Heading as="h6">{_('Well done, the history is activated!', 'history')}</Heading>
+          <Stack>
+            <Box>
+              {_(
+                'You can find and manage your complete history at any time in the menu',
+                'history'
+              )}
+            </Box>
+          </Stack>
+        </Box>
+      );
+    }
+
+    if (answer === false) {
+      return (
+        <Box m="l">
+          <Heading as="h6">{_('No worries, history is disabled', 'history')}</Heading>
+          <Stack>
+            <Box>
+              {_(
+                'You can change your mind at any time and manage the activation of the history in the menu.',
+                'history'
+              )}
+            </Box>
+          </Stack>
+        </Box>
+      );
+    }
+  };
 
   // Focused and empty field, unanswered prompt, history feature enabled: show history prompt
   return searchHistoryConfig?.enabled && value === '' && getHistoryPrompt() === null ? (
-    <Box m="l">
-      <Heading as="h6">{_('History is available on Qwant Maps', 'history')}</Heading>
-      <Stack>
-        <Box>
-          {_(
-            'Convenient and completely private, the history will only be visible to you on this device 🙈.',
-            'history'
-          )}{' '}
-          <a href="">{_('Read more', 'history')}</a>
-        </Box>
-        <Box mt="l">
-          <Button variant="secondary">{_('No thanks', 'history')}</Button>
-          <Button ml="l">{_('Enable history', 'history')}</Button>
-        </Box>
-      </Stack>
-    </Box>
+    historyPrompt()
   ) : (
     // Focused field and (answered prompt or history feature disabled): show suggest
     <ul className={classnames('autocomplete_suggestions', className)}>

--- a/src/panel/menu/MenuItem.jsx
+++ b/src/panel/menu/MenuItem.jsx
@@ -14,7 +14,7 @@ const MenuItem = ({ icon, children, href, onClick, outsideLink }) => (
         }
       : {})}
   >
-    <Flex alignItems="flex-start">
+    <Flex>
       {icon && <div className="u-mr-s">{icon}</div>}
       <div className="u-mr-s" style={{ flexGrow: 1 }}>
         {children}

--- a/src/scss/includes/suggest.scss
+++ b/src/scss/includes/suggest.scss
@@ -67,3 +67,7 @@
     margin-right: 30px;
   }
 }
+
+.suggestHistoryFooter {
+  padding: 15px;
+}


### PR DESCRIPTION
## Description

if the history feature flag is enabled:

- show history prompt in suggest, on focus, under the topBar field, if it hasn't been answered yet and if the field is empty (hide the favorites in that case)
- keep it visible until yes or no has been clicked, because otherwise everything disappears before the click is registered properly. 
- show the accept / refuse messages and enable / don't enable the history after clicking the yes / no buttons
- don't show the message again after filling and emptying the field or after navigating the app and focusing the field again
- show a message in the suggest footer if the field is focused and empty and if history items are present.
- include mobile/pc info in telemetry
- TODO: design
- TODO: final links (for history page and help center)


## Screenshots
![image](https://user-images.githubusercontent.com/1225909/146223540-51094ea1-866f-4fa0-b6f2-316f4a2b5897.png)
![image](https://user-images.githubusercontent.com/1225909/146224190-39ab6a97-146f-4314-a06c-4c24313b4b52.png)
![image](https://user-images.githubusercontent.com/1225909/146224231-19c8e4ce-55c1-4f7e-a5d3-497f3da527c1.png)
![image](https://user-images.githubusercontent.com/1225909/147654384-09969de6-3515-4e3f-b2e2-eb347c8edb03.png)

