### PR TITLE
QMAPS-2440 fix history

### DIFF
--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -163,7 +163,7 @@ const Suggest = ({
                 className="historyParagraph"
                 dangerouslySetInnerHTML={{
                   __html: _(
-                    'You can find and <a href="history" target="_self">manage your complete history</a> at any time in the menu.',
+                    'You can find and <a href="history" target="_self">manage your complete history</a> at any time in the menu',
                     'history'
                   ),
                 }}
@@ -187,7 +187,7 @@ const Suggest = ({
                 className="historyParagraph"
                 dangerouslySetInnerHTML={{
                   __html: _(
-                    'You can change your mind at any time and <a href="history" target="_self">manage</a> the activation of the history in the menu.',
+                    'You can change your mind at any time and <a href="history" target="_self">manage</a> the activation of the history in the menu',
                     'history'
                   ),
                 }}

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -163,7 +163,7 @@ const Suggest = ({
                 className="historyParagraph"
                 dangerouslySetInnerHTML={{
                   __html: _(
-                    'You can find and <a href="/history" target="_self">manage your complete history</a> at any time in the menu.',
+                    'You can find and <a href="history" target="_self">manage your complete history</a> at any time in the menu.',
                     'history'
                   ),
                 }}
@@ -187,7 +187,7 @@ const Suggest = ({
                 className="historyParagraph"
                 dangerouslySetInnerHTML={{
                   __html: _(
-                    'You can change your mind at any time and <a href="/history" target="_self">manage</a> the activation of the history in the menu.',
+                    'You can change your mind at any time and <a href="history" target="_self">manage</a> the activation of the history in the menu.',
                     'history'
                   ),
                 }}

--- a/src/modals/HistoryModal.jsx
+++ b/src/modals/HistoryModal.jsx
@@ -8,14 +8,14 @@ import { useI18n } from 'src/hooks';
 import { Button, Box, Flex, IconEmpty, Heading } from '@qwant/qwant-ponents';
 import { deleteSearchHistory } from 'src/adapters/search_history';
 import { GREY_DARK } from '../libs/colors';
-import { IconHistory } from '../components/ui/icons';
+import { IconHistoryDisabled } from '../components/ui/icons';
 
 const HistoryModal = ({ status, onClose, onAccept }) => {
   const { _ } = useI18n();
 
   const statuses = {
     DISABLE: {
-      icon: <IconHistory width={20} fill={GREY_DARK} className="historyModalIcon" />,
+      icon: <IconHistoryDisabled width={20} fill={GREY_DARK} className="historyModalIcon" />,
       title: _('Disable Qwant Maps history', 'history'),
       text: _('With this action, all your search history will be lost.', 'history'),
       button1: _('Cancel', 'history'),
@@ -47,11 +47,11 @@ const HistoryModal = ({ status, onClose, onAccept }) => {
               className="modal__subtitle u-text--subtitle"
               dangerouslySetInnerHTML={{ __html: text }}
             />
-            <Flex mb="xl">
-              <Button full variant="secondary" onClick={onClose} m="xxs">
+            <Flex mb="xl" className="history_modal_buttons">
+              <Button variant="secondary" onClick={onClose} m="xxs">
                 {button1}
               </Button>
-              <Button full variant="primary" onClick={onAccept} m="xxs">
+              <Button variant="primary" onClick={onAccept} m="xxs">
                 {button2}
               </Button>
             </Flex>

--- a/src/panel/history/HistoryPanel.jsx
+++ b/src/panel/history/HistoryPanel.jsx
@@ -16,6 +16,7 @@ import { listen, unListen } from 'src/libs/customEvents';
 import { openDisableHistoryModal, openClearHistoryModal } from 'src/modals/HistoryModal';
 import { GREY_SEMI_DARKNESS, PURPLE } from '../../libs/colors';
 import { IconHistory } from '../../components/ui/icons';
+import classnames from 'classnames';
 
 const HistoryPanel = () => {
   const [isChecked, setIsChecked] = useState(getHistoryEnabled());
@@ -213,7 +214,11 @@ const HistoryPanel = () => {
       }
       minimizedTitle={_('Show history', 'history panel')}
       onClose={close}
-      className="history_panel"
+      className={classnames(
+        'history_panel',
+        historyLength() === 0 && 'history_panel_empty',
+        isChecked === false && 'history_panel_disabled'
+      )}
     >
       <Flex mt="xs">
         <Text typo="body-2">
@@ -301,7 +306,7 @@ const HistoryPanel = () => {
             </Box>
           )}
           {historyLength() === 0 && (
-            <Box className="history_panel_empty">
+            <Box className="history_panel_empty_message">
               <IconHistory width={20} fill={PURPLE} className="historyIcon" />
               <Text typo="body-2">
                 {_('As soon as you do a search, you can find it here 👇', 'history panel')}

--- a/src/panel/history/HistoryPanel.jsx
+++ b/src/panel/history/HistoryPanel.jsx
@@ -221,7 +221,7 @@ const HistoryPanel = () => {
       )}
     >
       <Flex mt="xs">
-        <Text typo="body-2">
+        <Text typo="body-2" className="history_panel_switch_label">
           {isChecked
             ? _(
                 'Your history is enabled. It is only visible to you on this device.',

--- a/src/panel/history/HistoryPanel.jsx
+++ b/src/panel/history/HistoryPanel.jsx
@@ -161,7 +161,12 @@ const HistoryPanel = () => {
           </Box>
         </Flex>
         <Text color="primary" onClick={() => remove(item)}>
-          <IconEmpty width={20} fill={GREY_SEMI_DARKNESS} className="history_panel_trash" />
+          <IconEmpty
+            width={20}
+            fill={GREY_SEMI_DARKNESS}
+            className="history_panel_trash"
+            title={_('Delete', 'history')}
+          />
         </Text>
       </Flex>
     ) : (
@@ -198,7 +203,12 @@ const HistoryPanel = () => {
           </Box>
         </Flex>
         <Box color="primary" onClick={() => remove(item)}>
-          <IconEmpty width={20} fill={GREY_SEMI_DARKNESS} className="history_panel_trash" />
+          <IconEmpty
+            width={20}
+            fill={GREY_SEMI_DARKNESS}
+            className="history_panel_trash"
+            title={_('Delete', 'history')}
+          />
         </Box>
       </Flex>
     );
@@ -240,6 +250,7 @@ const HistoryPanel = () => {
             id="history_enabled"
             checked={isChecked}
             onChange={onChange}
+            title={isChecked ? _('Disable', 'history') : _('enable', 'history')}
           />
         </Box>
       </Flex>

--- a/src/scss/includes/modals/index.scss
+++ b/src/scss/includes/modals/index.scss
@@ -35,10 +35,6 @@
   padding: 0 $spacing-l;
 }
 
-.modal__maps__icon {
-  text-align: center;
-}
-
 .modal--active {
   display: flex;
 }

--- a/src/scss/includes/panels/history_panel.scss
+++ b/src/scss/includes/panels/history_panel.scss
@@ -12,7 +12,7 @@
   }
 
   .panel-header {
-    padding: 20px 14px 0;
+    padding: 20px 14px 4px;
   }
 
   .panel-content {
@@ -75,6 +75,11 @@
 
 .history-list-title {
   margin-bottom: 22px;
+}
+
+.history_panel_switch_label {
+  width: calc(100% - 30px);
+  padding: 0 8px 0 0;
 }
 
 .history_panel_switch {

--- a/src/scss/includes/panels/history_panel.scss
+++ b/src/scss/includes/panels/history_panel.scss
@@ -70,6 +70,10 @@
   margin-top: 9px;
   width: 20px;
   height: 20px;
+
+  &:hover {
+    fill: #0C0C0E;
+  }
 }
 
 .history-list-title {

--- a/src/scss/includes/panels/history_panel.scss
+++ b/src/scss/includes/panels/history_panel.scss
@@ -5,11 +5,18 @@
 }
 
 .history_panel {
-  padding: 20px 14px;
   position: relative;
 
   &.history_panel_empty {
     min-height: auto;
+  }
+
+  .panel-header {
+    padding: 20px 14px 0;
+  }
+
+  .panel-content {
+    padding: 0 14px 20px;
   }
 
   .closeButton {
@@ -29,10 +36,8 @@
   hr {
     border: none;
     border-bottom: 1px solid var(--grey-light);
-    width: 100%;
-    position: absolute;
-    left: 0;
-    margin-top: -14px;
+    width: calc(100% + 28px);
+    margin-left: -14px;
   }
 }
 

--- a/src/scss/includes/panels/history_panel.scss
+++ b/src/scss/includes/panels/history_panel.scss
@@ -32,12 +32,11 @@
 }
 
 .history-list {
-
   hr {
     border: none;
     border-bottom: 1px solid var(--grey-light);
     width: calc(100% + 28px);
-    margin-left: -14px;
+    margin: -14px 0 4px -14px;
   }
 }
 
@@ -95,4 +94,16 @@
   background: var(--grey-lighter);
   border-radius: 50%;
   margin-bottom: 4px;
+}
+
+.history_modal_buttons {
+  justify-content: center;
+}
+
+.modal__history__delete, .modal__history__disable {
+  text-align: center;
+
+  .closeButton {
+    margin: 8px;
+  }
 }

--- a/src/scss/includes/panels/history_panel.scss
+++ b/src/scss/includes/panels/history_panel.scss
@@ -8,6 +8,10 @@
   padding: 20px 14px;
   position: relative;
 
+  &.history_panel_empty {
+    min-height: auto;
+  }
+
   .closeButton {
     top: 10px;
   }
@@ -48,9 +52,9 @@
   width: 400px;
 }
 
-.history_panel_empty {
+.history_panel_empty_message {
   width: 210px;
-  margin: 96px auto 0;
+  margin: 8px auto 32px;
   text-align: center;
 
   .historyIcon {

--- a/src/scss/includes/suggest.scss
+++ b/src/scss/includes/suggest.scss
@@ -122,6 +122,10 @@
       margin: 16px 0 0;
       padding: 20px 14px;
       background: #fff;
+
+      div svg {
+        vertical-align: text-top;
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

- [x]  Corriger les liens "manage" dans le suggest (sur l'instance de dev il manque "/maps" dans l'url)
- [x]  Dans le suggest, après avoir cliqué sur oui ou non, bien aligner l'icone menu au texte et enlever le "." avant l'icone
- [x]  Quand le panel my history est vide et désactivé, lui mettre une height auto.
- [x]  Quand il est vide et activé: height auto +margin "32px auto" sur le message au centre (your history will appear here)
- [x]  Quand il est activé et rempli: full height, et coller la scrollbar à droite lorsqu'il y a besoin de scroller.
- [x]  Coller le switch du panel my history a droite sur mobile si l'écran mesure plus de 450px de large
- [x]  Utiliser la bonne icone dans la modale "désactiver l'historique" (celle en pointillés)
- [x]  Panel my history plié sur mobile: trop de marge en haut, "show history" est caché. Faire comme Favoris.
- [x]  Tooltips: "Effacer" sur la poubelle + l'icône passe en noir au hover (https://zpl.io/aM3r5RJ), "Activer" ou "Désactiver" sur le switch
- [x]  Width auto + centrage sur les boutons des modales history (qui apparaissent quand on désactive / efface l'historique)
- [x] Modales: centrer le texte et décoller la croix en haut à droite

## Testing
@remi-dupre @fatal69100 quand vous testerez ce ticket, voici des commandes utiles à entrer dans votre console JS:

- Vider l'historique (afin de revoir le prompt lors du focus du champ de recherche par exemple)
```localStorage.clear()```

- Remplir l'historique avec des items de différentes dates (après avoir activé l'historique)
```
localStorage.qmaps_v1_search_history_v1 = `[{"type":"poi","date":1643021091713,"item":{"id":"admin:osm:relation:170100","name":"Nice (06000-06300)","type":"zone","latLon":{"lat":43.7009358,"lng":7.2683912},"className":"","subClassName":"","bbox":[7.1819535,43.6454189,7.323912,43.7607635],"value":"Nice (06000-06300), Alpes-Maritimes, France","queryContext":{"term":"Nice","ranking":1,"lang":"fr","position":{"lat":"43.700","lon":"7.300","zoom":"11.000"}},"address":{"stateDistrict":"Alpes-Maritimes","country":"France"}}},{"type":"poi","date":1632581629687,"item":{"id":"admin:osm:relation:6581513","name":"Hôtel de Ville (13002)","type":"zone","latLon":{"lat":43.2972752,"lng":5.3672223},"className":"","subClassName":"","bbox":[5.3604597,43.2941413,5.3743739999999995,43.2994358],"value":"Hôtel de Ville (13002), 2e Arrondissement, Marseille, Bouches-du-Rhône, Provence-Alpes-Côte d'Azur, France","queryContext":{"term":"hotel","ranking":1,"lang":"fr","position":{"lat":"43.700","lon":"7.300","zoom":"17.000"}},"address":{"cityDistrict":"2e Arrondissement","city":"Marseille","stateDistrict":"Bouches-du-Rhône","state":"Provence-Alpes-Côte d'Azur","country":"France"}}},{"type":"poi","date":1641581639418,"item":{"id":"osm:way:5013364","name":"Tour Eiffel","type":"poi","latLon":{"lat":48.858260156496016,"lng":2.2944990157640612},"className":"attraction","subClassName":"attraction","value":"Tour Eiffel (Paris)","queryContext":{"term":"tour eiffel","ranking":1,"lang":"fr","position":{"lat":"43.300","lon":"5.400","zoom":"15.000"}},"address":{"street":"5 Avenue Anatole France","suburb":"Quartier du Gros-Caillou","cityDistrict":"Paris 7e Arrondissement","city":"Paris","stateDistrict":"Paris","state":"Île-de-France","country":"France","label":"5 Avenue Anatole France (Paris)"}}}]`
```