### PR TITLE
Qmaps 2414 no refresh

### DIFF
--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -168,7 +168,7 @@ const Suggest = ({
                 className="historyParagraph"
                 dangerouslySetInnerHTML={{
                   __html: _(
-                    'You can find and <a href="/history" target="_self">manage your complete history</a> at any time in the menu.',
+                    'You can find and <a href="history" target="_self">manage your complete history</a> at any time in the menu.',
                     'history'
                   ),
                 }}
@@ -192,7 +192,7 @@ const Suggest = ({
                 className="historyParagraph"
                 dangerouslySetInnerHTML={{
                   __html: _(
-                    'You can change your mind at any time and <a href="/history" target="_self">manage</a> the activation of the history in the menu.',
+                    'You can change your mind at any time and <a href="history" target="_self">manage</a> the activation of the history in the menu.',
                     'history'
                   ),
                 }}

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -163,7 +163,7 @@ const Suggest = ({
                 className="historyParagraph"
                 dangerouslySetInnerHTML={{
                   __html: _(
-                    'You can find and <a href="history" target="_self">manage your complete history</a> at any time in the menu',
+                    'You can find and <a href="/history" target="_self">manage your complete history</a> at any time in the menu.',
                     'history'
                   ),
                 }}
@@ -187,7 +187,7 @@ const Suggest = ({
                 className="historyParagraph"
                 dangerouslySetInnerHTML={{
                   __html: _(
-                    'You can change your mind at any time and <a href="history" target="_self">manage</a> the activation of the history in the menu',
+                    'You can change your mind at any time and <a href="/history" target="_self">manage</a> the activation of the history in the menu.',
                     'history'
                   ),
                 }}

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -168,7 +168,7 @@ const Suggest = ({
                 className="historyParagraph"
                 dangerouslySetInnerHTML={{
                   __html: _(
-                    'You can find and <a href="history" target="_self">manage your complete history</a> at any time in the menu.',
+                    'You can find and <a href="history" target="_self">manage your complete history</a> at any time in the menu',
                     'history'
                   ),
                 }}
@@ -192,7 +192,7 @@ const Suggest = ({
                 className="historyParagraph"
                 dangerouslySetInnerHTML={{
                   __html: _(
-                    'You can change your mind at any time and <a href="history" target="_self">manage</a> the activation of the history in the menu.',
+                    'You can change your mind at any time and <a href="history" target="_self">manage</a> the activation of the history in the menu',
                     'history'
                   ),
                 }}

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -6,7 +6,12 @@ import { useConfig, useDevice, useI18n } from 'src/hooks';
 import SuggestsDropdown from 'src/components/ui/SuggestsDropdown';
 import { fetchSuggests, getInputValue, modifyList } from 'src/libs/suggest';
 import { UserFeedbackYesNo } from './index';
-import { getHistoryPrompt, setHistoryPrompt, setHistoryEnabled } from 'src/adapters/search_history';
+import {
+  getHistoryPrompt,
+  setHistoryPrompt,
+  setHistoryEnabled,
+  getHistoryEnabled,
+} from 'src/adapters/search_history';
 import { Box, Button, Stack, Text } from '@qwant/qwant-ponents';
 import { PURPLE } from '../../libs/colors';
 import { IconHistory, IconHistoryDisabled, IconMenu } from './icons';
@@ -212,6 +217,9 @@ const Suggest = ({
       if (currentQuery) {
         currentQuery.abort();
       }
+
+      // Check if history has been enabled in the current session before fetching suggest items
+      withHistory = getHistoryEnabled();
 
       const query = fetchSuggests(value, {
         withCategories,


### PR DESCRIPTION
## Description
- Activer l'historique depuis le suggest
- Faire une recherche (ex: "Nice" + touche "Entrée")
- Vider le champ
- Focus le champ
- Il faut que la recherche qu'on vient de faire apparaisse dans le suggest en violet

![image](https://user-images.githubusercontent.com/1225909/151010626-9c63ff02-9fa7-4d62-9aca-b8c4f451b9e6.png)