### PR TITLE
QMAPS-2325 add history logs

### DIFF
--- a/local_modules/telemetry/index.js
+++ b/local_modules/telemetry/index.js
@@ -80,5 +80,13 @@ module.exports = {
     'survey_display',
     'survey_close',
     'survey_answer',
+    /* History */
+    'history_enabled_from_suggest',
+    'history_disabled_from_suggest',
+    'history_enabled_from_panel',
+    'history_disabled_from_panel',
+    'history_cleared_from_panel',
+    'history_item_clicked_suggest',
+    'history_item_clicked_panel',
   ],
 };

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -15,6 +15,7 @@ import {
 import { Box, Button, Stack, Text } from '@qwant/qwant-ponents';
 import { PURPLE } from '../../libs/colors';
 import { IconHistory, IconHistoryDisabled, IconMenu } from './icons';
+import Telemetry from 'src/libs/telemetry';
 
 const SUGGEST_DEBOUNCE_WAIT = 100;
 
@@ -121,6 +122,7 @@ const Suggest = ({
               <Button
                 variant="secondary"
                 onClick={() => {
+                  Telemetry.add(Telemetry.HISTORY_DISABLED_FROM_SUGGEST);
                   setHistoryPrompt(true);
                   setHistoryAnswer(false);
                   document.querySelector('#search').focus();
@@ -133,6 +135,7 @@ const Suggest = ({
               <Button
                 ml="xs"
                 onClick={() => {
+                  Telemetry.add(Telemetry.HISTORY_ENABLED_FROM_SUGGEST);
                   setHistoryPrompt(true);
                   setHistoryAnswer(true);
                   document.querySelector('#search').focus();
@@ -260,6 +263,9 @@ const Suggest = ({
   }, [hasFocus, fetchItems, value]);
 
   const selectItem = item => {
+    if (item._suggestSource === 'history') {
+      Telemetry.add(Telemetry.HISTORY_ITEM_CLICKED_SUGGEST);
+    }
     onSelect(item, { query: value });
     setHighlighted(null);
   };

--- a/src/modals/HistoryModal.jsx
+++ b/src/modals/HistoryModal.jsx
@@ -9,6 +9,7 @@ import { Button, Box, Flex, IconEmpty, Heading } from '@qwant/qwant-ponents';
 import { deleteSearchHistory } from 'src/adapters/search_history';
 import { GREY_DARK } from '../libs/colors';
 import { IconHistoryDisabled } from '../components/ui/icons';
+import Telemetry from 'src/libs/telemetry';
 
 const HistoryModal = ({ status, onClose, onAccept }) => {
   const { _ } = useI18n();
@@ -21,6 +22,7 @@ const HistoryModal = ({ status, onClose, onAccept }) => {
       button1: _('Cancel', 'history'),
       button2: _('Disable my history', 'history'),
       className: 'modal__history__disable',
+      telemetry: Telemetry.HISTORY_DISABLED_FROM_PANEL,
     },
     CLEAR: {
       icon: <IconEmpty width={20} fill={GREY_DARK} className="historyModalIcon" />,
@@ -29,10 +31,11 @@ const HistoryModal = ({ status, onClose, onAccept }) => {
       button1: _('Cancel', 'history'),
       button2: _('Clear my history', 'history'),
       className: 'modal__history__delete',
+      telemetry: Telemetry.HISTORY_CLEARED_FROM_PANEL,
     },
   };
 
-  const { icon, title, text, button1, button2, className } = statuses[status];
+  const { icon, title, text, button1, button2, className, telemetry } = statuses[status];
   return (
     <div className="modal__maps__history">
       <Modal onClose={onClose}>
@@ -51,7 +54,14 @@ const HistoryModal = ({ status, onClose, onAccept }) => {
               <Button variant="secondary" onClick={onClose} m="xxs">
                 {button1}
               </Button>
-              <Button variant="primary" onClick={onAccept} m="xxs">
+              <Button
+                variant="primary"
+                m="xxs"
+                onClick={() => {
+                  Telemetry.add(telemetry);
+                  onAccept();
+                }}
+              >
                 {button2}
               </Button>
             </Flex>

--- a/src/panel/history/HistoryPanel.jsx
+++ b/src/panel/history/HistoryPanel.jsx
@@ -17,6 +17,7 @@ import { openDisableHistoryModal, openClearHistoryModal } from 'src/modals/Histo
 import { GREY_SEMI_DARKNESS, PURPLE } from '../../libs/colors';
 import { IconHistory } from '../../components/ui/icons';
 import classnames from 'classnames';
+import Telemetry from '../../libs/telemetry';
 
 const HistoryPanel = () => {
   const [isChecked, setIsChecked] = useState(getHistoryEnabled());
@@ -76,6 +77,7 @@ const HistoryPanel = () => {
     if (e.target.checked === false) {
       openDisableHistoryModal();
     } else {
+      Telemetry.add(Telemetry.HISTORY_ENABLED_FROM_PANEL);
       setIsChecked(true);
       setHistoryEnabled(true);
     }
@@ -132,6 +134,7 @@ const HistoryPanel = () => {
       <Flex key={item.item.id} className="history-list-item">
         <Box
           onClick={() => {
+            Telemetry.add(Telemetry.HISTORY_ITEM_CLICKED_PANEL);
             visit(item);
           }}
         >
@@ -141,6 +144,7 @@ const HistoryPanel = () => {
           takeAvailableSpace
           column
           onClick={() => {
+            Telemetry.add(Telemetry.HISTORY_ITEM_CLICKED_PANEL);
             visit(item);
           }}
         >
@@ -174,6 +178,7 @@ const HistoryPanel = () => {
       <Flex key={item.item.category?.id || item.item.fullTextQuery} className="history-list-item">
         <Box
           onClick={() => {
+            Telemetry.add(Telemetry.HISTORY_ITEM_CLICKED_PANEL);
             visit(item);
           }}
         >
@@ -187,6 +192,7 @@ const HistoryPanel = () => {
           takeAvailableSpace
           column
           onClick={() => {
+            Telemetry.add(Telemetry.HISTORY_ITEM_CLICKED_PANEL);
             visit(item);
           }}
         >


### PR DESCRIPTION
## Description
Add 7 logs related to History

(the logs requests are visible in the network panel of the browser, named "events")

![image](https://user-images.githubusercontent.com/1225909/151818944-cb65cb6a-df93-4b78-b9bb-c93a0dd819a0.png)
