### PR TITLE
QMAPS-2444 history prompt update

### DIFF
--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -57,7 +57,6 @@ const Suggest = ({
   hide,
 }) => {
   const searchHistoryConfig = useConfig('searchHistory');
-
   const [items, setItems] = useState([]);
   const [isOpen, setIsOpen] = useState(false);
   const [highlighted, setHighlighted] = useState(null);
@@ -247,6 +246,9 @@ const Suggest = ({
   useEffect(() => {
     if (!hasFocus) {
       close();
+      if (historyAnswer !== null) {
+        setkeepHistoryPromptVisible(false);
+      }
     } else {
       setHighlighted(null);
       fetchItems(value);

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -13,9 +13,10 @@ import {
   getHistoryEnabled,
 } from 'src/adapters/search_history';
 import { Box, Button, Stack, Text } from '@qwant/qwant-ponents';
-import { PURPLE } from '../../libs/colors';
+import { PURPLE } from 'src/libs/colors';
 import { IconHistory, IconHistoryDisabled, IconMenu } from './icons';
 import Telemetry from 'src/libs/telemetry';
+import { listen, unListen } from 'src/libs/customEvents';
 
 const SUGGEST_DEBOUNCE_WAIT = 100;
 
@@ -212,6 +213,15 @@ const Suggest = ({
       onToggle(dropdownVisible);
     }
   }, [dropdownVisible, onToggle]);
+
+  useEffect(() => {
+    const disableHistoryHandler = listen('hide_history_prompt', () => {
+      setkeepHistoryPromptVisible(false);
+    });
+    return () => {
+      unListen(disableHistoryHandler);
+    };
+  }, []);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const fetchItems = useCallback(

--- a/src/panel/favorites/FavoritesPanel.jsx
+++ b/src/panel/favorites/FavoritesPanel.jsx
@@ -4,6 +4,7 @@ import Telemetry from 'src/libs/telemetry';
 import Panel from 'src/components/ui/Panel';
 import FavoriteItems from './FavoriteItems';
 import { useFavorites, usePageTitle } from 'src/hooks';
+import { fire } from 'src/libs/customEvents';
 
 const FavoritesPanel = () => {
   const { favorites, removeFromFavorites } = useFavorites();
@@ -12,6 +13,7 @@ const FavoritesPanel = () => {
 
   useEffect(() => {
     Telemetry.add(Telemetry.FAVORITE_OPEN);
+    fire('hide_history_prompt');
   }, []);
 
   const removeFav = poi => {

--- a/src/panel/history/HistoryPanel.jsx
+++ b/src/panel/history/HistoryPanel.jsx
@@ -12,7 +12,7 @@ import {
 } from 'src/adapters/search_history';
 import PlaceIcon from 'src/components/PlaceIcon';
 import { capitalizeFirst } from 'src/libs/string';
-import { listen, unListen } from 'src/libs/customEvents';
+import { fire, listen, unListen } from 'src/libs/customEvents';
 import { openDisableHistoryModal, openClearHistoryModal } from 'src/modals/HistoryModal';
 import { GREY_SEMI_DARKNESS, PURPLE } from 'src/libs/colors';
 import { IconHistory } from 'src/components/ui/icons';
@@ -66,6 +66,10 @@ const HistoryPanel = () => {
     return () => {
       unListen(clearHistoryHandler);
     };
+  }, []);
+
+  useEffect(() => {
+    fire('hide_history_prompt');
   }, []);
 
   const close = () => {


### PR DESCRIPTION
## Description
- [x] make history prompt disappear on unfocus after an answer has been given
- [x] prevent it from reappearing again if an answer has been given
- [x] make the prompt disappear when History or Favorite panel is opened, if no answer has been given yet