### PR TITLE
Qmaps 2394 dedup intentions

### DIFF
--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -56,7 +56,7 @@ export function saveQuery(item) {
 export function deleteQuery(item) {
   const searchHistory = getHistory();
   let index;
-  for (index = searchHistory.length - 1; index > 0; index--) {
+  for (index = searchHistory.length - 1; index >= 0; index--) {
     if (itemEquals(searchHistory[index], item)) {
       searchHistory.splice(index, 1);
     }

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -54,7 +54,6 @@ export function saveQuery(item) {
 }
 
 export function deleteQuery(item) {
-  console.log('delete', item, getHistory());
   const searchHistory = getHistory();
   const index = searchHistory.findIndex(stored => itemEquals(stored, item));
   if (index === -1) {
@@ -71,9 +70,7 @@ export function deleteSearchHistory() {
 
 const itemEquals = ({ type, item }, other) => {
   if (type === 'intention') {
-    console.log("equals", item, other);
     return (
-      item.fullTextQuery === other.fullTextQuery &&
       item.category?.name === other.category?.name &&
       item.place?.properties?.geocoding?.name === other.place?.properties?.geocoding?.name
     );

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -54,6 +54,7 @@ export function saveQuery(item) {
 }
 
 export function deleteQuery(item) {
+  console.log('delete', item, getHistory());
   const searchHistory = getHistory();
   const index = searchHistory.findIndex(stored => itemEquals(stored, item));
   if (index === -1) {

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -55,11 +55,12 @@ export function saveQuery(item) {
 
 export function deleteQuery(item) {
   const searchHistory = getHistory();
-  const index = searchHistory.findIndex(stored => itemEquals(stored, item));
-  if (index === -1) {
-    return;
+  let index;
+  for (index in searchHistory) {
+    if (itemEquals(searchHistory[index], item)) {
+      searchHistory.splice(index, 1);
+    }
   }
-  searchHistory.splice(index, 1);
   // Serialize the list and save it in localStorage
   setHistory(searchHistory);
 }

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -56,7 +56,7 @@ export function saveQuery(item) {
 export function deleteQuery(item) {
   const searchHistory = getHistory();
   let index;
-  for (index in searchHistory) {
+  for (index = searchHistory.length - 1; index > 0; index--) {
     if (itemEquals(searchHistory[index], item)) {
       searchHistory.splice(index, 1);
     }

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -71,6 +71,7 @@ export function deleteSearchHistory() {
 
 const itemEquals = ({ type, item }, other) => {
   if (type === 'intention') {
+    console.log("equals", item, other);
     return (
       item.fullTextQuery === other.fullTextQuery &&
       item.category?.name === other.category?.name &&

--- a/src/panel/history/HistoryPanel.jsx
+++ b/src/panel/history/HistoryPanel.jsx
@@ -179,7 +179,10 @@ const HistoryPanel = () => {
       </Flex>
     ) : (
       // intention
-      <Flex key={item.item.category?.id || item.item.fullTextQuery} className="history-list-item">
+      <Flex
+        key={item.item.category?.name + '_' + item.item.place?.properties?.geocoding?.name}
+        className="history-list-item"
+      >
         <Box
           onClick={() => {
             Telemetry.add(Telemetry.HISTORY_ITEM_CLICKED_PANEL);


### PR DESCRIPTION
## Description
Searches containing:
- Known category + place  (ex: "hotel nice")
- Known category "around this position" (ex: "hotel")
- Unknown category + place (ex: "macdo nice")
Must be present only once in the history panel, even if the search is performed many times

![image](https://user-images.githubusercontent.com/1225909/153162897-6a2e1c32-b627-4250-9d44-0647e5e2c123.png)



NB: This PR also fixes a React key duplication error in the History Panel. 
NB2: until now, the dedup test was looking for the "fullTextQuery" item, but this item has been removed, and afaik, it was not necessary to check the equality between two queries.