### PR TITLE
QMAPS-2329 fix datepicker spacer

### DIFF
--- a/src/panel/poi/blocks/Reservation/Reservation.jsx
+++ b/src/panel/poi/blocks/Reservation/Reservation.jsx
@@ -143,13 +143,16 @@ export function Reservation({ mobile, url: baseUrl }) {
             />
             {mobile ? (
               <>
-                <hr className="ReservationSeparator" />
-                <Stack horizontal gap="xs" px="xl" pt="m" end>
-                  <Button variant="tertiary" onClick={handleCancel}>
-                    {_('Cancel')}
-                  </Button>
-                  <Button onClick={hideDatepicker}>{_('Ok')}</Button>
-                </Stack>
+                <Box className="ReservationIADatePickerFooterSpacer" />
+                <Box className="ReservationIADatePickerFooter">
+                  <hr className="ReservationSeparator" />
+                  <Stack horizontal gap="xs" px="xl" py="m" end>
+                    <Button variant="tertiary" onClick={handleCancel}>
+                      {_('Cancel')}
+                    </Button>
+                    <Button onClick={hideDatepicker}>{_('Ok')}</Button>
+                  </Stack>
+                </Box>
               </>
             ) : (
               <>

--- a/src/panel/poi/blocks/Reservation/ReservationPopup.jsx
+++ b/src/panel/poi/blocks/Reservation/ReservationPopup.jsx
@@ -20,7 +20,7 @@ export function ReservationDatepickerPopup({ children, onHide, mobile }) {
     ['pointerdown']
   );
   useEffect(() => {
-    if (wrapperRef) {
+    if (wrapperRef && !mobile) {
       const { left, top } = wrapperRef.current.getBoundingClientRect();
       const { height } = ref.current.getBoundingClientRect();
       ref.current.style.setProperty('left', `${left}px`);

--- a/src/scss/includes/components/reservation.scss
+++ b/src/scss/includes/components/reservation.scss
@@ -53,6 +53,19 @@
   transform: translateY(var(--spacing-m));
 }
 
+.ReservationIADatePickerFooter {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1002;
+  background: var(--grey-white);
+}
+
+.ReservationIADatePickerFooterSpacer {
+  height: 70px;
+}
+
 .ReservationDatepickerBack {
   width: 48px;
   height: 48px;


### PR DESCRIPTION
## Description
Fix the datepicker actions at the bottom of the screen on mobile

## Why
The Datepicker is supposed to take 100vh in height but since it's constrained by an already fixed .panel the actions are pushed out of the screen. 

Improves Issue QMAPS-2329

