### PR TITLE
Clean config

### DIFF
--- a/bin/middlewares/fullText_query.js
+++ b/bin/middlewares/fullText_query.js
@@ -1,5 +1,6 @@
 const axios = require('axios');
 const yaml = require('node-yaml');
+const path = require('path');
 
 module.exports = function (config) {
   const idunnTimeout = Number(config.server.services.idunn.timeout);
@@ -9,8 +10,8 @@ module.exports = function (config) {
     );
   }
 
-  const idunnBaseUrl = config.server.services.idunn.url || config.services.idunn.url;
-  const geocoderUrl = idunnBaseUrl + '/v1/search';
+  const idunnBaseUrl = config.services.idunn.url;
+  const geocoderUrl = path.join(idunnBaseUrl, 'v1/search');
   const useNlu = config.services.geocoder.useNlu;
 
   // @TODO: share intention validation with src/adapters/intention.js

--- a/bin/middlewares/prefetch_poi.js
+++ b/bin/middlewares/prefetch_poi.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 
 module.exports = function (config) {
   // Use url from server config if defined
-  const idunnBaseUrl = config.server.services.idunn.url || config.services.idunn.url;
+  const idunnBaseUrl = config.services.idunn.url;
   const idunnTimeout = Number(config.server.services.idunn.timeout);
   if (isNaN(idunnTimeout)) {
     throw new Error(

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -10,7 +10,6 @@ server:
   enablePrometheus: true
   services:
     idunn:
-      url: # client url will be used by default
       timeout: 2000 # ms
   logger:
     headersWhitelistEnabled: true
@@ -26,7 +25,6 @@ server:
 # Services
 services:
   geocoder:
-    url: override_by_environment
     useLang: true
     maxItems: 7
     useFocus: true

--- a/tests/integration/test_config.js
+++ b/tests/integration/test_config.js
@@ -5,7 +5,6 @@ const config = configBuilder.get_without_check();
 config.mapStyle.baseMapUrl = '[]';
 config.mapStyle.poiMapUrl = '[]';
 config.services.idunn.url = 'http://idunn_test.test';
-config.services.geocoder.url = 'http://geocoder.test/autocomplete';
 config.direction.enabled = true;
 config.direction.service.api = 'mapbox'; // Directions fixtures use mapbox format
 config.events.enabled = true;


### PR DESCRIPTION
## Description
remove `config.services.geocoder.url` and `config.server.services.idunn.url` config and add `path` module in nodejs to concatenate path

## Why
There are too much duplication configuration that make it less maintainable

