### PR TITLE
QMAPS-2491 - Hide burger menu with config clientRule 

### DIFF
--- a/bin/app.js
+++ b/bin/app.js
@@ -122,11 +122,12 @@ function App(config) {
   const ogMeta = new require('./middlewares/og_meta')(config);
 
   router.get('/*', redirectUnsupported, fullTextQuery, preFetchPoi, ogMeta, (req, res) => {
-    const userAgent = req.headers['user-agent'];
-    const disableMenuRule = config.server.disableBurgerMenu.userAgentRule;
+    const disableMenuRule = config.server.disableBurgerMenu.clientRule;
     const { server: _droppedServerConfig, ...appConfig } = config;
+    const regexpRule = new RegExp(`[?&]client=${disableMenuRule}`);
+
     let localAppConfig = appConfig;
-    if (disableMenuRule && userAgent && userAgent.match(disableMenuRule)) {
+    if (disableMenuRule && regexpRule.test(req.originalUrl)) {
       localAppConfig = {
         ...appConfig,
         burgerMenu: {

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -15,7 +15,7 @@ server:
   logger:
     headersWhitelistEnabled: true
   disableBurgerMenu:
-    userAgentRule: '' # regex, ignored if empty
+    clientRule: override_by_environment
   # NB: `routerBaseUrl` may be different from `system.baseUrl` if a proxy is responsible for rewriting URLs
   routerBaseUrl: / # path prefix expected by the express server
   useGeoipForInitialPosition: true


### PR DESCRIPTION
## Description
We need to hide burger menu with certain client rule.

See more on QMAPS-2491.

NB:

New env var: TILEVIEW_server_disableBurgerMenu_clientRule=brz-huawei

Deprecated env var: TILEVIEW_server_disableBurgerMenu_userAgentRule=QwantMobile/3.0

Burger menu should be disabled when url contains [&?]client=brz-huawei