### PR TITLE
QMAPS-2470 - Use same display behaviour in panel for PagesJaunes and TripAdvisor

### DIFF
--- a/src/panel/category/CategoryPanel.jsx
+++ b/src/panel/category/CategoryPanel.jsx
@@ -174,7 +174,10 @@ const CategoryPanel = ({ poiFilters = {}, bbox }) => {
       resizable
       renderHeader={<NavHeader isMobile={isMobile} />}
       minimizedTitle={_('Unfold to show the results', 'categories')}
-      className={classnames('category__panel', { 'panel--pj': dataSource === sources.pagesjaunes })}
+      className={classnames('category__panel', {
+        'panel--pj': dataSource === sources.pagesjaunes,
+        'panel--ta': dataSource === sources.tripadvisor,
+      })}
       floatingItemsLeft={[
         isMobile && shouldShowBackToQwant() && <BackToQwantButton key="back-to-qwant" isMobile />,
       ]}

--- a/src/scss/includes/panels/categories.scss
+++ b/src/scss/includes/panels/categories.scss
@@ -20,7 +20,8 @@
 
 @media (min-width: 641px) {
   .category__panel {
-    &.panel--pj {
+    &.panel--pj, 
+    &.panel--ta {
       .panel-content {
         overflow: hidden;
         display: flex;
@@ -50,7 +51,8 @@
       pointer-events: none;
     }
 
-    &.panel--pj {
+    &.panel--pj,
+    &.panel--ta {
       padding: 0 0 36px;
     }
 


### PR DESCRIPTION
## Description
Apply the same display behaviour in result Panel when data source is pagesJaunes or TripAdvisor. 

## Why
When TripAdvisor results are shown in results Panel - the bar containing data source and the feedback bar are overlapping. 

## Screenshots

https://user-images.githubusercontent.com/442681/154093988-c2eed39b-82e5-4ad0-84e2-4f051e0a75ca.mp4


https://user-images.githubusercontent.com/442681/154093953-ad785b96-90c2-4c07-b00a-ab9196d9e961.mp4

NB: It also fix QMAPS-2436 which is also the same subject.
