### PR TITLE
QMAPS-2408 - Telemetry survey modal harmonization

### DIFF
--- a/bin/test-group.js
+++ b/bin/test-group.js
@@ -16,10 +16,10 @@ function getTestNPercent(config, req) {
 }
 
 function getTgpFromHash(hash) {
-  if (!hash) return 0;
+  if (!hash) return 10;
   const lastByte = parseInt(hash.charAt(hash.length - 2) + hash.charAt(hash.length - 1), 16);
 
-  return Math.ceil(((lastByte + 1) / 256) * 10) * 10 || 0;
+  return Math.ceil(((lastByte + 1) / 256) * 10) * 10 || 10;
 }
 
 function getABTestingInfos(config, req) {

--- a/src/components/Survey.jsx
+++ b/src/components/Survey.jsx
@@ -20,7 +20,10 @@ const Survey = () => {
   };
 
   const onClick = () => {
-    Telemetry.add(Telemetry.SURVEY_ANSWER, { id: survey.id });
+    Telemetry.add(Telemetry.SURVEY_ANSWER, {
+      id: survey.id,
+      device: isMobile ? 'mobile' : 'desktop',
+    });
   };
 
   return (

--- a/src/hooks/useSurvey.js
+++ b/src/hooks/useSurvey.js
@@ -22,7 +22,10 @@ export const useSurvey = () => {
       .then(response => response.json())
       .then(response => {
         if (response?.data?.[0] && !isSurveyClosed(response.data[0].id)) {
-          Telemetry.add(Telemetry.SURVEY_DISPLAY, { id: response.data[0].id });
+          Telemetry.add(Telemetry.SURVEY_DISPLAY, {
+            id: response.data[0].id,
+            device: isMobile ? 'mobile' : 'desktop',
+          });
           setSurvey(response.data[0]);
         }
       });


### PR DESCRIPTION
## Description

### Fix
Fallback the value of the test group to 10 instead of 0, because 0 isn't a valid tgp.

### Refactor

Use the same payload for all the survey events
```
Telemetry.SURVEY_DISPLAY
Telemetry.SURVEY_CLOSE 
Telemetry.SURVEY_ANSWER
```

Payload now always contains id of the survey and the device.