### PR TITLE
QMAPS-2480 - Switch Directions button variant to secondary if data source is TripAdvisor

### DIFF
--- a/src/panel/poi/ActionButtons.jsx
+++ b/src/panel/poi/ActionButtons.jsx
@@ -1,9 +1,10 @@
 /* globals _ */
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Telemetry from 'src/libs/telemetry';
 import { ShareMenu } from 'src/components/ui';
 import { IconHeart, IconHeartFill } from 'src/components/ui/icons';
+import { isFromTripAdvisor } from 'src/libs/pois';
 import { PINK_DARK } from 'src/libs/colors';
 import {
   Stack,
@@ -88,13 +89,17 @@ const ActionButtons = ({
   };
 
   const favoriteColor = isPoiInFavorite ? PINK_DARK : null;
+  const directionsButtonVariant = useMemo(
+    () => (isFromTripAdvisor(poi) ? 'secondary' : 'primary'),
+    [poi]
+  );
 
   return (
     <Stack className="poi_panel__actions" horizontal gap="xs">
       {isDirectionActive && (
         <Button
           className="poi_panel__action__direction"
-          variant="primary"
+          variant={directionsButtonVariant}
           onClick={openDirection}
           title={_('Directions', 'poi panel')}
         >


### PR DESCRIPTION
## Description
Switch Directions button variant to secondary if data source is TripAdvisor

## Why
At the moment, even if data source is TripAdvisor - it shows _primary_ variant.

## Screenshots
<img width="427" alt="TripAdvisorSource" src="https://user-images.githubusercontent.com/442681/154524106-86c8715f-607b-44e7-afd1-f03ba834fc8e.png">
<img width="433" alt="OSMSource" src="https://user-images.githubusercontent.com/442681/154524117-12dfc205-5ea0-4ab2-bd86-9dd35c1918ff.png">


