### PR TITLE
QMAPS-2509 - Local history - Fix navigation on an intention without bbox

### DIFF
--- a/src/panel/history/HistoryPanel.jsx
+++ b/src/panel/history/HistoryPanel.jsx
@@ -106,13 +106,17 @@ const HistoryPanel = () => {
       // With category
       if (item.item.category && item.item.category.name) {
         window.app.navigateTo(
-          `/places/?type=${item.item.category.name}&bbox=${item.item.bbox.join(',')}`
+          `/places/?type=${item.item.category.name}${
+            item?.item?.bbox ? `&bbox=${item.item.bbox.join(',')}` : ''
+          }`
         );
       }
       // Without category (ex: macdonalds nice)
       else {
         window.app.navigateTo(
-          `/places/?q=${item.item.fullTextQuery}&bbox=${item.item.bbox.join(',')}`
+          `/places/?q=${item.item.fullTextQuery}${
+            item?.item?.bbox ? `&bbox=${item.item.bbox.join(',')}` : ''
+          }}`
         );
       }
     }


### PR DESCRIPTION
## Description
This PR create a valid navigation URL - even if there isn't a bbox in the stored history item.

## Why
If the user search "Parc" and pick the first result (Nearest)) - then  - on Local Search History panel - there was a blocking js exception if you try to click on "Parc" (Nearest) because the intention stored in the localStorage does not contains a bbox.

