### PR TITLE
QMAPS-2506 - Local history style fix

### DIFF
--- a/src/scss/includes/suggest.scss
+++ b/src/scss/includes/suggest.scss
@@ -13,7 +13,7 @@
   display: flex;
   align-items: center;
   background-color: $background;
-  transition: background-color .2s;
+  transition: background-color 0.2s;
   cursor: pointer;
   line-height: 1.2;
   padding: $spacing-s;
@@ -38,7 +38,7 @@
   flex-grow: 1;
 
   > div {
-    text-overflow:ellipsis;
+    text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
 
@@ -69,7 +69,12 @@
 }
 
 .suggestHistoryFooter {
-  padding: 15px;
+  padding: 0 $spacing-s $spacing-s $spacing-s;
+  font-size: 12px;
+
+  a {
+    color: $action-blue-base;
+  }
 }
 
 .historyIcon {
@@ -105,7 +110,6 @@
 
 @media (min-width: 641px) {
   .top_bar--history-suggest {
-
     box-shadow: none;
     overflow: visible;
     background: none;


### PR DESCRIPTION
## Description
- Font-size, padding and link color in local history.

## Screenshots
![image](https://user-images.githubusercontent.com/442681/154986420-b8a385b4-806e-42fc-9ac2-453287564b82.png)
