### PR TITLE
QMAPS-2479 fix age list

### DIFF
--- a/src/panel/poi/blocks/Reservation/Reservation.jsx
+++ b/src/panel/poi/blocks/Reservation/Reservation.jsx
@@ -94,7 +94,7 @@ export function Reservation({ mobile, url: baseUrl }) {
       Telemetry.add(Telemetry.POI_TRIPADVISOR_OPEN);
     }
     setInitialLoading(false);
-  });
+  }, [initialLoading]);
 
   return (
     <Box mt="xl" pb="l">

--- a/src/panel/poi/blocks/Reservation/ReservationComposer.jsx
+++ b/src/panel/poi/blocks/Reservation/ReservationComposer.jsx
@@ -48,7 +48,6 @@ export function ReservationComposer({ value: propsValue, onChange, mobile, visib
     onClose();
   };
   const ageOptionsMemo = ageOptions();
-  console.log(ageOptionsMemo, value);
   const hasChildWithNoAge = value.ages.filter(a => a === null).length > 0;
   return (
     <Wrapper mobile={mobile} visible={visible} onClose={handleSubmit}>

--- a/src/panel/poi/blocks/Reservation/ReservationComposer.jsx
+++ b/src/panel/poi/blocks/Reservation/ReservationComposer.jsx
@@ -28,10 +28,13 @@ const fillArray = (arr, count) => {
   return arr.concat(new Array(count - arr.length).fill(null));
 };
 
-const ageOptions = firstLabel => {
-  return [firstLabel]
-    .concat(new Array(16).fill(1).map((v, k) => k + 1))
-    .reduce((acc, v, k) => ({ ...acc, [k]: v }), {});
+const ageOptions = () => {
+  const list = {};
+  let i;
+  for (i = 0; i < 18; i++) {
+    list[i] = i;
+  }
+  return list;
 };
 
 /**
@@ -44,7 +47,8 @@ export function ReservationComposer({ value: propsValue, onChange, mobile, visib
     onChange(value);
     onClose();
   };
-  const ageOptionsMemo = ageOptions(_('< 1 y old'));
+  const ageOptionsMemo = ageOptions();
+  console.log(ageOptionsMemo, value);
   const hasChildWithNoAge = value.ages.filter(a => a === null).length > 0;
   return (
     <Wrapper mobile={mobile} visible={visible} onClose={handleSubmit}>
@@ -165,7 +169,7 @@ function LineAge({ index, value, options, onChange }) {
           {_('Age of child %d').replace('%d', index + 1)}
         </Text>
       </Flex>
-      <Field onChange={handleChange} type="select" options={options} value={age || ''} />
+      <Field onChange={handleChange} type="select" options={options} value={age ? age.toString() : '0'} />
     </>
   );
 }

--- a/src/panel/poi/blocks/Reservation/ReservationComposer.jsx
+++ b/src/panel/poi/blocks/Reservation/ReservationComposer.jsx
@@ -168,7 +168,12 @@ function LineAge({ index, value, options, onChange }) {
           {_('Age of child %d').replace('%d', index + 1)}
         </Text>
       </Flex>
-      <Field onChange={handleChange} type="select" options={options} value={age ? age.toString() : '0'} />
+      <Field
+        onChange={handleChange}
+        type="select"
+        options={options}
+        value={age ? age.toString() : '0'}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Description
- I don't reproduce the Firefox issue anymore (white dropdown)
- This MR includes a fix of the ages list (0-17 instead of 0-16) + no label for the age 0 + correct default param for Field (it caused a React warning)

NB: I'm gonna remove the empty value in the <Field type=select> in the design system. The reservation form is the only one that uses it