### PR TITLE
QMAPS-2520 - Viewport body height miscalculation with 100vh

### DIFF
--- a/src/scss/includes/main.scss
+++ b/src/scss/includes/main.scss
@@ -1,5 +1,7 @@
 body {
-  background: url("../images/backgrounds/grid.png");
+  background: url('../images/backgrounds/grid.png');
+  // Override @qwant-ponents body { min-height: 100vh } which is buggy on iOS.
+  min-height: -webkit-fill-available !important;
 }
 
 noscript {
@@ -68,7 +70,7 @@ noscript {
   display: none;
 }
 
-.map_container .marker.active ,
+.map_container .marker.active,
 .map_container .marker:hover {
   z-index: 2;
 }


### PR DESCRIPTION
## Description
Buggy behaviour when using Qmaps on Safari - focusing the top bar and focusing out 

## Screenshots
Issue: 
https://user-images.githubusercontent.com/442681/155574553-aefa5809-4152-4ec5-a398-caf9830128bc.mov


