### PR TITLE
Fix: Replace dot operator by middle dot in french translation

### DIFF
--- a/language/message/fr.po
+++ b/language/message/fr.po
@@ -1179,7 +1179,7 @@ msgstr ""
 #: public/build/javascript/bundle.js:96373
 #: public/build/javascript/bundle.js:98624
 msgid "Satisfied with the results?"
-msgstr "Satisfait⋅e des résultats proposés ?"
+msgstr "Satisfait·e des résultats proposés ?"
 
 #: public/build/javascript/bundle.js:91901
 msgid "Your history is activated. It is only visible to you on this device."


### PR DESCRIPTION
## Description
Replace dot operator character (U+22C5) by middle dot (U+00B7) in french translation.

## Why
In french the middle dot (U+00B7) is [used for gender-neutral writing](https://en.wikipedia.org/wiki/Interpunct#French) instead of the multiplication dot (U+22C5) [which is used mostly for mathematics](https://en.wikipedia.org/wiki/Interpunct#In_mathematics_and_science).