### PR TITLE
QMAPS-2522 fix datepicker language

### DIFF
--- a/src/panel/poi/blocks/Reservation/Reservation.jsx
+++ b/src/panel/poi/blocks/Reservation/Reservation.jsx
@@ -149,6 +149,7 @@ export function Reservation({ mobile, url: baseUrl }) {
               onMonthVisible={() => null}
               weekStart={1}
               observerId={datepickerMode}
+              language={window.getLang().code}
             />
             {mobile ? (
               <>


### PR DESCRIPTION
## Description
- Pass the current language's code ('en' / 'fr' / ...) to the DatePicker to make it display the month names and days initials in the right language.
- The "check availability" button's target is already in the right language (tripadvisor.fr for FR, tripadvisor.com for EN, etc), contrary to what was said in the JIRA issue.

## Screenshots
![image](https://user-images.githubusercontent.com/1225909/156017080-18468b69-7e4c-48a0-a1ac-40e4876036a6.png)
