### PR TITLE
QMAPS-2528 make history and favorite panels fullscreen and not resizable on mobile

### DIFF
--- a/src/panel/favorites/FavoritesPanel.jsx
+++ b/src/panel/favorites/FavoritesPanel.jsx
@@ -28,15 +28,14 @@ const FavoritesPanel = () => {
 
   return (
     <Panel
-      resizable
+      resizable={false}
       renderHeader={
-        <div className="favorite-header u-text--smallTitle u-center">
+        <div className="favorite-header u-text--smallTitle">
           {favorites.length === 0
             ? _('Favorite places', 'favorite panel')
             : _('My favorites', 'favorite panel')}
         </div>
       }
-      minimizedTitle={_('Show favorites', 'favorite panel')}
       onClose={close}
       className="favorite_panel"
     >

--- a/src/panel/history/HistoryPanel.jsx
+++ b/src/panel/history/HistoryPanel.jsx
@@ -244,13 +244,12 @@ const HistoryPanel = () => {
 
   return (
     <Panel
-      resizable
+      resizable={false}
       renderHeader={
         <Text bold color="primary">
           {_('My history', 'history panel')}
         </Text>
       }
-      minimizedTitle={_('Show history', 'history panel')}
       onClose={close}
       className={classnames(
         'history_panel',

--- a/src/scss/includes/panels/favorite_panel.scss
+++ b/src/scss/includes/panels/favorite_panel.scss
@@ -1,6 +1,6 @@
-@media (min-width: 641px){
-  .favorite-header {
-    margin: 8px 0;
+.favorite_panel {
+  .panel-header {
+    padding: 20px 14px 4px;
   }
 }
 
@@ -10,7 +10,7 @@
 
 .favorite_panel__container__empty {
   color: $secondary_text;
-  padding: 20px;
+  padding: 14px;
 }
 
 .favorite_panel__item {
@@ -54,4 +54,20 @@
   white-space: nowrap;
   color: $primary_text;
   font-weight: bold;
+}
+
+@media (min-width: 641px){
+  .favorite-header {
+    margin: 8px 0;
+  }
+}
+
+// Make the panel fullscreen on mobile
+// (CSS hardcoded until we do a refact of <Panel> that allows it natively)
+@media (max-width: 640px){
+  .favorite_panel {
+    transform: translate3D(0,0,0) !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+  }
 }

--- a/src/scss/includes/panels/history_panel.scss
+++ b/src/scss/includes/panels/history_panel.scss
@@ -100,6 +100,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  margin: 0 0 0 20px;
 }
 
 .historyModalIcon {
@@ -121,5 +122,15 @@
 
   .closeButton {
     margin: 8px;
+  }
+}
+
+// Make the panel fullscreen on mobile
+// (CSS hardcoded until we do a refact of <Panel> that allows it natively)
+@media (max-width: 640px){
+  .history_panel {
+    transform: translate3D(0,0,0) !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
   }
 }


### PR DESCRIPTION
## Description
- Make history and favorite panels fullscreen and not resizable on mobile
- No change on desktop (resizable/maximized is only for mobile views)
- Add some CSS fixes to start harmonizing the style of these two panels (header, and add a bit of space around the history switch)

NB: since the panel component can't do that yet and is too old to be fixed soon enough, I fixed that using a little CSS hack, so we can merge and deploy on time.
In the near future, a refact of the Panel component will be needed and we'll include this feature to replace the CSS hack



## Screenshots

![image](https://user-images.githubusercontent.com/1225909/156373761-8ff2a93c-b6c2-482e-8bb7-629ca34fbb77.png)

![image](https://user-images.githubusercontent.com/1225909/156373804-a88e22f6-8e08-4dd9-bba8-e224b31790c6.png)
