### PR TITLE
QMAPS-2532 fix history in suggest

### DIFF
--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -102,6 +102,7 @@ const itemMatches = ({ type, item }, term) => {
 
 export function getHistoryItems(term = '', { withIntentions = false } = {}) {
   const searchHistory = getHistory();
+
   return searchHistory
     .reverse() // so it's ordered with most recent items first
     .filter(stored => withIntentions || stored.type !== 'intention')

--- a/src/adapters/suggest_sources.js
+++ b/src/adapters/suggest_sources.js
@@ -31,10 +31,12 @@ export function suggestResults(
   const historyItems =
     maxHistoryItems > 0
       ? getHistoryItems(term, { withIntentions: withCategories })
-          .filter(item => !favoriteItems.find(favorite => favorite.id === item.id))
           .slice(0, maxHistoryItems)
           .map(item => {
             item._suggestSource = 'history';
+            if (favoriteItems.find(favorite => favorite.id === item.id)) {
+              item._isFavorite = true;
+            }
             return item;
           })
       : [];

--- a/src/adapters/suggest_sources.js
+++ b/src/adapters/suggest_sources.js
@@ -31,7 +31,7 @@ export function suggestResults(
   const historyItems =
     maxHistoryItems > 0
       ? getHistoryItems(term, { withIntentions: withCategories })
-          .filter(item => item.id !== favoriteItems.find(favorite => favorite.id === item.id)?.id)
+          .filter(item => !favoriteItems.find(favorite => favorite.id === item.id))
           .slice(0, maxHistoryItems)
           .map(item => {
             item._suggestSource = 'history';

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -371,14 +371,18 @@ const Suggest = ({
       {(dropdownVisible || isHistoryPromptVisible) &&
         ReactDOM.createPortal(
           <div ref={dropDownContent}>
-            {!value && items.length > 0 && !items[0].errorLabel && getHistoryEnabled() && (
-              <Flex between className="manage_history">
-                <Text typo="body-1" color="primary" bold>
-                  {_('Recent history')}
-                </Text>
-                <button onClick={() => navigateToHistoryPanel()}>{_('Manage history')}</button>
-              </Flex>
-            )}
+            {!value &&
+              items.length > 0 &&
+              !items[0].errorLabel &&
+              items.some(item => item._suggestSource === 'history') &&
+              getHistoryEnabled() && (
+                <Flex between className="manage_history">
+                  <Text typo="body-1" color="primary" bold>
+                    {_('Recent history')}
+                  </Text>
+                  <button onClick={() => navigateToHistoryPanel()}>{_('Manage history')}</button>
+                </Flex>
+              )}
             {dropdownVisible && !isHistoryPromptVisible && (
               <SuggestsDropdown
                 className={classnames(
@@ -400,23 +404,27 @@ const Suggest = ({
                 question={_('Satisfied with the results?')}
               />
             )}
-            {!value && items.length > 0 && !items[0].errorLabel && getHistoryEnabled() && (
-              <div className="suggestHistoryFooter">
-                {_(
-                  'Your history is activated. It is only visible to you on this device.',
-                  'suggest'
-                )}{' '}
-                <a
-                  href="@TODO"
-                  target="_blank"
-                  onMouseDown={e => {
-                    e.preventDefault();
-                  }}
-                >
-                  {_('Learn more', 'suggest')}
-                </a>
-              </div>
-            )}
+            {!value &&
+              items.length > 0 &&
+              !items[0].errorLabel &&
+              items.some(item => item._suggestSource === 'history') &&
+              getHistoryEnabled() && (
+                <div className="suggestHistoryFooter">
+                  {_(
+                    'Your history is activated. It is only visible to you on this device.',
+                    'suggest'
+                  )}{' '}
+                  <a
+                    href="@TODO"
+                    target="_blank"
+                    onMouseDown={e => {
+                      e.preventDefault();
+                    }}
+                  >
+                    {_('Learn more', 'suggest')}
+                  </a>
+                </div>
+              )}
           </div>,
           outputNode
         )}

--- a/src/components/ui/SuggestItem.jsx
+++ b/src/components/ui/SuggestItem.jsx
@@ -34,11 +34,10 @@ const SuggestItem = ({ item }) => {
   const props = {};
   const variants = [];
   const isHistory = item._suggestSource === 'history';
-  const isFavorite = item instanceof PoiStore;
+  const isFavorite = item instanceof PoiStore || item._isFavorite === true;
   if (isFavorite) {
     variants.push('favorite');
-  }
-  if (isHistory) {
+  } else if (isHistory) {
     variants.push('history');
   }
 


### PR DESCRIPTION
## Description
- Make intentions (categories) appear in the suggest (field empty or filled)
- Deduplicate intentions in the suggest (both "hotels nice" and "hotels à proximité" must be able to appear)

![image](https://user-images.githubusercontent.com/1225909/157053894-18818a47-fde3-4531-b106-c9da3290ca72.png)
![image](https://user-images.githubusercontent.com/1225909/157053978-394a5187-2b4b-43e9-ab31-3d32c543f5f8.png)

- Fix history/favorite deduplication in the suggest

![image](https://user-images.githubusercontent.com/1225909/157054390-fe2b7d54-87e4-4643-b59c-467e8302dfe0.png)

- I also noticed that when only favorites are displayed in the suggest, the "manage history" header still appeared:

![image](https://user-images.githubusercontent.com/1225909/157056866-cbebd5ea-e738-473c-9633-4264cb89555d.png)

So I fixed it too:

![image](https://user-images.githubusercontent.com/1225909/157059355-4cac47cb-296a-4113-acfd-3b45b3da94fb.png)

- I also noticed that when a history suggest was also favorite, the favorite style wasn't applied to it, so I fixed it too.
Here for example, Hotel Negresco is both in favorites and history => appears as favorite

![image](https://user-images.githubusercontent.com/1225909/157064715-b995fb4f-81ff-4c7f-95bb-7d39426bb7ac.png)
