### PR TITLE
QMAPS-2532 don't mix favorites with hisory in suggest

### DIFF
--- a/src/adapters/suggest_sources.js
+++ b/src/adapters/suggest_sources.js
@@ -28,18 +28,18 @@ export function suggestResults(
   // - get all the history items
   // - ignore the items that are already present in the favourites list
   // - keep the N first items (where N = maxHistoryItems)
-  const historyItems =
-    maxHistoryItems > 0
-      ? getHistoryItems(term, { withIntentions: withCategories })
-          .slice(0, maxHistoryItems)
-          .map(item => {
-            item._suggestSource = 'history';
-            if (favoriteItems.find(favorite => favorite.id === item.id)) {
-              item._isFavorite = true;
-            }
-            return item;
-          })
-      : [];
+  let historyItems =
+    maxHistoryItems > 0 ? getHistoryItems(term, { withIntentions: withCategories }) : [];
+
+  if (term !== '') {
+    historyItems = historyItems.filter(
+      item => !favoriteItems.find(favorite => favorite.id === item.id)
+    );
+  }
+  historyItems = historyItems.slice(0, maxHistoryItems).map(item => {
+    item._suggestSource = 'history';
+    return item;
+  });
 
   // Field focused and empty: get history + favourite items, but no favourites if history items are present
   if (term === '') {

--- a/src/components/ui/SuggestItem.jsx
+++ b/src/components/ui/SuggestItem.jsx
@@ -34,7 +34,7 @@ const SuggestItem = ({ item }) => {
   const props = {};
   const variants = [];
   const isHistory = item._suggestSource === 'history';
-  const isFavorite = item instanceof PoiStore || item._isFavorite === true;
+  const isFavorite = item instanceof PoiStore === true;
   if (isFavorite) {
     variants.push('favorite');
   } else if (isHistory) {


### PR DESCRIPTION
## Description
To avoid confusion until the favorite panel is redesigned, don't show favorite items when the history items are displayed in the suggest, when the field is empty


## Screenshots

Ex: here, Hotel Negresco is in history but also in favorites => let's display it as history item only 
![image](https://user-images.githubusercontent.com/1225909/157252465-207ed24d-572a-4323-bc8a-bc79be1d7bd9.png)

