### PR TITLE
QMAPS-2543 enhance mobile attribution

### DIFF
--- a/src/scss/includes/map_theme.scss
+++ b/src/scss/includes/map_theme.scss
@@ -180,11 +180,13 @@
     left: 0;
     bottom: 0;
     width: auto;
-    height: 48px;
     display: flex;
-    flex-direction: row-reverse;
     align-items: center;
     z-index: 1;
+    height: 20px !important;
+    justify-content: space-around;
+    flex-direction: row-reverse;
+    font-size: 10px;
 
     .mapboxgl-ctrl.map_control__scale {
       background: none;
@@ -236,7 +238,6 @@
       }
 
       .mapboxgl-ctrl-attrib-button {
-        top: auto;
         right: auto;
         height: 20px;
         width: 20px;


### PR DESCRIPTION
## Description
NB: on mobile, the scale disappears after a couple seconds of inactivity, it's a feature.

The attribution ribbon acted weird when we opened it on mobile (using the (i) button), the attribution and scale were not placed correctly (vertical alignment, superposition with the right buttons on small screens...)
I fixed that.
You can remark thet when the (i) button is clicked, it does a little "bump", I did not find any css rule that provokes it, so I think it's mapbox-gl-js that does it voluntarily? For now I don't know how to fix it. :/

![attrib](https://user-images.githubusercontent.com/1225909/158343398-a4044ab4-c243-4e49-8939-1c7cd611e7f6.gif)

