### PR TITLE
Add config file path in ts-loader

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -135,7 +135,14 @@ const mainJsChunkConfig = buildMode => {
         },
         {
           test: /\.(ts|tsx)$/,
-          use: [{ loader: 'ts-loader' }],
+          use: [
+            {
+              loader: 'ts-loader',
+              options: {
+                configFile: path.resolve(__dirname, '../tsconfig.json'),
+              },
+            },
+          ],
         },
         {
           test: /\.(css|scss)$/,


### PR DESCRIPTION
## Description
Add config file path in ts-loader to prevent wrong access to tsconfig file in CI.