### PR TITLE
Fix visual regression on top-bar input width

### DIFF
--- a/src/scss/includes/menu.scss
+++ b/src/scss/includes/menu.scss
@@ -190,6 +190,10 @@ $productDrawerWidth: 744px;
 }
 
 @media (min-width: 641px) {
+  #react_menu__container {
+    width: 0;
+  }
+
   .menu__button-container {
     position: fixed;
     right: $spacing-s;


### PR DESCRIPTION
## Description
Because input should be full width.

## Screenshots
Before
<img width="440" alt="image" src="https://user-images.githubusercontent.com/442681/160869313-9fe873e2-7827-443e-bae6-9fe8dc604687.png">
After
<img width="439" alt="image" src="https://user-images.githubusercontent.com/442681/160869355-0f2a36b4-1b3f-47b4-96ae-9f8f65a2ead0.png">


