### PR TITLE
QMAPS-2648 itinerary logs

### DIFF
--- a/local_modules/telemetry/index.js
+++ b/local_modules/telemetry/index.js
@@ -28,6 +28,7 @@ module.exports = {
     'itinerary_route_toggle_details',
     'itinerary_point_geolocation',
     'itinerary_route_preview_open',
+    'itinerary_search',
     /* Poi */
     'poi_category_open',
     'poi_backtofavorite',

--- a/src/adapters/direction_api.js
+++ b/src/adapters/direction_api.js
@@ -1,5 +1,6 @@
 import Ajax from '../libs/ajax';
 import nconf from '@qwant/nconf-getter';
+import Telemetry from 'src/libs/telemetry';
 
 const directionConfig = nconf.get().direction.service;
 const timeout = nconf.get().direction.timeout;
@@ -95,6 +96,7 @@ export default class DirectionApi {
     let response = null;
     try {
       response = await Ajax.get(directionsUrl, directionsParams, { timeout });
+      Telemetry.add(Telemetry.ITINERARY_SEARCH, { mode });
     } catch (e) {
       if (Number.isInteger(e) && e >= 400 && e < 600) {
         // Use the error codes 4xx and 5xx to display different error messages

--- a/src/panel/direction/DirectionPanel.jsx
+++ b/src/panel/direction/DirectionPanel.jsx
@@ -187,6 +187,7 @@ class DirectionPanel extends React.Component {
       fire('set_origin', origin);
       fire('set_destination', destination);
       const directionResponse = await DirectionApi.search(origin, destination, vehicle);
+
       // A more recent query was done in the meantime, ignore this result silently
       if (currentQueryId !== this.lastQueryId) {
         return;


### PR DESCRIPTION
## Description
Log every itinerary search, including the mode (vehicle) used.

![image](https://user-images.githubusercontent.com/1225909/161582804-8e067273-07b0-4c90-b82d-63c838046d1b.png)

Must be triggered with each Direction API call:
- edit a field
- switch felds
- change vehicle
- etc.