### PR TITLE
Fix unknown identity when pushing storybook to github

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,8 @@ jobs:
 
       - name: Deploy Storybook
         if: "contains(github.ref_name, 'master')"
-        run: npm run deploy-storybook
+        run: |
+          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          npm run deploy -- -u "github-actions-bot <support+actions@github.com>"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
When building - the CI was complaining about unknown Git identity when pushing to the repo.
As documented in gh-pages doc page we do as following:


> Deploying with GitHub Actions
In order to deploy with GitHub Actions, you will need to define a user and set the git repository for the process. See the 
example step below

```
- name: Deploy with gh-pages
  run: |
    git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
    npx gh-pages -d build -u "github-actions-bot <support+actions@github.com>"
   env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```
