### PR TITLE
QMAPS-2664 fix direction panel max height (don't include the top bar)

### DIFF
--- a/src/scss/includes/direction-panel.scss
+++ b/src/scss/includes/direction-panel.scss
@@ -1,6 +1,12 @@
 .direction-panel {
   padding-top: 12px;
 
+  @media (min-width: 641px) {
+    &.panel {
+      max-height: calc(100vh - 92px);
+    }
+  }
+
   @media (max-width: 640px) {
     background-color: $background;
     @include card_shadow();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1225909/162969027-c54e6d49-79ae-4291-a32f-5ed9380f95bf.png)

direction panel max height was too small (because it included the top bar's height, which is not present)