### PR TITLE
fix non-existing method for intention's category in history

### DIFF
--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -109,10 +109,12 @@ export function getHistoryItems(term = '', { withIntentions = false } = {}) {
     .filter(stored => itemMatches(stored, term))
     .map(stored => {
       if (stored.type === 'intention') {
-        return Object.assign(
+        const res = Object.assign(
           new Intention({ filter: stored.item.filter, description: { place: stored.item.place } }),
           stored.item
         );
+        res.category = Category.create(stored.item.category);
+        return res;
       } else {
         return Object.assign(new Poi(), stored.item);
       }


### PR DESCRIPTION
In the history the category field was overridden by an object parsed from local-storage, hence didn't have any properties inherited from the `Category` class. This sometimes resulted in trying to call an non-existing method, which makes the whole react context crash.

I didn't want to fundamentally change how the history code is structured but the way how we fetch objects from the history seems non-recommended and very error prone. Instead of building a fake `Intention` instance and replacing its fields, we should probably rather have a constructor that allows to set all its fields directly, or even a method recursively building it from an object.

# Reproduce the bug

 1. Ensure you have an intention with a category in the history (eg. by searching "restaurant")
 2. Perform a search that will show this intention from the history
 3. Press the "down" key

Normally all react components will disappear from the page and the console will show this exception:

> Uncaught TypeError: e.category.getInputValue is not a function

PR  # 1337 :sunglasses: