### PR TITLE
QMAPS-2725 field fix 

### DIFF
--- a/src/components/TopBar/TopBar.jsx
+++ b/src/components/TopBar/TopBar.jsx
@@ -33,6 +33,7 @@ const TopBar = ({ value, setUserInputValue, inputRef, onSuggestToggle, backButto
   // give keyboard focus to the field when typing anywhere
   useEffect(() => {
     const globalKeyHandler = e => {
+      window.startedTyping = true;
       if (MAPBOX_RESERVED_KEYS.find(key => key === e.key)) {
         return;
       }
@@ -151,6 +152,7 @@ const TopBar = ({ value, setUserInputValue, inputRef, onSuggestToggle, backButto
                   handleFocus(e);
                   setFocused(true);
                   onFocus();
+                  window.startedTyping = false;
                 }}
                 onBlur={() => {
                   // The mouseLeave flag allows to keep the suggest open when clicking outside of the browser

--- a/src/libs/suggest.js
+++ b/src/libs/suggest.js
@@ -76,7 +76,11 @@ export const modifyList = (items, withGeoloc, query, hideItem) => {
     items = items.filter(item => item.id !== hideItem.id);
   }
 
-  if (query.length > 0 && (items.length === 0 || (items.length === 1 && withGeoloc))) {
+  if (
+    window.startedTyping &&
+    query.length > 0 &&
+    (items.length === 0 || (items.length === 1 && withGeoloc))
+  ) {
     items.push({
       errorLabel: true,
     });

--- a/src/panel/PanelManager.jsx
+++ b/src/panel/PanelManager.jsx
@@ -262,7 +262,10 @@ const PanelManager = ({ router }) => {
           mounts and unmounts of the ActivePanel, that would have inappropriate side effects
           on map markers, requests to server, etc.
         */}
-        <div className="panel_container" style={{ display: !isPanelVisible ? 'none' : null }}>
+        <div
+          className="panel_container"
+          style={{ display: !isPanelVisible && window.startedTyping ? 'none' : null }}
+        >
           <ActivePanel {...options} />
         </div>
       </PanelContext.Provider>

--- a/src/scss/includes/suggest.scss
+++ b/src/scss/includes/suggest.scss
@@ -17,6 +17,10 @@
       border-top: none;
     }
   }
+
+  &.autocomplete_suggestions--empty {
+    border: none;
+  }
 }
 
 .autocomplete_suggestion {


### PR DESCRIPTION
WIP do not merge

When the field is not empty, and gets focused, but no item is found:
- don't hide the currently opened panel
- don't show a no item found error 

When we start typing in the non-empty field:
- show results / no item found error
- hide current panel

TODO: 
- replace global var with zustand boolean state
- fix side effects on other parts of the app