### PR TITLE
QMAPS-3725 fix focus behavior

### DIFF
--- a/src/components/TopBar/TopBar.jsx
+++ b/src/components/TopBar/TopBar.jsx
@@ -38,10 +38,12 @@ const TopBar = ({ value, setUserInputValue, inputRef, onSuggestToggle, backButto
   // give keyboard focus to the field when typing anywhere
   useEffect(() => {
     const globalKeyHandler = e => {
-      setSearchInputTyping(true);
       if (MAPBOX_RESERVED_KEYS.find(key => key === e.key)) {
         return;
       }
+
+      setSearchInputTyping(true);
+
       // KeyboardEvent.key is either the printed character representation or a standard value for specials keys
       // See https://developer.mozilla.org/fr/docs/Web/API/KeyboardEvent/key/Key_Values
       if (

--- a/src/components/TopBar/TopBar.jsx
+++ b/src/components/TopBar/TopBar.jsx
@@ -27,12 +27,18 @@ const TopBar = ({ value, setUserInputValue, inputRef, onSuggestToggle, backButto
   const config = useConfig();
   const searchHistoryEnabled = getHistoryEnabled();
   const { _ } = useI18n();
-  const { isMenuDrawerOpen, setMenuDrawerOpen, isProductsDrawerOpen, setProductsDrawerOpen } =
-    useStore();
+  const {
+    isMenuDrawerOpen,
+    setMenuDrawerOpen,
+    isProductsDrawerOpen,
+    setProductsDrawerOpen,
+    setSearchInputTyping,
+  } = useStore();
 
   // give keyboard focus to the field when typing anywhere
   useEffect(() => {
     const globalKeyHandler = e => {
+      setSearchInputTyping(true);
       if (MAPBOX_RESERVED_KEYS.find(key => key === e.key)) {
         return;
       }
@@ -151,12 +157,14 @@ const TopBar = ({ value, setUserInputValue, inputRef, onSuggestToggle, backButto
                   handleFocus(e);
                   setFocused(true);
                   onFocus();
+                  setSearchInputTyping(false);
                 }}
                 onBlur={() => {
                   // The mouseLeave flag allows to keep the suggest open when clicking outside of the browser
                   if (!window.mouseLeave) {
                     setFocused(false);
                     onBlur();
+                    setSearchInputTyping(false);
                   }
                 }}
                 onKeyDown={onKeyDown}

--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -14,6 +14,7 @@ import Telemetry from 'src/libs/telemetry';
 import { listen, unListen } from 'src/libs/customEvents';
 import useDelayedState from 'use-delayed-state';
 import classnames from 'classnames';
+import { useStore } from 'src/store';
 
 const SUGGEST_DEBOUNCE_WAIT = 100;
 
@@ -64,6 +65,8 @@ const Suggest = ({
     getHistoryEnabled() === null
   );
   const { isMobile } = useDevice();
+
+  const { isSearchInputTyping } = useStore();
 
   const displayHistoryPrompt = useMemo(
     () =>
@@ -276,8 +279,10 @@ const Suggest = ({
       }
     } else {
       setHighlighted(null);
-      fetchItems(value);
-      setIsOpen(true);
+      if (!value || isSearchInputTyping) {
+        fetchItems(value);
+        setIsOpen(true);
+      }
       if (value) {
         setKeepHistoryPromptVisible(false);
       }

--- a/src/scss/includes/components/feedback.scss
+++ b/src/scss/includes/components/feedback.scss
@@ -4,7 +4,7 @@
   padding: $spacing-s $spacing-m;
 
   .closeButton {
-    align-self: flex-start;
+    margin-top: 0;
   }
 
   &-question {

--- a/src/store/slices/ui.ts
+++ b/src/store/slices/ui.ts
@@ -8,13 +8,16 @@ import { AppState } from '..';
 export interface UiSlice extends State {
   isMenuDrawerOpen: boolean;
   isProductsDrawerOpen: boolean;
+  isSearchInputTyping: boolean;
   setMenuDrawerOpen: (isOpen: boolean) => void;
   setProductsDrawerOpen: (isOpen: boolean) => void;
+  setSearchInputTyping: (isSearchInputTyping: boolean) => void;
 }
 
 export const createUiSlice = (set: NamedSet<AppState>, get: GetState<AppState>): UiSlice => ({
   isMenuDrawerOpen: false,
   isProductsDrawerOpen: false,
+  isSearchInputTyping: false,
   setMenuDrawerOpen: isOpen =>
     set(
       () => {
@@ -32,5 +35,13 @@ export const createUiSlice = (set: NamedSet<AppState>, get: GetState<AppState>):
       },
       false,
       'UI/setProductsDrawerOpen'
+    ),
+  setSearchInputTyping: isSearchInputTyping =>
+    set(
+      () => {
+        return { isSearchInputTyping };
+      },
+      false,
+      'UI/setSearchInputTyping'
     ),
 });


### PR DESCRIPTION
## Description

When top bar field is focused:
- if empty: same as before (show favs / history)
- if not empty: no suggest, current panel stays open until we start typing in the field
- If not empty and typing in the field; same as before (show geocoder suggest)

Also: CSS fix on user feedback "x" button.