### PR TITLE
QMAPS-2569 QMAPS-2533 fix history

### DIFF
--- a/src/adapters/category.js
+++ b/src/adapters/category.js
@@ -43,7 +43,12 @@ export default class Category {
     return matched;
   }
 
-  static create({ name, label, icon, color, matcher }) {
+  static create(options) {
+    const name = options?.name || '';
+    const label = options?.label || '';
+    const icon = options?.icon || null;
+    const color = options?.color || '';
+    const matcher = options?.matcher || '';
     return new Category(name, label, icon, color, matcher);
   }
 }

--- a/src/panel/history/HistoryPanel.jsx
+++ b/src/panel/history/HistoryPanel.jsx
@@ -10,6 +10,7 @@ import {
   historyLength,
   deleteQuery,
   deleteSearchHistory,
+  saveQuery,
 } from 'src/adapters/search_history';
 import PlaceIcon from 'src/components/PlaceIcon';
 import { capitalizeFirst } from 'src/libs/string';
@@ -99,6 +100,9 @@ const HistoryPanel = () => {
   }, [last6Months, lastMidnight, lastMonth, lastWeek, lastYear, now]);
 
   const visit = item => {
+    // Save new visit in history
+    saveQuery(item.item);
+
     // PoI
     if (item.type === 'poi') {
       window.app.navigateTo(`/place/${item.item.id}`);
@@ -120,7 +124,7 @@ const HistoryPanel = () => {
         window.app.navigateTo(
           `/places/?q=${item.item.fullTextQuery}${
             item?.item?.bbox ? `&bbox=${item.item.bbox.join(',')}` : ''
-          }}`
+          }`
         );
       }
     }
@@ -140,10 +144,12 @@ const HistoryPanel = () => {
     openClearHistoryModal();
   };
 
+  let count = 0;
+
   const showItem = item => {
     return item.type === 'poi' ? (
       // poi / city / address
-      <Flex key={item.item.id} className="history-list-item">
+      <Flex key={'item' + count++} className="history-list-item">
         <Box
           onClick={() => {
             Telemetry.add(Telemetry.HISTORY_ITEM_CLICKED_PANEL);
@@ -189,10 +195,7 @@ const HistoryPanel = () => {
       </Flex>
     ) : (
       // intention
-      <Flex
-        key={item.item.category?.name + '_' + item.item.place?.properties?.geocoding?.name}
-        className="history-list-item"
-      >
+      <Flex key={'item' + count++} className="history-list-item">
         <Box
           onClick={() => {
             Telemetry.add(Telemetry.HISTORY_ITEM_CLICKED_PANEL);

--- a/src/panel/history/HistoryPanel.jsx
+++ b/src/panel/history/HistoryPanel.jsx
@@ -144,12 +144,10 @@ const HistoryPanel = () => {
     openClearHistoryModal();
   };
 
-  let count = 0;
-
   const showItem = item => {
     return item.type === 'poi' ? (
       // poi / city / address
-      <Flex key={'item' + count++} className="history-list-item">
+      <Flex key={item.item.date} className="history-list-item">
         <Box
           onClick={() => {
             Telemetry.add(Telemetry.HISTORY_ITEM_CLICKED_PANEL);
@@ -195,7 +193,7 @@ const HistoryPanel = () => {
       </Flex>
     ) : (
       // intention
-      <Flex key={'item' + count++} className="history-list-item">
+      <Flex key={item.item.date} className="history-list-item">
         <Box
           onClick={() => {
             Telemetry.add(Telemetry.HISTORY_ITEM_CLICKED_PANEL);


### PR DESCRIPTION
## Description
- don't deduplicate items in history
- include creation date in each history items to identify the duplicates
- generate React key differently in history items list (the old model didn't support all the poi / category types, nor the duplicates)
- fix typos that created errors in some edge cases
- when a history item is clicked: a new history item is created on top of the list
- in the suggest, do the deduplication of the items to avoid suggesting the same thing 3 times.

![image](https://user-images.githubusercontent.com/1225909/174651360-871e15c7-a00e-4a6d-84d7-38743d743dff.png)
![image](https://user-images.githubusercontent.com/1225909/174651445-859ea180-1d0b-4758-97ea-70197b5913a1.png)

