### PR TITLE
QMAPS-2569 history-fix

### DIFF
--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -19,7 +19,17 @@ export function getHistoryEnabled() {
 }
 
 export function getHistory() {
-  return get(SEARCH_HISTORY_KEY) || [];
+  const items = get(SEARCH_HISTORY_KEY) || [];
+
+  // Modification of localStorage entry (06/2022):
+  // Date is now stored inside the item, not aside.
+  let item;
+  for (item in items) {
+    if (items[item].date && !items[item].item.date) {
+      items[item].item.date = items[item].date;
+    }
+  }
+  return items;
 }
 
 export function setHistory(searchHistory) {

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -19,24 +19,14 @@ export function getHistoryEnabled() {
 }
 
 export function getHistory() {
-  const items = get(SEARCH_HISTORY_KEY) || [];
-
-  // Modification of localStorage entry (06/2022):
-  // Date is now stored inside the item, not aside.
-  let item;
-  for (item in items) {
-    if (items[item].date && !items[item].item.date) {
-      items[item].item.date = items[item].date;
-    }
-  }
-  return items;
+  return get(SEARCH_HISTORY_KEY) || [];
 }
 
 export function setHistory(searchHistory) {
   set(SEARCH_HISTORY_KEY, searchHistory);
 }
 
-function getQueryType(item) {
+export function getQueryType(item) {
   switch (true) {
     case item instanceof Poi:
     case item instanceof BragiPoi:
@@ -58,12 +48,10 @@ export async function saveQuery(item, type) {
   // Retrieve the search history
   const searchHistory = getHistory();
 
-  // Put date in item
-  item.date = Date.now();
-
   // Put the query at the end of the array
   searchHistory.push({
     type: type || getQueryType(item),
+    date: Date.now(),
     item,
   });
 
@@ -71,11 +59,17 @@ export async function saveQuery(item, type) {
   setHistory(searchHistory);
 }
 
-export function deleteQuery(item) {
+// Delete a query from the History
+// if the deletion occurs from the suggest, fromSuggest will be true,
+// in that case the latest occurrence of that item will be deleted.
+// if the deletion occurs from history panel, fromSuggest will be false,
+// in that case an exact date equality will be checked
+export function deleteQuery(item, fromSuggest) {
   const searchHistory = getHistory();
   let index;
+
   for (index = searchHistory.length - 1; index >= 0; index--) {
-    if (itemEquals(searchHistory[index], item)) {
+    if (itemEquals(searchHistory[index], item, fromSuggest)) {
       searchHistory.splice(index, 1);
     }
   }
@@ -87,15 +81,20 @@ export function deleteSearchHistory() {
   del(SEARCH_HISTORY_KEY);
 }
 
-const itemEquals = ({ type, item }, other) => {
-  if (type === 'intention') {
+// Compare two History items
+// - intention: compare category name + place name (+ date)
+// - poi: compare id (+ date)
+// Date is only compared if deleteMostRecent is false.
+const itemEquals = (current, other, deleteMostRecent) => {
+  if (current.type === 'intention') {
     return (
-      item.category?.name === other.category?.name &&
-      item.place?.properties?.geocoding?.name === other.place?.properties?.geocoding?.name &&
-      item.date === other.date
+      current.item.category?.name === other.item.category?.name &&
+      current.item.place?.properties?.geocoding?.name ===
+        other.item.place?.properties?.geocoding?.name &&
+      (deleteMostRecent || current.date === other.date)
     );
-  } else if (type === 'poi') {
-    return item.id === other.id && item.date === other.date;
+  } else if (current.type === 'poi') {
+    return current.item.id === other.item.id && (deleteMostRecent || current.date === other.date);
   }
   return false;
 };
@@ -148,7 +147,7 @@ export function getHistoryItems(term = '', { withIntentions = false } = {}) {
 export function listHistoryItemsByDate(from, to) {
   return getHistory()
     .reverse() // so it's ordered with most recent items first
-    .filter(item => item.item.date >= from && item.item.date < to); // filter by date range
+    .filter(item => item.date >= from && item.date < to); // filter by date range
 }
 
 export function historyLength() {

--- a/src/adapters/search_history.js
+++ b/src/adapters/search_history.js
@@ -42,7 +42,9 @@ function getQueryType(item) {
   }
 }
 
-export async function saveQuery(item) {
+// Add a query in History.
+// The type is optional, used to revisit items from the History. Otherwise, it is guessed by getQueryType.
+export async function saveQuery(item, type) {
   // Retrieve the search history
   const searchHistory = getHistory();
 
@@ -51,7 +53,7 @@ export async function saveQuery(item) {
 
   // Put the query at the end of the array
   searchHistory.push({
-    type: getQueryType(item),
+    type: type || getQueryType(item),
     item,
   });
 

--- a/src/components/ui/SuggestItem.jsx
+++ b/src/components/ui/SuggestItem.jsx
@@ -7,7 +7,7 @@ import { Address } from 'src/components/ui';
 import PlaceIcon from 'src/components/PlaceIcon';
 import PoiStore from 'src/adapters/poi/poi_store';
 import NoResultMessage from 'src/panel/NoResultMessage';
-import { deleteQuery } from 'src/adapters/search_history';
+import { deleteQuery, getQueryType } from 'src/adapters/search_history';
 import { useI18n } from 'src/hooks';
 import { IconEmpty } from '@qwant/qwant-ponents';
 import { GREY_SEMI_DARKNESS } from '../../libs/colors';
@@ -48,7 +48,7 @@ const SuggestItem = ({ item }) => {
     e.preventDefault();
     // Prevent triggering the mouse down action on the parent
     e.stopPropagation();
-    deleteQuery(item);
+    deleteQuery({ item, type: getQueryType(item) }, true);
     setRemoved(true);
   };
 

--- a/src/panel/history/HistoryPanel.jsx
+++ b/src/panel/history/HistoryPanel.jsx
@@ -133,7 +133,7 @@ const HistoryPanel = () => {
   // Remove one item from the list
   const remove = item => {
     // Remove the item in localStorage
-    deleteQuery(item.item);
+    deleteQuery(item);
 
     // Refresh lists and re-render the page
     computeHistory();
@@ -147,7 +147,7 @@ const HistoryPanel = () => {
   const showItem = item => {
     return item.type === 'poi' ? (
       // poi / city / address
-      <Flex key={item.item.date} className="history-list-item">
+      <Flex key={item.date} className="history-list-item">
         <Box
           onClick={() => {
             Telemetry.add(Telemetry.HISTORY_ITEM_CLICKED_PANEL);
@@ -193,7 +193,7 @@ const HistoryPanel = () => {
       </Flex>
     ) : (
       // intention
-      <Flex key={item.item.date} className="history-list-item">
+      <Flex key={item.date} className="history-list-item">
         <Box
           onClick={() => {
             Telemetry.add(Telemetry.HISTORY_ITEM_CLICKED_PANEL);

--- a/src/panel/history/HistoryPanel.jsx
+++ b/src/panel/history/HistoryPanel.jsx
@@ -101,7 +101,7 @@ const HistoryPanel = () => {
 
   const visit = item => {
     // Save new visit in history
-    saveQuery(item.item);
+    saveQuery(item.item, item.type);
 
     // PoI
     if (item.type === 'poi') {


### PR DESCRIPTION
## Description
1) use the right poi type when revisiting an item from the history panel to avoid the difference shown here:

![image](https://user-images.githubusercontent.com/1225909/174819480-48c555f0-7949-442c-aedc-fb7ac89c8888.png)

Fixed:

![image](https://user-images.githubusercontent.com/1225909/174819526-e3c79a99-fd52-42d5-b7d8-ec3579264bc5.png)

2) Maintain compatibility for history items created before this feature (keep history item's date stored aside and not indide)
