### PR TITLE
route_utils: support for geojson's MultiLineString in routes

### DIFF
--- a/src/libs/route_utils.js
+++ b/src/libs/route_utils.js
@@ -69,8 +69,18 @@ const last = array => array && array[array.length - 1];
 
 export const originDestinationCoords = route => {
   const fc = normalizeToFeatureCollection(route.geometry);
-  return {
-    origin: first(first(fc.features).geometry.coordinates),
-    destination: last(last(fc.features).geometry.coordinates),
-  };
+  const first_geo = first(fc.features).geometry;
+  const last_geo = last(fc.features).geometry;
+
+  const origin =
+    first_geo.type === 'MultiLineString'
+      ? first(first(first_geo.coordinates))
+      : first(first_geo.coordinates);
+
+  const destination =
+    last_geo.type === 'MultiLineString'
+      ? last(last(last_geo.coordinates))
+      : last(last_geo.coordinates);
+
+  return { origin, destination };
 };


### PR DESCRIPTION
## Description

When receiving a route, Erdapfel currently expects a [`LineString`](https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.4). The next iteration on the directions may return [`MultiLineString`](https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.5) which is currently not supported and results in the start and destination pins disappearing.

I think it is reasonable to make Erdapfel a bit more robust in this specific case even though it is a bit premature since it will only actually be useful once we use Hove's directions.