### PR TITLE
use SVG icon for walking "vehicle"

### DIFF
--- a/src/panel/direction/RouteSummaryInfo.jsx
+++ b/src/panel/direction/RouteSummaryInfo.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import RouteVia from './RouteVia';
 import RouteStartEndTimes from './RouteStartEndTimes';
+import VehicleIcon from './VehicleIcon';
 import { Badge } from 'src/components/ui';
 import { formatDuration, formatDistance } from 'src/libs/route_utils';
 
@@ -13,8 +14,7 @@ const RouteWalkingTime = ({ route }) => {
 
   return (
     <span className="u-text--subtitle u-mr-s">
-      {/* @TODO: replace by SVG icon */}
-      <i className="icon-foot u-mr-xxs" style={{ fontSize: 11 }} />
+      <VehicleIcon vehicle="walking" fill="currentColor" height={11} />
       {formatDuration(walkingTime)}
     </span>
   );

--- a/src/panel/direction/RouteVia.jsx
+++ b/src/panel/direction/RouteVia.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import PublicTransportLine from './PublicTransportLine';
+import VehicleIcon from './VehicleIcon';
 
 const RouteVia = ({ route, vehicle, className }) => {
   if (vehicle !== 'publicTransport') {
@@ -19,7 +20,7 @@ const RouteVia = ({ route, vehicle, className }) => {
         .map((summaryPart, idx) => (
           <span key={idx} className="routeVia-step">
             {summaryPart.mode === 'WALK' ? (
-              <i className="icon-foot" /> // @TODO: replace by SVG icon
+              <VehicleIcon vehicle="walking" fill="currentColor" />
             ) : (
               <PublicTransportLine mode={summaryPart.mode} info={summaryPart.info} />
             )}


### PR DESCRIPTION
This fixes the display of the walking icon in the summary of public
transport directions, which was formerly using a deprecated icon class.

## Screenshots

Notice the small icon on the 4th line

| before (master) | after (HEAD) |
|-|-|
| ![Screen Shot 2022-06-29 at 15 03 29](https://user-images.githubusercontent.com/1173464/176445951-935897f6-bb7d-40dd-8bf2-766833c1eb73.png) | ![Screen Shot 2022-06-29 at 15 02 58](https://user-images.githubusercontent.com/1173464/176445983-0c31147d-7440-4229-acb1-3966589e6450.png) |