### PR TITLE
geocoder.js: fix intention field which was renamed from intentions

### DIFF
--- a/src/adapters/geocoder.js
+++ b/src/adapters/geocoder.js
@@ -71,7 +71,7 @@ export function getGeocoderSuggestions(term, { focus = {}, useNlu = false } = {}
     }
     suggestsPromise = ajax.get(geocoderUrl, query);
     suggestsPromise
-      .then(({ features, intentions }) => {
+      .then(({ features, intention }) => {
         const pois = features.map((feature, index) => {
           const queryContext = new QueryContext(
             term,
@@ -82,10 +82,11 @@ export function getGeocoderSuggestions(term, { focus = {}, useNlu = false } = {}
           return new BragiPoi(feature, queryContext);
         });
         const bragiResponse = { pois };
-        if (intentions) {
-          bragiResponse.intentions = intentions
-            .map(intention => new Intention(intention))
-            .filter(intention => intention.isValid());
+        if (intention) {
+          const parsed = new Intention(intention);
+          if (parsed.isValid()) {
+            bragiResponse.intentions = [parsed];
+          }
         }
         bragiCache[cacheKey] = bragiResponse;
         resolve(bragiResponse);


### PR DESCRIPTION
## Description
The `intentions` list field was renamed into a simpler `intention` value in a recent [refacto of Idunn](https://github.com/Qwant/idunn/pull/333). This led erdapfel to not find a value for this field an fallback to the regex mode.

## Screenshots
| master | HEAD |
|-|-|
|![Screen Shot 2022-07-12 at 08 30 44](https://user-images.githubusercontent.com/1173464/178423782-947154de-7643-4919-a981-94b59f8bfab9.png)|![Screen Shot 2022-07-12 at 08 30 56](https://user-images.githubusercontent.com/1173464/178423792-90ca47e7-b92b-49c7-b5a0-fd5f7773a99e.png)|