### PR TITLE
Stringified instructions for walk sections

### DIFF
--- a/language/message/de.po
+++ b/language/message/de.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Maps\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-12 11:56+0200\n"
-"PO-Revision-Date: 2022-07-12 11:56+0200\n"
+"POT-Creation-Date: 2022-07-19 08:43+0200\n"
+"PO-Revision-Date: 2022-07-19 08:44+0200\n"
 "Last-Translator: maxime euziere <m.euziere@qwant.com>, 2022\n"
 "Language-Team: German (https://www.transifex.com/qwant-1/teams/89416/de/)\n"
 "Language: de\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.0.1\n"
+"X-Generator: Poedit 3.1\n"
 "X-Poedit-Basepath: ../..\n"
 "X-Poedit-KeywordsList: ;_;_n:1,2\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -1322,6 +1322,29 @@ msgstr "Über"
 
 msgid "Fastest route"
 msgstr "Schnellste Route"
+
+msgid "Turn left"
+msgstr "Links abbiegen"
+
+msgid "Keep left"
+msgstr "Links halten"
+
+msgid "Walk"
+msgstr "Spaziergang"
+
+msgid "Keep right"
+msgstr "Rechts halten"
+
+msgid "Turn right"
+msgstr "Rechts abbiegen"
+
+#, fuzzy
+#| msgid "Go back"
+msgid "Turn back"
+msgstr "Zurück gehen"
+
+msgid "{modifier} on {name}"
+msgstr "{modifier} auf {name}"
 
 msgid "Walk on {walkDistance}"
 msgstr "Lauf über {walkDistance}"

--- a/language/message/es.po
+++ b/language/message/es.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Maps\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-12 11:56+0200\n"
-"PO-Revision-Date: 2022-07-12 11:56+0200\n"
+"POT-Creation-Date: 2022-07-19 08:39+0200\n"
+"PO-Revision-Date: 2022-07-19 08:42+0200\n"
 "Last-Translator: maxime euziere <m.euziere@qwant.com>, 2022\n"
 "Language-Team: Spanish (https://www.transifex.com/qwant-1/teams/89416/es/)\n"
 "Language: es\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.0.1\n"
+"X-Generator: Poedit 3.1\n"
 "X-Poedit-Basepath: ../..\n"
 "X-Poedit-KeywordsList: ;_;_n:1,2\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -1316,6 +1316,29 @@ msgstr "Por"
 
 msgid "Fastest route"
 msgstr "Ruta más rápida"
+
+msgid "Turn left"
+msgstr "Gire a la izquierda"
+
+msgid "Keep left"
+msgstr "Manténgase a la izquierda"
+
+msgid "Walk"
+msgstr "Paseo"
+
+msgid "Keep right"
+msgstr "Manténgase a la derecha"
+
+msgid "Turn right"
+msgstr "Gire a la derecha"
+
+#, fuzzy
+#| msgid "Go back"
+msgid "Turn back"
+msgstr "Volver"
+
+msgid "{modifier} on {name}"
+msgstr "{modifier} en la {name}"
 
 msgid "Walk on {walkDistance}"
 msgstr "Camina {walkDistance}"

--- a/language/message/fr.po
+++ b/language/message/fr.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-12 11:55+0200\n"
-"PO-Revision-Date: 2022-07-12 11:55+0200\n"
+"POT-Creation-Date: 2022-07-12 14:07+0200\n"
+"PO-Revision-Date: 2022-07-12 14:08+0200\n"
 "Last-Translator: Benjamin Becquet <b.becquet@qwant.com>, 2021\n"
 "Language-Team: French (https://www.transifex.com/qwant-1/teams/89416/fr/)\n"
 "Language: fr\n"
@@ -59,10 +59,8 @@ msgstr "banque"
 msgid "museum"
 msgstr "musée"
 
-#, fuzzy
-#| msgid "airport"
 msgid "sport"
-msgstr "aéroport"
+msgstr "sport"
 
 msgid "service"
 msgstr "services"
@@ -331,8 +329,6 @@ msgstr "magasin matériel medical"
 msgid "furnitures shop"
 msgstr "électroménager"
 
-#, fuzzy
-#| msgid "outdoor activities shop'"
 msgid "outdoor activities shop"
 msgstr "magasin d'activité extérieur"
 
@@ -1318,6 +1314,27 @@ msgstr "Via"
 
 msgid "Fastest route"
 msgstr "Itinéraire le plus rapide"
+
+msgid "Turn left"
+msgstr "Tournez à gauche"
+
+msgid "Keep left"
+msgstr "Continuez à gauche"
+
+msgid "Walk"
+msgstr "Marchez"
+
+msgid "Keep right"
+msgstr "Continuez à droite"
+
+msgid "Turn right"
+msgstr "Tournez à droite"
+
+msgid "Turn back"
+msgstr "Faites demi tour"
+
+msgid "{modifier} on {name}"
+msgstr "{modifier} sur {name}"
 
 msgid "Walk on {walkDistance}"
 msgstr "Marchez sur {walkDistance}"

--- a/language/message/it.po
+++ b/language/message/it.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Maps\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-12 11:55+0200\n"
-"PO-Revision-Date: 2022-07-12 11:55+0200\n"
+"POT-Creation-Date: 2022-07-19 08:45+0200\n"
+"PO-Revision-Date: 2022-07-19 08:47+0200\n"
 "Last-Translator: maxime euziere <m.euziere@qwant.com>, 2022\n"
 "Language-Team: Italian (https://www.transifex.com/qwant-1/teams/89416/it/)\n"
 "Language: it\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.0.1\n"
+"X-Generator: Poedit 3.1\n"
 "X-Poedit-Basepath: ../..\n"
 "X-Poedit-KeywordsList: ;_;_n:1,2\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -1319,6 +1319,29 @@ msgstr "Via"
 
 msgid "Fastest route"
 msgstr "Strada più veloce"
+
+msgid "Turn left"
+msgstr "Girare a sinistra"
+
+msgid "Keep left"
+msgstr "Mantenere la sinistra"
+
+msgid "Walk"
+msgstr "Camminare"
+
+msgid "Keep right"
+msgstr "Mantenere la destra"
+
+msgid "Turn right"
+msgstr "Girare a destra"
+
+#, fuzzy
+#| msgid "Go back"
+msgid "Turn back"
+msgstr "Torna indietro"
+
+msgid "{modifier} on {name}"
+msgstr "{modifier} su {name}"
 
 msgid "Walk on {walkDistance}"
 msgstr "Cammina per {walkDistance}"

--- a/src/panel/direction/RoutesList/Route/RoadMap/WalkLeg/index.jsx
+++ b/src/panel/direction/RoutesList/Route/RoadMap/WalkLeg/index.jsx
@@ -7,6 +7,26 @@ import LegLine from '../LegLine';
 import classnames from 'classnames';
 import { Chevron } from 'src/components/ui';
 
+const stringifyManeuver = maneuver => {
+  const stringifyModifier = {
+    'sharp left': _('Turn left', 'direction'),
+    left: _('Turn left', 'direction'),
+    'slight left': _('Keep left', 'direction'),
+    straight: _('Walk', 'direction'),
+    'slight right': _('Keep right', 'direction'),
+    right: _('Turn right', 'direction'),
+    'sharp right': _('Turn right', 'direction'),
+    uturn: _('Turn back', 'direction'),
+  };
+
+  const context = {
+    modifier: stringifyModifier[maneuver.modifier],
+    name: maneuver.detail.name,
+  };
+
+  return maneuver.detail.name ? _('{modifier} on {name}', 'direction', context) : context.modifier;
+};
+
 const WalkLeg = ({ leg }) => {
   const [detailsOpen, setDetailsOpen] = useState(false);
   const summary = _('Walk on {walkDistance}', 'direction', {
@@ -39,7 +59,7 @@ const WalkLeg = ({ leg }) => {
           {leg.steps.map((step, index) => (
             <div key={index} className="itinerary_roadmap_substep">
               <RoadMapIcon iconClass={getStepIcon(step)} />
-              <div>{step.maneuver.instruction}</div>
+              <div>{step.maneuver.instruction || stringifyManeuver(step.maneuver)}</div>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Description
Add stringified instructions when they are not provided for walking steps on public transport directions.

:warning: This PR is based on #1369 in order to get a shorter diff, make sure it is merged before.

| master | HEAD |
|-|-|
| ![Screen Shot 2022-07-12 at 14 20 35](https://user-images.githubusercontent.com/1173464/178488534-554a3efd-60e3-45a2-8515-d91bbd56ffd7.png) | ![Screen Shot 2022-07-12 at 14 18 13](https://user-images.githubusercontent.com/1173464/178488571-3ea82606-84e6-48fc-8fe1-6c9ed2b4e374.png) |

## Languages

 - [x] English
 - [x] French
 - [x] German
 - [x] Italian
 - [x] Spanish

## Bummers

First, in french translations this naïve approach will get us "Tournez à doite sur Avenue de la Paix" instead of "Tournez à droite sur l'Avenue de la Paix". We could maybe try to be smarter but I think we will either have to cover a large range of specific cases or make something more generic that would expose us to even weirder edge cases.

Second, on some cases there are several consecutive instructions with no road name, which lead to show several consecutive lines of "Walk" to the user. However I don't think it is a topic for this PR, the API should probably be responsible of merging consecutive irrelevant parts.