### PR TITLE
QMAPS-2749 save preferred itinerary vehicle in localStorage

### DIFF
--- a/src/panel/direction/index.jsx
+++ b/src/panel/direction/index.jsx
@@ -20,6 +20,7 @@ import { openPendingDirectionModal } from 'src/modals/GeolocationModal';
 import { updateQueryString } from 'src/libs/url_utils';
 import isEmpty from 'lodash.isempty';
 import { usePageTitle, useDevice } from 'src/hooks';
+import { useStore } from 'src/store';
 
 class DirectionPanel extends React.Component {
   static propTypes = {
@@ -31,6 +32,8 @@ class DirectionPanel extends React.Component {
     activeRouteId: PropTypes.number,
     details: PropTypes.bool,
     isMobile: PropTypes.bool,
+    defaultVehicle: PropTypes.string,
+    setDefaultVehicle: PropTypes.func,
   };
 
   static defaultProps = {
@@ -45,7 +48,7 @@ class DirectionPanel extends React.Component {
       this.vehicles.splice(1, 0, modes.PUBLIC_TRANSPORT);
     }
 
-    const activeVehicle = this.vehicles.indexOf(props.mode) !== -1 ? props.mode : modes.DRIVING;
+    const activeVehicle = props.mode || props.defaultVehicle;
 
     this.lastQueryId = 0;
 
@@ -244,6 +247,7 @@ class DirectionPanel extends React.Component {
   onSelectVehicle = vehicle => {
     Telemetry.add(Telemetry[`${('itinerary_mode_' + vehicle).toUpperCase()}`]);
     this.setState({ vehicle, isDirty: true }, this.update);
+    this.props.setDefaultVehicle(vehicle);
   };
 
   onClose = () => {
@@ -416,7 +420,15 @@ class DirectionPanel extends React.Component {
 const DirectionPanelFunc = props => {
   usePageTitle(_('Directions'));
   const { isMobile } = useDevice();
-  return <DirectionPanel isMobile={isMobile} {...props} />;
+  const { defaultVehicle, setDefaultVehicle } = useStore();
+  return (
+    <DirectionPanel
+      isMobile={isMobile}
+      defaultVehicle={defaultVehicle}
+      setDefaultVehicle={setDefaultVehicle}
+      {...props}
+    />
+  );
 };
 
 export default DirectionPanelFunc;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -12,9 +12,9 @@ export const useStore = create<AppState>(
     })),
     {
       name: 'qmaps-persist',
-      // Store isn't persisted by default - you need to do it case by case
-      // Add here portion of state that should be persisted
-      partialize: () => ({}),
+      // Store isn't persisted by default in localStorage
+      // The partialize method indicates which state entries should persist:
+      partialize: state => ({ defaultVehicle: state.defaultVehicle }),
     }
   )
 );

--- a/src/store/slices/ui.ts
+++ b/src/store/slices/ui.ts
@@ -21,7 +21,7 @@ export const createUiSlice = (set: NamedSet<AppState>, get: GetState<AppState>):
   isMenuDrawerOpen: false,
   isProductsDrawerOpen: false,
   isSearchInputTyping: false,
-  defaultVehicle: modes.WALKING,
+  defaultVehicle: modes.DRIVING,
   setMenuDrawerOpen: isOpen =>
     set(
       () => {

--- a/src/store/slices/ui.ts
+++ b/src/store/slices/ui.ts
@@ -3,21 +3,25 @@ import { onDrawerChange } from 'src/libs/url_utils';
 import { MenuType } from 'src/panel/Menu';
 import { GetState, State } from 'zustand';
 import { NamedSet } from 'zustand/middleware';
+import { modes } from 'src/adapters/direction_api';
 import { AppState } from '..';
 
 export interface UiSlice extends State {
   isMenuDrawerOpen: boolean;
   isProductsDrawerOpen: boolean;
   isSearchInputTyping: boolean;
+  defaultVehicle: string;
   setMenuDrawerOpen: (isOpen: boolean) => void;
   setProductsDrawerOpen: (isOpen: boolean) => void;
   setSearchInputTyping: (isSearchInputTyping: boolean) => void;
+  setDefaultVehicle: (defaultVehicle: string) => void;
 }
 
 export const createUiSlice = (set: NamedSet<AppState>, get: GetState<AppState>): UiSlice => ({
   isMenuDrawerOpen: false,
   isProductsDrawerOpen: false,
   isSearchInputTyping: false,
+  defaultVehicle: modes.WALKING,
   setMenuDrawerOpen: isOpen =>
     set(
       () => {
@@ -43,5 +47,13 @@ export const createUiSlice = (set: NamedSet<AppState>, get: GetState<AppState>):
       },
       false,
       'UI/setSearchInputTyping'
+    ),
+  setDefaultVehicle: defaultVehicle =>
+    set(
+      () => {
+        return { defaultVehicle };
+      },
+      false,
+      'UI/setDefaultVehicle'
     ),
 });


### PR DESCRIPTION
## Description

- first visit: default directions vehicle is car (driving)
- if the user changes vehicle when they compute their route, the last selected vehicle is saved in localStorage
- next visit: default vehicle is the one present in localStorage
- if the user visits an url that contains "?mode={vehicle}", then this vehicle is used instead of the value present in localStorage.

![image](https://user-images.githubusercontent.com/1225909/179523655-8b86e828-13cf-4ca8-b380-90b011075dd4.png)
