### PR TITLE
QMAPS-2075 better display of minutes < 10 for itineraries < 10h

### DIFF
--- a/src/libs/route_utils.js
+++ b/src/libs/route_utils.js
@@ -13,8 +13,8 @@ export function formatDuration(sec) {
   const hour = Math.floor(min / 60);
   min = min - 60 * hour;
   let ret = `${hour} h`;
-  if (min > 0 && hour < 10) {
-    ret += ` ${min < 10 ? '0' : ''}${min}`;
+  if (hour < 10) {
+    ret += ' ' + min.toString().padStart(2, '0');
   }
   return ret;
 }

--- a/src/libs/route_utils.js
+++ b/src/libs/route_utils.js
@@ -14,7 +14,7 @@ export function formatDuration(sec) {
   min = min - 60 * hour;
   let ret = `${hour} h`;
   if (hour < 10) {
-    ret += ' ' + min.toString().padStart(2, '0');
+    ret += ' ' + min.toString().padStart(2, '0');
   }
   return ret;
 }

--- a/tests/units/route_utils.js
+++ b/tests/units/route_utils.js
@@ -7,7 +7,7 @@ describe('route_utils', () => {
       { seconds: 0, result: '1 min' },
       { seconds: 37, result: '1 min' },
       { seconds: 125, result: '2 min' },
-      { seconds: 3600, result: '1 h' },
+      { seconds: 3600, result: '1 h 00' },
       { seconds: 5100, result: '1 h 25' },
       { seconds: 36000, result: '10 h' },
     ];


### PR DESCRIPTION
## Description
Itineraries > 1h and < 10h must show the minutes number on 2 digits, even if it's < 10

Ex: 1h06, 1h00

![image](https://user-images.githubusercontent.com/1225909/180744492-766facb7-d099-4e00-9b92-5629455d1a68.png)
