### PR TITLE
QMAPS-2785 mobile throttling

### DIFF
--- a/src/components/ui/Suggest.jsx
+++ b/src/components/ui/Suggest.jsx
@@ -376,7 +376,7 @@ const Suggest = ({
         onBlur: () => {
           // The mouseLeave flag allows to keep the suggest open when clicking outside of the browser
           if (!window.mouseLeave) {
-            setHasFocus(false, 150);
+            setHasFocus(false, isMobile ? 300 : 150);
           }
         },
         highlightedValue: highlighted ? getInputValue(highlighted) : null,


### PR DESCRIPTION
## Description

NB: this is a temp fix, to be replaced with a global click state store that will do the right thing instead of depending on onBlur.

Set a 300ms blur timeout on mobile on the suggest. Keep 150ms on desktop.
300ms is the click / blur registration time on many mobile browsers, so it should be fine.
I couldn't test this fix on PC because the bug is never present on PC even in mobile mode + CPU throttling,
so let's deploy it in dev and test on real mobile?


