### PR TITLE
QMAPS-2129 add startAt / arriveBy options in public transports (draft / poc)

### DIFF
--- a/src/adapters/direction_api.js
+++ b/src/adapters/direction_api.js
@@ -48,18 +48,20 @@ const modeToProfile = {
 };
 
 export default class DirectionApi {
-  static async search(start, end, mode) {
+  static async search(start, end, mode, startAt, arriveBy) {
     if (mode === modes.CYCLING) {
       // Fetch routes without ferry in priority
-      const firstSearch = await DirectionApi._search(start, end, mode, { exclude: 'ferry' });
+      const firstSearch = await DirectionApi._search(start, end, mode, null, null, {
+        exclude: 'ferry',
+      });
       if (firstSearch.data && firstSearch.data.routes && firstSearch.data.routes.length > 0) {
         return firstSearch;
       }
     }
-    return DirectionApi._search(start, end, mode);
+    return DirectionApi._search(start, end, mode, startAt, arriveBy);
   }
 
-  static async _search(start, end, mode, { exclude = '' } = {}) {
+  static async _search(start, end, mode, startAt, arriveBy, { exclude = '' } = {}) {
     const apiProfile = modeToProfile[mode];
     let directionsUrl = directionConfig.apiBaseUrl;
     const userLang = window.getLang();
@@ -92,6 +94,8 @@ export default class DirectionApi {
     }
     const s_start = poiToMapBoxCoordinates(start);
     const s_end = poiToMapBoxCoordinates(end);
+    if (startAt) directionsParams.depart_at = startAt;
+    if (arriveBy) directionsParams.arrive_by = arriveBy;
     directionsUrl = `${directionsUrl}${s_start};${s_end}`;
     let response = null;
     try {

--- a/src/panel/direction/DirectionForm/index.jsx
+++ b/src/panel/direction/DirectionForm/index.jsx
@@ -19,6 +19,9 @@ const DirectionForm = ({
   isInitializing,
   originInputText,
   destinationInputText,
+  onStartNow,
+  onStartAt,
+  onArriveBy,
 }) => {
   const { _ } = useI18n();
   const { isMobile } = useDevice();
@@ -93,6 +96,27 @@ const DirectionForm = ({
           <IconArrowUpDown fill="currentColor" />
         </Button>
       </form>
+      {activeVehicle === 'publicTransport' && (
+        <div className="poc">
+          <p>
+            Start now <button onClick={onStartNow}>GO</button>
+          </p>
+          <p>
+            or: Start at <input type="datetime-local" id="start_at" />{' '}
+            <button onClick={() => onStartAt(+new Date(document.querySelector('#start_at').value))}>
+              GO
+            </button>
+          </p>
+          <p>
+            or: Arrive by <input type="datetime-local" id="arrive_by" />{' '}
+            <button
+              onClick={() => onArriveBy(+new Date(document.querySelector('#arrive_by').value))}
+            >
+              GO
+            </button>
+          </p>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/panel/direction/RouteSummaryInfo/RouteStartEndTimes/index.tsx
+++ b/src/panel/direction/RouteSummaryInfo/RouteStartEndTimes/index.tsx
@@ -17,10 +17,13 @@ const RouteStartEndTimes: React.FunctionComponent<RouteStartEndTimesProps> = ({
     return null;
   }
 
+  const dateFormatter = getTimeFormatter({ month: '2-digit', day: '2-digit' });
   const timeFormatter = getTimeFormatter({ hour: '2-digit', minute: '2-digit' });
 
   return (
     <div className={cx('u-bold', className)}>
+      {dateFormatter.format(new Date(stripTimeZone(start)))}
+      {' - '}
       {timeFormatter.format(new Date(stripTimeZone(start)))}
       {' - '}
       {timeFormatter.format(new Date(stripTimeZone(end)))}

--- a/src/panel/direction/index.jsx
+++ b/src/panel/direction/index.jsx
@@ -65,6 +65,8 @@ class DirectionPanel extends React.Component {
       isInitializing: true,
       originInputText: '',
       destinationInputText: '',
+      startAt: null,
+      arriveBy: null,
     };
 
     this.restorePoints(props);
@@ -180,7 +182,7 @@ class DirectionPanel extends React.Component {
   }
 
   computeRoutes = async () => {
-    const { origin, destination, vehicle } = this.state;
+    const { origin, destination, vehicle, startAt, arriveBy } = this.state;
     if (origin && destination) {
       this.setState({
         isDirty: false,
@@ -191,7 +193,13 @@ class DirectionPanel extends React.Component {
       const currentQueryId = ++this.lastQueryId;
       fire('set_origin', origin);
       fire('set_destination', destination);
-      const directionResponse = await DirectionApi.search(origin, destination, vehicle);
+      const directionResponse = await DirectionApi.search(
+        origin,
+        destination,
+        vehicle,
+        startAt,
+        arriveBy
+      );
       // A more recent query was done in the meantime, ignore this result silently
       if (currentQueryId !== this.lastQueryId) {
         return;
@@ -330,6 +338,21 @@ class DirectionPanel extends React.Component {
     }
   };
 
+  startNow = () => {
+    this.setState({ startAt: null, arriveBy: null }, this.update);
+    this.computeRoutes();
+  };
+
+  startAt = datetime => {
+    this.setState({ startAt: datetime, arriveBy: null }, this.update);
+    this.computeRoutes();
+  };
+
+  arriveBy = datetime => {
+    this.setState({ startAt: null, arriveBy: datetime }, this.update);
+    this.computeRoutes();
+  };
+
   render() {
     const {
       origin,
@@ -361,6 +384,9 @@ class DirectionPanel extends React.Component {
         onSelectVehicle={this.onSelectVehicle}
         activeVehicle={vehicle}
         isInitializing={isInitializing}
+        onStartNow={this.startNow}
+        onStartAt={this.startAt}
+        onArriveBy={this.arriveBy}
       />
     );
 

--- a/src/scss/includes/direction-form.scss
+++ b/src/scss/includes/direction-form.scss
@@ -1,6 +1,15 @@
 @import './vehicleSelector.scss';
 
 .direction-form {
+
+  .poc p {
+    margin: 5px 0;
+  }
+  .poc input, .poc button {
+    border: 1px solid #000;
+  }
+
+
   display: flex;
   flex-direction: column;
   padding: var(--spacing-m);


### PR DESCRIPTION
- if public transport is enabled, show 3 forms under the direction form (ugly draft, while waiting for final design!)
![image](https://user-images.githubusercontent.com/1225909/181275282-d7472476-0234-4c9a-8a32-edf64fa721d9.png)

- Pressing "GO"  after "start now" updates the URL and computes a route that starts now. (as usual)
![image](https://user-images.githubusercontent.com/1225909/181275650-3488985a-5898-475b-86fb-4f66cd62246f.png)

- Choosing a date/time and pressing "GO"  after "start at" updates the URL and computes a route that starts after that date/time
![image](https://user-images.githubusercontent.com/1225909/181276469-c46ffc04-ca53-4285-b222-10097c370d99.png)

- Choosing a date/time and pressing "GO"  after "arrive by" updates the URL and computes a route that arrives before that date/time
![image](https://user-images.githubusercontent.com/1225909/181276881-c021aea5-6847-4bf5-8d58-b6b91e67d4f2.png)

NB: I added the date in the routes summaries. It's a suggestion for Design, to remind people which day the route starts

Not done yet:

- handle date out of bounds errors
- custom calendar
- use Zustand to handle optional start/end dates