### PR TITLE
Make front compatible with intention api field

### DIFF
--- a/src/adapters/geocoder.js
+++ b/src/adapters/geocoder.js
@@ -71,7 +71,7 @@ export function getGeocoderSuggestions(term, { focus = {}, useNlu = false } = {}
     }
     suggestsPromise = ajax.get(geocoderUrl, query);
     suggestsPromise
-      .then(({ features, intentions }) => {
+      .then(({ features, intention }) => {
         const pois = features.map((feature, index) => {
           const queryContext = new QueryContext(
             term,
@@ -82,10 +82,11 @@ export function getGeocoderSuggestions(term, { focus = {}, useNlu = false } = {}
           return new BragiPoi(feature, queryContext);
         });
         const bragiResponse = { pois };
-        if (intentions) {
-          bragiResponse.intentions = intentions
-            .map(intention => new Intention(intention))
-            .filter(intention => intention.isValid());
+        if (intention) {
+          const parsed = new Intention(intention);
+          if (parsed.isValid()) {
+            bragiResponse.intentions = [parsed];
+          }
         }
         bragiCache[cacheKey] = bragiResponse;
         resolve(bragiResponse);


### PR DESCRIPTION
## Description
API return `intention` instead of `intentions` field. Need to be merge for new Idunn api version that return a `intention` field

## Why
Because there is a maximum of 1 intention return by the back end
