### PR TITLE
fix transparent topbar borders for mobile

### DIFF
--- a/src/scss/includes/search_form.scss
+++ b/src/scss/includes/search_form.scss
@@ -10,7 +10,7 @@ $input-height: 48px;
   align-items: center;
   background: var(--green-400) !important;
   border: 1px solid var(--grey-900-alpha16);
-  border-radius: var(--spacing-xs)
+  border-radius: 0 0 var(--spacing-xs) var(--spacing-xs);
 }
 
 // Wrapper around the field and some icons, gets a colored border when the field is focused

--- a/src/scss/includes/top_bar.scss
+++ b/src/scss/includes/top_bar.scss
@@ -21,7 +21,7 @@
     top: 0;
     left: 0;
     width: 100%;
-    border-radius: 0;
+    border-radius: 0 0 var(--spacing-xs) var(--spacing-xs);
     box-shadow: 
       0 2px 16px 0 rgba(12, 12, 14, 0.2),
       0 4px 8px 0 rgba(12, 12, 14, 0.12);


### PR DESCRIPTION


## Description

The topbar was displayed with weird white corners on top and the bottom
corners were also displayed in white instead of transparent.

This was not affecting desktop view.


## Screenshots

| before | after |
|-|-|
| ![Screen Shot 2022-08-30 at 14 01 00](https://user-images.githubusercontent.com/1173464/187458003-444d2bdc-4b42-4c5f-8583-34e410c087c5.png) | ![Screen Shot 2022-08-30 at 14 00 51](https://user-images.githubusercontent.com/1173464/187458013-de4fd8dc-8eea-4f81-a465-7ae5ccca45ea.png) |