### PR TITLE
QMAPS-2850 scroll to selected route

### DIFF
--- a/src/panel/direction/RoutesList/Route/index.jsx
+++ b/src/panel/direction/RoutesList/Route/index.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect } from 'react';
 import RouteSummary from './RouteSummary';
 import RoadMap from './RoadMap';
 
@@ -14,9 +14,19 @@ const Route = ({
   selectRoute,
   isMobile,
 }) => {
+  const itemRef = React.useRef(null);
+
+  useEffect(() => {
+    if (isActive) {
+      itemRef.current.scrollIntoView({
+        behavior: 'smooth',
+      });
+    }
+  }, [isActive]);
+
   return (
     <Fragment>
-      <div className={`itinerary_leg ${isActive ? 'itinerary_leg--active' : ''}`}>
+      <div className={`itinerary_leg ${isActive ? 'itinerary_leg--active' : ''}`} ref={itemRef}>
         <RouteSummary
           id={id}
           route={route}


### PR DESCRIPTION
## Description
When selecting a route from the list or from the map, if this route is not entirely visible into the list, scroll smoothly to it.
NB: some Safari versions may not support the smooth option and will scroll directly to the right place instead.
![image](https://user-images.githubusercontent.com/1225909/187714806-fc716d41-c7ec-4010-80bf-6729e3545c2c.png)
![image](https://user-images.githubusercontent.com/1225909/187714887-f76f44aa-f9bc-41d4-b25d-3f6a1b305e1a.png)
