### PR TITLE
QMAPS-2854 make inactive labels smaller (PT directions)

### DIFF
--- a/src/scss/includes/routeLabel.scss
+++ b/src/scss/includes/routeLabel.scss
@@ -1,5 +1,9 @@
 .routeLabel-marker {
   z-index: 1;
+  
+  & > :not(.active) {
+    transform: scale(.75);
+  }
 }
 
 .routeLabel {


### PR DESCRIPTION
## Description

Make inactive PT labels 25% smaller 

Do not merge before Design approval

![image](https://user-images.githubusercontent.com/1225909/188892248-5f0017e0-575b-4b32-a78c-886c811515c3.png)

