### PR TITLE
Fix logo ratio in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Erdapfel
 
 <h1 align="center">
-  <img src="https://github.com/Qwant/qwantmaps/raw/master/images/logo.png" alt="QwantMaps" width="200" height="200" />
+  <img src="https://github.com/Qwant/qwantmaps/raw/master/images/logo.png" alt="QwantMaps" height="200" />
 </h1>
 
 


### PR DESCRIPTION
## Description

Fix logo ratio in README.md by removing with incorrect width attribute.

## Why

Because it looks pretty 💅


