### PR TITLE
Update lat/lon precision according to the zoom level

### DIFF
--- a/@types/config.ts
+++ b/@types/config.ts
@@ -3,7 +3,7 @@ export interface Geocoder {
   useLang: boolean;
   maxItems: number;
   useFocus: boolean;
-  focusPrecision: string;
+  focusPrecision: Array<[string, string]>;
   focusZoomPrecision: string;
   focusMinZoom: number;
   useNlu: boolean;

--- a/@types/config.ts
+++ b/@types/config.ts
@@ -5,7 +5,6 @@ export interface Geocoder {
   useFocus: boolean;
   focusPrecision: Array<[string, string]>;
   focusZoomPrecision: string;
-  focusMinZoom: number;
   useNlu: boolean;
 }
 

--- a/@types/config.ts
+++ b/@types/config.ts
@@ -3,9 +3,14 @@ export interface Geocoder {
   useLang: boolean;
   maxItems: number;
   useFocus: boolean;
-  focusPrecision: Array<[string, string]>;
+  focusPrecision: Array<ZoomPrecision>;
   focusZoomPrecision: string;
   useNlu: boolean;
+}
+
+export interface ZoomPrecision {
+  zoom: string;
+  precision: string;
 }
 
 export interface Idunn {

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -30,9 +30,8 @@ services:
     useLang: true
     maxItems: 7
     useFocus: true
-    focusPrecision: [{"zoom":'7',"precision":'0.1'},{"zoom":'11',"precision":'0.01'},{"zoom":'14',"precision":'0.001'}] # lat/lon degrees
+    focusPrecision: '[{"zoom":"7","precision":"0.1"},{"zoom":"11","precision":"0.01"},{"zoom":"14","precision":"0.001"}]' # lat/lon degrees
     focusZoomPrecision: '1.0'
-    focusMinZoom: 7
     useNlu: false
   idunn:
     url: override_by_environment

--- a/config/default_config.yml
+++ b/config/default_config.yml
@@ -30,7 +30,7 @@ services:
     useLang: true
     maxItems: 7
     useFocus: true
-    focusPrecision: '0.1' # lat/lon degrees
+    focusPrecision: [{"zoom":'7',"precision":'0.1'},{"zoom":'11',"precision":'0.01'},{"zoom":'14',"precision":'0.001'}] # lat/lon degrees
     focusZoomPrecision: '1.0'
     focusMinZoom: 7
     useNlu: false

--- a/src/adapters/geocoder.js
+++ b/src/adapters/geocoder.js
@@ -6,7 +6,6 @@ import Intention from './intention';
 
 const serviceConfigs = nconf.get().services;
 const {
-  focusMinZoom,
   focusPrecision,
   focusZoomPrecision,
   maxItems,
@@ -30,16 +29,17 @@ function getFocusParams({ lat, lon, zoom }) {
   if (lat === undefined || lon === undefined || zoom === undefined) {
     return null;
   }
-  if (zoom < Number(focusMinZoom)) {
-    return null;
-  }
+
   // Get the precision specific to a zoom level
-  const zoomFocusPrecision = focusPrecision
+  const zoomFocusPrecision = JSON.parse(focusPrecision)
     .filter(zp => zoom > zp.zoom)
     .map(zp => zp.precision)
     .sort()
     .shift();
 
+  if (zoomFocusPrecision === undefined) {
+    return null;
+  }
   return {
     lat: roundWithPrecision(lat, zoomFocusPrecision),
     lon: roundWithPrecision(lon, zoomFocusPrecision),

--- a/src/adapters/geocoder.js
+++ b/src/adapters/geocoder.js
@@ -33,9 +33,16 @@ function getFocusParams({ lat, lon, zoom }) {
   if (zoom < Number(focusMinZoom)) {
     return null;
   }
+  // Get the precision specific to a zoom level
+  const zoomFocusPrecision = focusPrecision
+    .filter(zp => zoom > zp.zoom)
+    .map(zp => zp.precision)
+    .sort()
+    .shift();
+
   return {
-    lat: roundWithPrecision(lat, focusPrecision),
-    lon: roundWithPrecision(lon, focusPrecision),
+    lat: roundWithPrecision(lat, zoomFocusPrecision),
+    lon: roundWithPrecision(lon, zoomFocusPrecision),
     zoom: roundWithPrecision(zoom, focusZoomPrecision),
   };
 }


### PR DESCRIPTION
## Description
Update latitude & longitude precision according to the zoom level. More the user zoom, bigger the precision is.

## Why
In order to have closer suggestion result of the zoomed bounding box