### PR TITLE
use class name for categories in impact POIs

### DIFF
--- a/src/components/PoiItem.jsx
+++ b/src/components/PoiItem.jsx
@@ -15,9 +15,11 @@ const PoiItem = React.memo(
   ({ poi, withOpeningHours, withImage, withAlternativeName, className, inList, ...rest }) => {
     const reviews = poi.blocksByType?.grades;
     const { _ } = useI18n();
-    const subclass = capitalizeFirst(poiSubClass(poi.subClassName));
-    const stars = findBlock(poi.blocks, 'stars');
     const isEcoResponsible = findBlock(poi.blocks, 'ecoresponsible') !== null;
+    const subclass = capitalizeFirst(
+      isEcoResponsible ? poiSubClass(poi.className) : poiSubClass(poi.subClassName)
+    );
+    const stars = findBlock(poi.blocks, 'stars');
     const openingHours = withOpeningHours && poi?.blocksByType?.opening_hours;
     const texts = {
       opening_hours: _('opening hours'),


### PR DESCRIPTION
Becaused we use a hacky subclass to get corresponding icon on impact POIs they are displayed with weird category names (eg. florist for circuits courts).

This change uses the class name instead of subclass name for impact POIs so that the displayed category name is correct while keeping the same icon.
