### PR TITLE
add knowledge claims in POI pannel

### DIFF
--- a/@types/idunn.ts
+++ b/@types/idunn.ts
@@ -465,9 +465,21 @@ export interface components {
       type?: 'description';
       /** Description */
       description: string;
+      /**
+       * Claims
+       * @default []
+       */
+      claims?: components['schemas']['DescriptionClaim'][];
       source: components['schemas']['DescriptionSources'];
       /** Url */
       url?: string;
+    };
+    /** DescriptionClaim */
+    DescriptionClaim: {
+      /** Label */
+      label: string;
+      /** Value */
+      value: string;
     };
     /** DescriptionEvent */
     DescriptionEvent: {
@@ -491,7 +503,7 @@ export interface components {
      * @description An enumeration.
      * @enum {undefined}
      */
-    DescriptionSources: 'osm' | 'pagesjaunes' | 'wikipedia';
+    DescriptionSources: 'osm' | 'pagesjaunes' | 'wikipedia' | 'knowledge';
     /** DirectionsData */
     DirectionsData: {
       /** Routes */
@@ -1615,12 +1627,6 @@ export interface components {
        */
       location: [number, number];
     };
-    /**
-     * Type
-     * @description An enumeration.
-     * @enum {string}
-     */
-    Type: 'house' | 'poi' | 'public_transport:stop_area' | 'street' | 'zone';
     /** ValidationError */
     ValidationError: {
       /** Location */
@@ -1989,7 +1995,7 @@ export interface operations {
         /** Filter type of documents raised from inside of the shape. */
         shape_scope?: components['schemas']['PlaceDocType'][];
         /** Filter on type of document. */
-        type?: components['schemas']['Type'][];
+        type?: string[];
         /** Filter on type of zone. */
         zone_type?: components['schemas']['ZoneType'][];
         /** Filter on type of POI. */
@@ -2011,6 +2017,12 @@ export interface operations {
         zoom?: number;
         /** Perform NLU analysis to extract location and intention from the request. */
         nlu?: boolean;
+        /** Search only exact match */
+        is_exact_match?: boolean;
+        /** Filter to get only hotel poi */
+        is_hotel_filter?: boolean;
+        /** Filter famous poi. If it's a OSM, it needs a wikidata field.Still nothing done for tripadvisor */
+        is_famous_poi?: boolean;
       };
       header: {
         'x-client-hash'?: string;
@@ -2053,7 +2065,7 @@ export interface operations {
         /** Filter type of documents raised from inside of the shape. */
         shape_scope?: components['schemas']['PlaceDocType'][];
         /** Filter on type of document. */
-        type?: components['schemas']['Type'][];
+        type?: string[];
         /** Filter on type of zone. */
         zone_type?: components['schemas']['ZoneType'][];
         /** Filter on type of POI. */
@@ -2075,6 +2087,12 @@ export interface operations {
         zoom?: number;
         /** Perform NLU analysis to extract location and intention from the request. */
         nlu?: boolean;
+        /** Search only exact match */
+        is_exact_match?: boolean;
+        /** Filter to get only hotel poi */
+        is_hotel_filter?: boolean;
+        /** Filter famous poi. If it's a OSM, it needs a wikidata field.Still nothing done for tripadvisor */
+        is_famous_poi?: boolean;
       };
       header: {
         'x-client-hash'?: string;
@@ -2173,3 +2191,5 @@ export interface operations {
     };
   };
 }
+
+export interface external {}

--- a/src/libs/miniMarkdown.ts
+++ b/src/libs/miniMarkdown.ts
@@ -14,18 +14,26 @@ export enum textType {
 }
 
 export type textLink = {
-  type: textType;
+  type: textType.Link;
   text: string;
   url: string;
 };
 
 export type textRaw = {
-  type: textType;
+  type: textType.Raw;
   text: string;
 };
 
 export type textElement = textLink | textRaw;
 
+// Parse a simple text with markdown formatted links and return an array of `textElement`.
+//
+// For example with text "Hello, [World](https://perdu.com)!" it returns the following array:
+// [
+//     { type: 'Raw', text: 'Hello, ' },
+//     { type: 'Link', text: 'World', url: 'https://perdu.com/' },
+//     { type: 'Raw', text: '!' },
+// ]
 export function parseText(raw: string): textElement[] {
   // Build elements for chunks of the raw value, with specific handling for links
   //
@@ -41,16 +49,18 @@ export function parseText(raw: string): textElement[] {
   //     <a href="https://b">a</a>,
   //     <a href="https://d">c</a>
   // ];
-  const texts = raw.split(urlPattern).map(text => ({
+  const texts: textElement[] = raw.split(urlPattern).map(text => ({
     type: textType.Raw,
     text,
   }));
 
-  const links = Array.from(raw.matchAll(urlPatternWithCapture)).map(([, text, url]) => ({
-    type: textType.Link,
-    text,
-    url,
-  }));
+  const links: textElement[] = Array.from(raw.matchAll(urlPatternWithCapture)).map(
+    ([, text, url]) => ({
+      type: textType.Link,
+      text,
+      url,
+    })
+  );
 
   // Put the elements from texts and links in order to reflect original content.
   const content = Array.from(Array(texts.length + links.length).keys())

--- a/src/libs/miniMarkdown.ts
+++ b/src/libs/miniMarkdown.ts
@@ -1,0 +1,66 @@
+// Build a regexp that matches links in the form [text](url), optionaly with or
+// without capture groups.
+function buildUrlPattern(capture: boolean): RegExp {
+  const group = (inner: string) => '(' + (capture ? '' : '?:') + inner + ')';
+  return RegExp('\\[' + group('[^\\]]*') + '\\]\\(' + group('[^\\)]*') + '\\)', 'g');
+}
+
+const urlPattern = buildUrlPattern(false);
+const urlPatternWithCapture = buildUrlPattern(true);
+
+export enum textType {
+  Raw = 'Raw',
+  Link = 'Link',
+}
+
+export type textLink = {
+  type: textType;
+  text: string;
+  url: string;
+};
+
+export type textRaw = {
+  type: textType;
+  text: string;
+};
+
+export type textElement = textLink | textRaw;
+
+export function parseText(raw: string): textElement[] {
+  // Build elements for chunks of the raw value, with specific handling for links
+  //
+  // For example with "first link: [a](https://b), second link: [c](https://d)":
+  //
+  // texts = [
+  //     <>first link: </>,
+  //     <>, second link:</>,
+  //     <></>
+  // ];
+  //
+  // links = [
+  //     <a href="https://b">a</a>,
+  //     <a href="https://d">c</a>
+  // ];
+  const texts = raw.split(urlPattern).map(text => ({
+    type: textType.Raw,
+    text,
+  }));
+
+  const links = Array.from(raw.matchAll(urlPatternWithCapture)).map(([, text, url]) => ({
+    type: textType.Link,
+    text,
+    url,
+  }));
+
+  // Put the elements from texts and links in order to reflect original content.
+  const content = Array.from(Array(texts.length + links.length).keys())
+    .map(i =>
+      // Note that `texts.lengths == links.length + 1` because links are
+      // separators of text sections.
+      i % 2 === 0 ? texts[i / 2] : links[(i - 1) / 2]
+    )
+    // Cleanup empty text sections
+    .filter(part => !(part.type === 'Raw' && !part.text));
+
+  return content;
+}

--- a/src/libs/miniMarkdown.ts
+++ b/src/libs/miniMarkdown.ts
@@ -8,19 +8,19 @@ function buildUrlPattern(capture: boolean): RegExp {
 const urlPattern = buildUrlPattern(false);
 const urlPatternWithCapture = buildUrlPattern(true);
 
-export enum textType {
+export enum TextType {
   Raw = 'Raw',
   Link = 'Link',
 }
 
 export type textLink = {
-  type: textType.Link;
+  type: TextType.Link;
   text: string;
   url: string;
 };
 
 export type textRaw = {
-  type: textType.Raw;
+  type: TextType.Raw;
   text: string;
 };
 
@@ -50,13 +50,13 @@ export function parseText(raw: string): textElement[] {
   //     <a href="https://d">c</a>
   // ];
   const texts: textElement[] = raw.split(urlPattern).map(text => ({
-    type: textType.Raw,
+    type: TextType.Raw,
     text,
   }));
 
   const links: textElement[] = Array.from(raw.matchAll(urlPatternWithCapture)).map(
     ([, text, url]) => ({
-      type: textType.Link,
+      type: TextType.Link,
       text,
       url,
     })

--- a/src/panel/poi/blocks/Description/index.tsx
+++ b/src/panel/poi/blocks/Description/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { components } from 'appTypes/idunn';
+import { parseText } from '../../../../libs/miniMarkdown';
 
 export type PoiDescriptionBlockProps = {
   block: components['schemas']['DescriptionBlock'];
@@ -11,42 +12,14 @@ export type PoiDescriptionBlockProps = {
   onClick: () => void;
 };
 
-// Build a regexp that matches links in the form [text](url), optionaly with or
-// without capture groups.
-function buildUrlPattern(capture: boolean): RegExp {
-  const group = (inner: string) => '(' + (capture ? '' : '?:') + inner + ')';
-  return RegExp('\\[' + group('[^\\]]*') + '\\]\\(' + group('[^\\)]*') + '\\)', 'g');
-}
-
-const urlPattern = buildUrlPattern(false);
-const urlPatternWithCapture = buildUrlPattern(true);
-
 function parseClaimValue(raw: string): JSX.Element {
-  // Build elements for chunks of the raw value, with specific handling for links
-  //
-  // For example with "first link: [a](https://b), second link: [c](https://d)":
-  //
-  // texts = [
-  //     <>first link: </>,
-  //     <>, second link:</>,
-  //     <></>
-  // ];
-  //
-  // links = [
-  //     <a href="https://b">a</a>,
-  //     <a href="https://d">c</a>
-  // ];
-  const texts = raw.split(urlPattern).map(text => <>{text}</>);
-  const links = Array.from(raw.matchAll(urlPatternWithCapture)).map(([, text, link]) =>
-    link.match(/^https?:\/\//) ? <a href={link}>{text}</a> : <span>{text}</span>
-  );
-
-  // Put the elements from texts and links in order to reflect original content.
-  const content = Array.from(Array(texts.length + links.length).keys()).map(i =>
-    // Note that `texts.lengths == links.length + 1` because links are
-    // separators of text sections.
-    i % 2 === 0 ? texts[i / 2] : links[(i - 1) / 2]
-  );
+  const content = parseText(raw).map(part => {
+    if ('url' in part) {
+      return <a href={part.url}>{part.text}</a>;
+    } else {
+      return <span>{part.text}</span>;
+    }
+  });
 
   return <>{content}</>;
 }

--- a/src/panel/poi/blocks/Description/index.tsx
+++ b/src/panel/poi/blocks/Description/index.tsx
@@ -39,13 +39,15 @@ const PoiDescriptionBlock: React.FunctionComponent<PoiDescriptionBlockProps> = (
           </a>
         )}
       </div>
-      <ul className="block-description-extra">
-        {(block.claims ?? []).map(claim => (
-          <li key={claim.label}>
-            <strong>{claim.label} :</strong> {parseClaimValue(claim.value)}
-          </li>
-        ))}
-      </ul>
+      {block.claims?.length && (
+        <ul className="block-description-extra">
+          {block.claims.map(claim => (
+            <li key={claim.label}>
+              <strong>{claim.label} :</strong> {parseClaimValue(claim.value)}
+            </li>
+          ))}
+        </ul>
+      )}
     </>
   );
 };

--- a/src/panel/poi/blocks/Description/index.tsx
+++ b/src/panel/poi/blocks/Description/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { components } from 'appTypes/idunn';
-import { textType, parseText } from '../../../../libs/miniMarkdown';
+import { TextType, parseText } from '../../../../libs/miniMarkdown';
 
 export type PoiDescriptionBlockProps = {
   block: components['schemas']['DescriptionBlock'];
@@ -15,9 +15,9 @@ export type PoiDescriptionBlockProps = {
 function parseClaimValue(raw: string): JSX.Element {
   const content = parseText(raw).map(part => {
     switch (part.type) {
-      case textType.Raw:
+      case TextType.Raw:
         return <span>{part.text}</span>;
-      case textType.Link:
+      case TextType.Link:
         return <a href={part.url}>{part.text}</a>;
     }
   });

--- a/src/panel/poi/blocks/Description/index.tsx
+++ b/src/panel/poi/blocks/Description/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { components } from 'appTypes/idunn';
-import { parseText } from '../../../../libs/miniMarkdown';
+import { textType, parseText } from '../../../../libs/miniMarkdown';
 
 export type PoiDescriptionBlockProps = {
   block: components['schemas']['DescriptionBlock'];
@@ -14,10 +14,11 @@ export type PoiDescriptionBlockProps = {
 
 function parseClaimValue(raw: string): JSX.Element {
   const content = parseText(raw).map(part => {
-    if ('url' in part) {
-      return <a href={part.url}>{part.text}</a>;
-    } else {
-      return <span>{part.text}</span>;
+    switch (part.type) {
+      case textType.Raw:
+        return <span>{part.text}</span>;
+      case textType.Link:
+        return <a href={part.url}>{part.text}</a>;
     }
   });
 

--- a/src/panel/poi/blocks/Description/index.tsx
+++ b/src/panel/poi/blocks/Description/index.tsx
@@ -11,20 +11,69 @@ export type PoiDescriptionBlockProps = {
   onClick: () => void;
 };
 
+// Build a regexp that matches links in the form [text](url), optionaly with or
+// without capture groups.
+function buildUrlPattern(capture: boolean): RegExp {
+  const group = (inner: string) => '(' + (capture ? '' : '?:') + inner + ')';
+  return RegExp('\\[' + group('[^\\]]*') + '\\]\\(' + group('[^\\)]*') + '\\)', 'g');
+}
+
+const urlPattern = buildUrlPattern(false);
+const urlPatternWithCapture = buildUrlPattern(true);
+
+function parseClaimValue(raw: string): JSX.Element {
+  // Build elements for chunks of the raw value, with specific handling for links
+  //
+  // For example with "first link: [a](https://b), second link: [c](https://d)":
+  //
+  // texts = [
+  //     <>first link: </>,
+  //     <>, second link:</>,
+  //     <></>
+  // ];
+  //
+  // links = [
+  //     <a href="https://b">a</a>,
+  //     <a href="https://d">c</a>
+  // ];
+  const texts = raw.split(urlPattern).map(text => <>{text}</>);
+  const links = Array.from(raw.matchAll(urlPatternWithCapture)).map(([, text, link]) =>
+    link.match(/^https?:\/\//) ? <a href={link}>{text}</a> : <span>{text}</span>
+  );
+
+  // Put the elements from texts and links in order to reflect original content.
+  const content = Array.from(Array(texts.length + links.length).keys()).map(i =>
+    // Note that `texts.lengths == links.length + 1` because links are
+    // separators of text sections.
+    i % 2 === 0 ? texts[i / 2] : links[(i - 1) / 2]
+  );
+
+  return <>{content}</>;
+}
+
 const PoiDescriptionBlock: React.FunctionComponent<PoiDescriptionBlockProps> = ({
   block,
   texts,
   onClick,
 }) => {
   return (
-    <div className="block-description u-mb-m">
-      {block?.description && <p>{block?.description}</p>}
-      {block?.url && (
-        <a rel="noopener noreferrer" target="_blank" href={block?.url} onClick={onClick}>
-          {texts[block.source] || texts.readMore}
-        </a>
-      )}
-    </div>
+    <>
+      <div className="block-description u-mb-m">
+        {block?.description && <p>{block?.description}</p>}
+        {block?.url && (
+          <a rel="noopener noreferrer" target="_blank" href={block?.url} onClick={onClick}>
+            {texts[block.source] || texts.readMore}
+          </a>
+        )}
+      </div>
+      <ul className="block-description-extra">
+        {(block.claims ?? []).map(claim => (
+          <li key={claim.label}>
+            <strong>{claim.label} :</strong> {parseClaimValue(claim.value)}
+          </li>
+        ))}
+      </ul>
+    </>
   );
 };
 

--- a/src/scss/includes/panels/poi_panel.scss
+++ b/src/scss/includes/panels/poi_panel.scss
@@ -117,6 +117,14 @@ $BLOCK_ICON_FONT_SIZE: 16px;
   }
 }
 
+.block-description-extra {
+  margin-bottom: 20px;
+
+  li {
+    margin-bottom: 8px;
+  }
+}
+
 .poi_panel__pictures_tiles {
   position: relative;
   width: 100%;

--- a/tests/units/markdown.js
+++ b/tests/units/markdown.js
@@ -1,6 +1,6 @@
 import { parseText } from '../../src/libs/miniMarkdown';
 
-describe('mini markdown', () => {
+describe('miniMarkdown', () => {
   test('simpleLinks', () => {
     const cases = [
       { input: 'Hello, World!', output: [{ type: 'Raw', text: 'Hello, World!' }] },

--- a/tests/units/markdown.js
+++ b/tests/units/markdown.js
@@ -1,0 +1,31 @@
+import { parseText } from '../../src/libs/miniMarkdown';
+
+describe('mini markdown', () => {
+  test('simpleLinks', () => {
+    const cases = [
+      { input: 'Hello, World!', output: [{ type: 'Raw', text: 'Hello, World!' }] },
+      {
+        input: 'Are you [lost](https://perdu.com/)?',
+        output: [
+          { type: 'Raw', text: 'Are you ' },
+          { type: 'Link', text: 'lost', url: 'https://perdu.com/' },
+          { type: 'Raw', text: '?' },
+        ],
+      },
+      {
+        input:
+          'Are you [lost](https://perdu.com/)[s](https://perdus.com/)? Try using [Qwant](https://www.qwant.com/)!!!',
+        output: [
+          { type: 'Raw', text: 'Are you ' },
+          { type: 'Link', text: 'lost', url: 'https://perdu.com/' },
+          { type: 'Link', text: 's', url: 'https://perdus.com/' },
+          { type: 'Raw', text: '? Try using ' },
+          { type: 'Link', text: 'Qwant', url: 'https://www.qwant.com/' },
+          { type: 'Raw', text: '!!!' },
+        ],
+      },
+    ];
+
+    cases.forEach(({ input, output }) => expect(parseText(input)).toEqual(output));
+  });
+});


### PR DESCRIPTION
A new `claims` field was recently added in the description block of Idunn which lists a few key informations about a place.

Idunn returns the values in the same format as Knowledge, which may include some markdown links. I wanted to avoid to add a complex dependency for the very basic task of handling those links so I implemented a very naïve parser based on regexps. This sounds like a very ":confused:" idea, so **I'll leave the decision of me changing this up to my dear reviewers**. (Note that on worst case this "parser" will just display URLs with escaped "]" as full text.

Also, some links are filtered out because they contain the sticky param of phoenix, we could make use of this information to redirect to qwant.com in the future and it is still relevant in the API result as we could naturally use it in the instant answer.

![image](https://user-images.githubusercontent.com/1173464/206478584-f1926e37-f5a3-4467-bdef-613940464874.png)