### PR TITLE
Add qwant com url in hard link to fix wikidata link redirection

### DIFF
--- a/src/panel/poi/blocks/Description/index.tsx
+++ b/src/panel/poi/blocks/Description/index.tsx
@@ -18,7 +18,11 @@ function parseClaimValue(raw: string): JSX.Element {
       case TextType.Raw:
         return <span>{part.text}</span>;
       case TextType.Link:
-        return <a href={part.url}>{part.text}</a>;
+        return (
+          <a href={'https://www.qwant.com/?q=' + part.text + '&t=web&sticky=' + part.url}>
+            {part.text}
+          </a>
+        );
     }
   });
 


### PR DESCRIPTION
## Description
C'est le back de foundation qui gère le sticky pour la redirection des liens de wikidata

## Why
Bug: Quand on clique sur le lien, c'était un lien relatif vers qwant maps qui ne gère pas le sticky

