### PR TITLE
QMAPS-3269 - fix: focused state cta survey modal wrong color

### DIFF
--- a/src/scss/includes/survey.scss
+++ b/src/scss/includes/survey.scss
@@ -16,7 +16,7 @@
   & a {
     background-color: var(--green-400);
 
-    &:hover {
+    &:hover, &:focus {
       background-color: var(--green-300);
     }
   }


### PR DESCRIPTION
La couleur du CTA survey en "dark' devenait bleu après un clic (focus). Ce fix reprend les éléments du design system et utilise donc le vert green-300

![Capture d’écran 2023-07-21 à 14 28 34](https://github.com/Qwant/erdapfel/assets/8363334/d12e51ba-10bf-4e0c-ac6b-16a8d15291e8)
